### PR TITLE
Fix uninstall command and redact aad token

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -53,20 +53,16 @@ confirm_uninstall() {
     echo -e "${YELLOW}NOTE: This will first run 'aks-flex-node unbootstrap' to clean up cluster and Arc resources.${NC}"
     echo ""
 
-    # Check if running interactively
-    if [[ -t 0 ]]; then
-        read -p "Are you sure you want to continue? (y/N): " -n 1 -r
+    # Always prompt for confirmation, even when piped
+    if [[ "${1:-}" != "--force" ]]; then
+        read -p "Are you sure you want to continue? (y/N): " -n 1 -r response </dev/tty
         echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        if [[ ! $response =~ ^[Yy]$ ]]; then
             echo "Uninstall cancelled."
             exit 0
         fi
     else
-        log_warning "Running in non-interactive mode. Use --force to skip confirmation."
-        if [[ "${1:-}" != "--force" ]]; then
-            log_error "Uninstall cancelled. Use --force flag to proceed without confirmation."
-            exit 1
-        fi
+        log_info "Force flag provided, skipping confirmation."
     fi
 }
 


### PR DESCRIPTION
Error msg: 

┌💁  wenxuan @ 💻  party in 📁  ~
└❯ curl -fsSL https://raw.githubusercontent.com/Azure/AKSFlexNode/v0.0.4/scripts/uninstall.sh | sudo bash
AKS Flex Node Uninstaller

This will remove the following components:
• AKS Flex Node binary (/usr/local/bin/aks-flex-node)
• Systemd service (aks-flex-node-agent.service)
• Service user (aks-flex-node)
• Configuration directory (/etc/aks-flex-node)
• Data directory (/var/lib/aks-flex-node)
• Log directory (/var/log/aks-flex-node)
• Sudo permissions (/etc/sudoers.d/aks-flex-node)
• Azure Arc agent and connection

NOTE: This will first run 'aks-flex-node unbootstrap' to clean up cluster and Arc resources.

**WARNING: Running in non-interactive mode. Use --force to skip confirmation.
ERROR: Uninstall cancelled. Use --force flag to proceed without confirmation.**
