### PR TITLE
Fix sudoer for jq and iptables installation

### DIFF
--- a/aks-flex-node-sudoers
+++ b/aks-flex-node-sudoers
@@ -51,13 +51,11 @@ aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/systemctl is-active *
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/systemctl is-enabled *
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/systemctl list-unit-files *
 
-# Package management (for installing Kubernetes components)
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-get update
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-get install -y apt-transport-https ca-certificates curl gpg
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-get install -y kubelet kubeadm kubectl containerd
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-get remove -y kubelet kubeadm kubectl containerd runc
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-mark hold kubelet kubeadm kubectl
-aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt-mark unhold kubelet kubeadm kubectl
+# Package management (for utility packages only)
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt update
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt install -y jq
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt install -y iptables
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/apt install -y curl
 
 # Directory and file operations for Kubernetes paths - simplified for compatibility
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/mkdir *, /usr/bin/mkdir *


### PR DESCRIPTION
Error msg:
Jan 20 19:25:00 divine-emu sudo[33743]: pam_unix(sudo:auth): conversation failed
Jan 20 19:25:00 divine-emu sudo[33743]: pam_unix(sudo:auth): auth could not identify password for [aks-flex-node]
Jan 20 19:25:00 divine-emu aks-flex-node[33743]: sudo: a password is required
Jan 20 19:25:00 divine-emu sudo[33743]: aks-flex-node : command not allowed ; PWD=/ ; USER=root ; COMMAND=/usr/bin/apt install -y jq
Jan 20 19:25:00 divine-emu aks-flex-node[33176]: level=error msg="bootstrap step: KubeletInstaller failed with error: failed to configure kubelet: failed to install required packages: failed to install jq: exit status 1 with duration 3.425265ms" func="[executor.go:143]"
Jan 20 19:25:00 divine-emu aks-flex-node[33176]: level=error msg="Bootstrap failed at step KubeletInstaller: failed to configure kubelet: failed to install required packages: failed to install jq: exit status 1 (completedSteps: 8, totalSteps: 10)" func="[executor.go:88]"