### PR TITLE
Fix npd tmp directory clean up command

### DIFF
--- a/pkg/components/npd/npd_installer.go
+++ b/pkg/components/npd/npd_installer.go
@@ -56,7 +56,7 @@ func (i *Installer) installNpd() error {
 		return fmt.Errorf("failed to clean up existing NPD temp directory %s: %w", tempDir, err)
 	}
 	defer func() {
-		if err := utils.RunCleanupCommand(tempDir); err != nil {
+		if err := utils.RunSystemCommand("bash", "-c", fmt.Sprintf("rm -rf %s", tempDir)); err != nil {
 			logrus.Warnf("Failed to clean up temp directory %s: %v", tempDir, err)
 		}
 	}()


### PR DESCRIPTION
JError msg:

an 20 19:55:19 wxvm aks-flex-node[49248]: level=info msg="Node Problem Detector version v1.35.1 installed successfully" func="[npd_installer.go:107]"
Jan 20 19:55:19 wxvm aks-flex-node[50162]: **rm: cannot remove '/tmp/npd': Is a directory**
Jan 20 19:55:19 wxvm aks-flex-node[49248]: Cleanup command failed: rm -f /tmp/npd - exit status 1
Jan 20 19:55:19 wxvm aks-flex-node[49248]: time="2026-01-20T19:55:19Z" level=warning msg="Failed to clean up temp directory /tmp/npd: exit status 1"
