### PR TITLE
Housekeeping - clean up and refactor code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
 
             **Quick install (Ubuntu 22.04/24.04):**
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/install.sh | sudo bash
+            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.version.outputs.VERSION }}/scripts/install.sh | sudo bash
             ```
 
             **Manual installation:**

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ aks-flex-node agent --config /etc/aks-flex-node/config.json
 cat /var/log/aks-flex-node/aks-flex-node.log
 
 # Option 2: Using systemd service
-sudo systemctl enable aks-flex-node-agent.service; sudo systemctl start aks-flex-node-agent
+sudo systemctl enable --now aks-flex-node-agent
 journalctl -u aks-flex-node-agent --since "1 minutes ago" -f
 
 ```

--- a/aks-flex-node-agent.service
+++ b/aks-flex-node-agent.service
@@ -17,8 +17,8 @@ Restart=on-failure
 RestartSec=30
 User=aks-flex-node
 Group=aks-flex-node
-SupplementaryGroups=himds ubuntu
-Environment=AZURE_CONFIG_DIR=/home/ubuntu/.azure
+SupplementaryGroups=himds PLACEHOLDER_USER_GROUP
+Environment=AZURE_CONFIG_DIR=PLACEHOLDER_AZURE_CONFIG_DIR
 RuntimeDirectory=aks-flex-node
 RuntimeDirectoryMode=0755
 StandardOutput=journal

--- a/pkg/components/cni/cni_setup_installer.go
+++ b/pkg/components/cni/cni_setup_installer.go
@@ -205,7 +205,7 @@ func getCNIVersion(cfg *config.Config) string {
 	return DefaultCNIVersion
 }
 
-// CreateBridgeConfig creates bridge CNI configuration for edge nodes (compatible with AKS Cilium)
+// CreateBridgeConfig creates bridge CNI configuration for edge nodes (compatible with BYO Cilium)
 func (i *Installer) createBridgeConfig() error {
 	logrus.Info("Creating bridge CNI configuration for edge node...")
 	configPath := filepath.Join(DefaultCNIConfDir, bridgeConfigFile)

--- a/pkg/components/kube_binaries/kube_binaries_uninstaller.go
+++ b/pkg/components/kube_binaries/kube_binaries_uninstaller.go
@@ -2,7 +2,6 @@ package kube_binaries
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
@@ -27,31 +26,9 @@ func (u *UnInstaller) GetName() string {
 
 // Execute removes Kubernetes components
 func (u *UnInstaller) Execute(ctx context.Context) error {
-	u.logger.Info("Executeing Kubernetes components")
-
-	// List of Kubernetes packages to remove
-	packages := []string{
-		kubeletBinary,
-		kubeadmBinary,
-		kubectlBinary,
-	}
-
-	// Remove packages using shared utility
-	errors := utils.RemovePackages(packages, u.logger)
-
-	// Clean up package cache using shared utility
-	utils.CleanPackageCache(u.logger)
-
-	// Remove Kubernetes repository files
-	u.logger.Info("Removing Kubernetes apt repository")
-	repoFiles := []string{
-		KubernetesRepoList,
-		KubernetesKeyring,
-	}
-	utils.RemoveFiles(repoFiles, u.logger)
-
-	// Remove binaries directly if they were manually Executeed
 	u.logger.Info("Removing Kubernetes binaries")
+
+	// Remove Kubernetes binaries (rm -f handles non-existent files gracefully)
 	binaryFiles := []string{
 		kubeletPath,
 		kubectlPath,
@@ -63,11 +40,7 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 		}
 	}
 
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove %d Kubernetes components: %v", len(errors), errors[0])
-	}
-
-	u.logger.Info("Kubernetes components Executeed successfully")
+	u.logger.Info("Kubernetes binaries removal completed")
 	return nil
 }
 

--- a/pkg/components/kubelet/consts.go
+++ b/pkg/components/kubelet/consts.go
@@ -2,23 +2,28 @@ package kubelet
 
 const (
 	// System directories
-	EtcDefaultDir     = "/etc/default"
-	KubeletServiceDir = "/etc/systemd/system/kubelet.service.d"
+	etcDefaultDir     = "/etc/default"
+	kubeletServiceDir = "/etc/systemd/system/kubelet.service.d"
+	etcKubernetesDir  = "/etc/kubernetes"
+
+	// Kubelet-specific directories
+	kubeletManifestsDir    = "/etc/kubernetes/manifests"
+	kubeletVolumePluginDir = "/etc/kubernetes/volumeplugins"
 
 	// Configuration file paths
-	KubeletDefaultsPath       = "/etc/default/kubelet"
-	KubeletServicePath        = "/etc/systemd/system/kubelet.service"
-	KubeletContainerdConfig   = "/etc/systemd/system/kubelet.service.d/10-containerd.conf"
-	KubeletTLSBootstrapConfig = "/etc/systemd/system/kubelet.service.d/10-tlsbootstrap.conf"
+	kubeletDefaultsPath       = "/etc/default/kubelet"
+	kubeletServicePath        = "/etc/systemd/system/kubelet.service"
+	kubeletContainerdConfig   = "/etc/systemd/system/kubelet.service.d/10-containerd.conf"
+	kubeletTLSBootstrapConfig = "/etc/systemd/system/kubelet.service.d/10-tlsbootstrap.conf"
 
 	// Runtime configuration paths
-	KubeletConfigPath          = "/var/lib/kubelet/config.yaml"
-	KubeletKubeConfig          = "/etc/kubernetes/kubelet.conf"
-	KubeletBootstrapKubeConfig = "/etc/kubernetes/bootstrap-kubelet.conf"
-	KubeletVarDir              = "/var/lib/kubelet"
-	KubeletKubeconfigPath      = "/var/lib/kubelet/kubeconfig"
-	KubeletTokenScriptPath     = "/var/lib/kubelet/token.sh"
+	kubeletConfigPath          = "/var/lib/kubelet/config.yaml"
+	kubeletKubeConfig          = "/etc/kubernetes/kubelet.conf"
+	kubeletBootstrapKubeConfig = "/etc/kubernetes/bootstrap-kubelet.conf"
+	kubeletVarDir              = "/var/lib/kubelet"
+	kubeletKubeconfigPath      = "/var/lib/kubelet/kubeconfig"
+	kubeletTokenScriptPath     = "/var/lib/kubelet/token.sh"
 
 	// Azure resource identifiers
-	AKSServiceResourceID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+	aksServiceResourceID = "6dae42f8-4368-4678-94ff-3960e28e3630"
 )

--- a/pkg/components/kubelet/kubelet_uninstaller.go
+++ b/pkg/components/kubelet/kubelet_uninstaller.go
@@ -37,17 +37,20 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 
 	// Remove kubelet configuration files
 	kubeletFiles := []string{
-		KubeletDefaultsPath,
-		KubeletServicePath,
-		KubeletContainerdConfig,
-		KubeletConfigPath,
-		KubeletKubeConfig,
-		KubeletBootstrapKubeConfig,
+		kubeletDefaultsPath,
+		kubeletServicePath,
+		kubeletContainerdConfig,
+		kubeletConfigPath,
+		kubeletKubeConfig,
+		kubeletBootstrapKubeConfig,
 	}
 
 	// Remove kubelet configuration directories
 	kubeletDirectories := []string{
-		KubeletServiceDir,
+		kubeletServiceDir,      // /etc/systemd/system/kubelet.service.d
+		kubeletVarDir,          // /var/lib/kubelet
+		kubeletManifestsDir,    // Static pod manifests (kubelet-specific)
+		kubeletVolumePluginDir, // Volume plugins (kubelet-specific)
 	}
 
 	// Remove individual files
@@ -77,9 +80,9 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 func (u *UnInstaller) IsCompleted(ctx context.Context) bool {
 	// Check critical configuration files
 	criticalFiles := []string{
-		KubeletConfigPath,
-		KubeletKubeConfig,
-		KubeletBootstrapKubeConfig,
+		kubeletConfigPath,
+		kubeletKubeConfig,
+		kubeletBootstrapKubeConfig,
 	}
 
 	for _, file := range criticalFiles {

--- a/pkg/components/system_configuration/system_configuration_installer.go
+++ b/pkg/components/system_configuration/system_configuration_installer.go
@@ -60,7 +60,9 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.ipv4.ip_forward = 1
 vm.overcommit_memory = 1
 kernel.panic = 10
-kernel.panic_on_oops = 1`
+kernel.panic_on_oops = 1
+# Disable swap permanently - required for kubelet
+vm.swappiness = 0`
 
 	// Create sysctl directory if it doesn't exist
 	if err := utils.RunSystemCommand("mkdir", "-p", sysctlDir); err != nil {


### PR DESCRIPTION
- Service Configuration: Updated systemd service file to use placeholders for user-specific paths instead of hardcoded ubuntu user references
- Removed unused utility functions from utils.go (package management, service health checks, Azure CLI helpers)
Simplified kube binaries uninstaller by removing package management and keeping only binary cleanup (kube_binaries_uninstaller.go)
- Removed validation logic from kubelet installer to enforce reconfiguration on every run (kubelet_installer.go:60)
Installation Improvements:
- Enhanced Arc agent cleanup in uninstall.sh with comprehensive removal of services, binaries, and configuration
- Fixed permission setup in install.sh to properly handle Azure CLI directory ownership
- Perform full cleanup of arc agent in the uninstall script
- Install prerequisite packages ("jq", "iptables") during kubelet installer #36 
-  Disable swap in for kubelet in system_configuration_installer.go  `vm.swappiness = 0` #36 
- Fix git action release note to reference the current branch and tag 