### PR TITLE
add unmanaged label to edge node

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,11 +82,23 @@ func LoadConfig(configPath string) (*Config, error) {
 
 // SetDefaults sets default values for any missing configuration fields
 func (c *Config) SetDefaults() {
+	c.setAzureCloudDefaults()
+	c.setAgentDefaults()
+	c.setPathDefaults()
+	c.setNodeDefaults()
+	c.setContainerdDefaults()
+	c.setRuncDefaults()
+	c.setNpdDefaults()
+}
+
+func (c *Config) setAzureCloudDefaults() {
 	// Set default Azure cloud if not provided
 	if c.Azure.Cloud == "" {
 		c.Azure.Cloud = defaultAzureCloud
 	}
+}
 
+func (c *Config) setAgentDefaults() {
 	// Set default agent configuration if not provided
 	if c.Agent.LogLevel == "" {
 		c.Agent.LogLevel = defaultLogLevel
@@ -94,7 +106,9 @@ func (c *Config) SetDefaults() {
 	if c.Agent.LogDir == "" {
 		c.Agent.LogDir = defaultLogDir
 	}
+}
 
+func (c *Config) setPathDefaults() {
 	// Set default paths for Kubernetes components if not provided
 	if c.Paths.Kubernetes.ConfigDir == "" {
 		c.Paths.Kubernetes.ConfigDir = "/etc/kubernetes"
@@ -111,13 +125,26 @@ func (c *Config) SetDefaults() {
 	if c.Paths.Kubernetes.KubeletDir == "" {
 		c.Paths.Kubernetes.KubeletDir = "/var/lib/kubelet"
 	}
+}
 
+func (c *Config) setNodeDefaults() {
 	// Set default node configuration if not provided
 	if c.Node.MaxPods == 0 {
 		c.Node.MaxPods = 110 // Default Kubernetes node pod limit
 	}
 
+	// set default node labels if not provided
+	if c.Node.Labels == nil {
+		c.Node.Labels = make(map[string]string)
+	}
+	// Mark node as unmanaged by cloud controller manager by default, otherwise ccm will delete this node if node is not ready
+	// doc: https://cloud-provider-azure.sigs.k8s.io/topics/cross-resource-group-nodes/#unmanaged-nodes
+	c.Node.Labels["kubernetes.azure.com/managed"] = "false"
+
 	// Set default kubelet configuration if not provided
+	if c.Node.Kubelet.Verbosity == 0 {
+		c.Node.Kubelet.Verbosity = 2
+	}
 	if c.Node.Kubelet.ImageGCHighThreshold == 0 {
 		c.Node.Kubelet.ImageGCHighThreshold = 85 // start GC when disk usage > 85%
 	}
@@ -131,16 +158,22 @@ func (c *Config) SetDefaults() {
 	if c.Node.Kubelet.EvictionHard == nil {
 		c.Node.Kubelet.EvictionHard = make(map[string]string)
 	}
+}
 
+func (c *Config) setContainerdDefaults() {
 	if c.Containerd.MetricsAddress == "" {
 		c.Containerd.MetricsAddress = "0.0.0.0:10257"
 	}
+}
 
+func (c *Config) setRuncDefaults() {
 	// Set default runc configuration if not provided
 	if c.Runc.Version == "" {
 		c.Runc.Version = "1.1.12"
 	}
+}
 
+func (c *Config) setNpdDefaults() {
 	// Set default NPD configuration if not provided
 	if c.Npd.Version == "" {
 		c.Npd.Version = "v1.35.1"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,6 +50,7 @@ func TestSetDefaults(t *testing.T) {
 			},
 			want: func(c *Config) bool {
 				return c.Node.MaxPods == 50 && // preserved
+					c.Node.Kubelet.Verbosity == 2 &&
 					c.Node.Kubelet.ImageGCHighThreshold == 85 &&
 					c.Node.Kubelet.ImageGCLowThreshold == 80 &&
 					c.Node.Kubelet.KubeReserved != nil &&
@@ -307,7 +308,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create temporary config file
 			configFile := filepath.Join(tempDir, "config.json")
-			if err := os.WriteFile(configFile, []byte(tt.configJSON), 0644); err != nil {
+			if err := os.WriteFile(configFile, []byte(tt.configJSON), 0o644); err != nil {
 				t.Fatalf("Failed to write test config file: %v", err)
 			}
 

--- a/pkg/config/structs.go
+++ b/pkg/config/structs.go
@@ -89,6 +89,7 @@ type NodeConfig struct {
 type KubeletConfig struct {
 	KubeReserved         map[string]string `json:"kubeReserved"`
 	EvictionHard         map[string]string `json:"evictionHard"`
+	Verbosity            int               `json:"verbosity"`
 	ImageGCHighThreshold int               `json:"imageGCHighThreshold"`
 	ImageGCLowThreshold  int               `json:"imageGCLowThreshold"`
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -70,7 +70,7 @@ func RunSystemCommand(name string, args ...string) error {
 // RunCommandWithOutput executes a command and returns output with sudo when needed
 func RunCommandWithOutput(name string, args ...string) (string, error) {
 	cmd := createCommand(name, args)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	return string(output), err
 }
 


### PR DESCRIPTION
If the node doesn't have the unmanaged label, once the node is not ready, azure cloud controller manger will delete this node. This will make us lose track of the readiness of kubelet.

In the PR, I added this label to make sure even kubelet is not ready, we can still see the status.
```
ubuntu@flex-node:~$kubectl describe node flex-node
Name:               flex-node
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/os=linux
                    **kubernetes.azure.com/managed=false**
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=flex-node
                    kubernetes.io/os=linux
Annotations:        node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true

```
```
ubuntu@flex-node:~$ sudo systemctl stop containerd
ubuntu@flex-node:~$ sudo kubectl get node flex-node
NAME        STATUS   ROLES    AGE   VERSION
flex-node   Ready    <none>   66s   v1.32.7
ubuntu@flex-node:~$
ubuntu@flex-node:~$ sudo kubectl get node flex-node
NAME        STATUS     ROLES    AGE     VERSION
flex-node   NotReady   <none>   2m54s   v1.32.7
ubuntu@flex-node:~$ sudo kubectl get node flex-node
NAME        STATUS     ROLES    AGE     VERSION
flex-node   NotReady   <none>   2m56s   v1.32.7
ubuntu@flex-node:~$ sudo systemctl start containerd
ubuntu@flex-node:~$ sudo kubectl get node flex-node
NAME        STATUS   ROLES    AGE     VERSION
flex-node   Ready    <none>   5m49s   v1.32.7
ubuntu@flex-node:~$
```

Beside it,
- customized the kubelet verbose level for debugging purpose
- fixed one bug that error returned wont give output back

before: 
```
level=info msg="Starting periodic status collection at 2026-01-22 14:14:14..." func="[commands.go:161]"
level=error msg="kubectl command failed: exit status 1 with output: " func="[collector.go:217]"
```
after:
```
level=info msg="Starting periodic status collection at 2026-01-22 14:25:21..." func="[commands.go:161]"
level=error msg="kubectl command failed: exit status 1 with output: Error from server (NotFound): nodes \"flex-node\" not found\n" func="[collector.go:217]"

```

