### PR TITLE
Fix a couple bugs observed during EC2 test

### DIFF
--- a/aks-flex-node-sudoers
+++ b/aks-flex-node-sudoers
@@ -81,9 +81,11 @@ aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/tee /etc/sysctl.d/k8s.conf
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/tee /etc/modules-load.d/k8s.conf
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/tee /etc/containerd/config.toml
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/cat /etc/default/kubelet
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/cat /etc/systemd/system/kubelet.service
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/cat /etc/systemd/system/kubelet.service.d/*
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/cat /etc/kubernetes/*
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/cat /etc/default/kubelet
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/cat /etc/systemd/system/kubelet.service
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/cat /etc/systemd/system/kubelet.service.d/*
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/cat /etc/kubernetes/*
 

--- a/pkg/components/services/services_installer.go
+++ b/pkg/components/services/services_installer.go
@@ -66,7 +66,8 @@ func (i *Installer) Execute(ctx context.Context) error {
 
 // IsCompleted checks if containerd and kubelet services are enabled and running
 func (i *Installer) IsCompleted(ctx context.Context) bool {
-	return utils.IsServiceActive("containerd") && utils.IsServiceActive("kubelet")
+	// always return false to ensure services are reenabled each time
+	return false
 }
 
 // Validate validates prerequisites for enabling services


### PR DESCRIPTION
Fixed Issues
1. Uninstall Script Improvements
- Automated unbootstrap: Now automatically runs aks-flex-node unbootstrap during uninstall instead of requiring manual execution
- Complete Arc agent removal: Added comprehensive Azure Arc agent cleanup including files, services, and users
- Updated completion message: Now accurately reflects all removed components

2. Installation Enhancements
- Azure CLI installation: Added automatic Azure CLI installation with verification
- Improved Azure CLI permissions: Enhanced directory permissions with proper inheritance using setgid bits
- Hostname resolution setup: Added hostname configuration to /etc/hosts for Kubernetes networking

3. Service Management Fixes
- Force service re-enablement: Changed IsCompleted() to always return false, ensuring services are properly re-enabled on each bootstrap
- Enhanced sudo permissions: Added missing kubelet service file read permissions for both /usr/bin/cat and /bin/cat

4  Code Quality
- Fixed documentation: Corrected misleading comment in runc installer
- Standardized naming: Fixed inconsistent naming in runc uninstalle