### PR TITLE
Prep work for pod networking setup

### DIFF
--- a/pkg/components/cni/consts.go
+++ b/pkg/components/cni/consts.go
@@ -1,13 +1,17 @@
 package cni
 
 const (
-	// CNI directories
-	DefaultCNIBinDir  = "/opt/cni/bin"
+	// DefaultCNIBinDir is the directory where CNI binaries are installed
+	DefaultCNIBinDir = "/opt/cni/bin"
+	// DefaultCNIConfDir is the directory where CNI configuration files are stored
 	DefaultCNIConfDir = "/etc/cni/net.d"
-	DefaultCNILibDir  = "/var/lib/cni"
+	// DefaultCNILibDir is the directory for CNI library files
+	DefaultCNILibDir = "/var/lib/cni"
 
 	// CNI configuration files
-	bridgeConfigFile = "10-bridge.conf"
+	// Using 99-bridge.conf (high number) ensures other CNI solutions like Cilium
+	// can override this temporary bridge with lower-numbered configs (e.g., 05-cilium.conf)
+	bridgeConfigFile = "99-bridge.conf"
 
 	// Required CNI plugins
 	bridgePlugin    = "bridge"
@@ -18,10 +22,10 @@ const (
 	tuningPlugin    = "tuning"
 
 	// CNI version
-	DefaultCNIVersion = "1.5.1"
+	defaultCNIVersion = "1.5.1"
 
 	// CNI specification version for configuration files
-	DefaultCNISpecVersion = "0.3.1"
+	defaultCNISpecVersion = "0.3.1"
 )
 
 var cniDirs = []string{

--- a/pkg/components/kubelet/consts.go
+++ b/pkg/components/kubelet/consts.go
@@ -21,7 +21,7 @@ const (
 	kubeletKubeConfig          = "/etc/kubernetes/kubelet.conf"
 	kubeletBootstrapKubeConfig = "/etc/kubernetes/bootstrap-kubelet.conf"
 	kubeletVarDir              = "/var/lib/kubelet"
-	kubeletKubeconfigPath      = "/var/lib/kubelet/kubeconfig"
+	KubeletKubeconfigPath      = "/var/lib/kubelet/kubeconfig"
 	kubeletTokenScriptPath     = "/var/lib/kubelet/token.sh"
 
 	// Azure resource identifiers

--- a/pkg/components/kubelet/kubelet_installer.go
+++ b/pkg/components/kubelet/kubelet_installer.go
@@ -200,7 +200,7 @@ func (i *Installer) createKubeletDefaultsFile() error {
 	kubeletDefaults := fmt.Sprintf(`KUBELET_NODE_LABELS="%s"
 KUBELET_CONFIG_FILE_FLAGS=""
 KUBELET_FLAGS="\
-	--v=%d \
+  --v=%d \
   --address=0.0.0.0 \
   --anonymous-auth=false \
   --authentication-token-webhook=true \
@@ -208,6 +208,8 @@ KUBELET_FLAGS="\
   --cgroup-driver=systemd \
   --cgroups-per-qos=true \
   --enforce-node-allocatable=pods \
+  --cluster-dns=%s \
+  --cluster-domain=cluster.local \
   --event-qps=0  \
   --eviction-hard=%s  \
   --kube-reserved=%s  \
@@ -225,6 +227,7 @@ KUBELET_FLAGS="\
   "`,
 		strings.Join(labels, ","),
 		i.config.Node.Kubelet.Verbosity,
+		i.config.Node.Kubelet.DNSServiceIP,
 		mapToEvictionThresholds(i.config.Node.Kubelet.EvictionHard, ","),
 		mapToKeyValuePairs(i.config.Node.Kubelet.KubeReserved, ","),
 		i.config.Node.Kubelet.ImageGCHighThreshold,
@@ -411,7 +414,7 @@ users:
 		i.config.Azure.TargetCluster.Name)
 
 	// Write kubeconfig file to the correct location for kubelet
-	if err := utils.WriteFileAtomicSystem(kubeletKubeconfigPath, []byte(kubeconfigContent), 0o600); err != nil {
+	if err := utils.WriteFileAtomicSystem(KubeletKubeconfigPath, []byte(kubeconfigContent), 0o600); err != nil {
 		return fmt.Errorf("failed to create kubeconfig file: %w", err)
 	}
 

--- a/pkg/components/npd/consts.go
+++ b/pkg/components/npd/consts.go
@@ -5,10 +5,7 @@ const (
 	npdBinaryPath  = "/usr/bin/node-problem-detector"
 	npdConfigPath  = "/etc/node-problem-detector/kernel-monitor.json"
 	npdServicePath = "/etc/systemd/system/node-problem-detector.service"
-
-	kubeletKubeconfigPath = "/var/lib/kubelet/kubeconfig"
-
-	tempDir = "/tmp/npd"
+	tempDir        = "/tmp/npd"
 )
 
 var (

--- a/pkg/components/npd/npd_installer.go
+++ b/pkg/components/npd/npd_installer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"go.goms.io/aks/AKSFlexNode/pkg/components/kubelet"
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
 )
@@ -123,7 +124,7 @@ func (i *Installer) configure() error {
 }
 
 func (i *Installer) createNpdServiceFile() error {
-	kubeConfigData, err := utils.RunCommandWithOutput("cat", kubeletKubeconfigPath)
+	kubeConfigData, err := utils.RunCommandWithOutput("cat", kubelet.KubeletKubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to read kubelet kubeconfig file: %w", err)
 	}
@@ -134,7 +135,7 @@ func (i *Installer) createNpdServiceFile() error {
 	}
 
 	cmd := fmt.Sprintf("%s --apiserver-override=\"%s?inClusterConfig=false&auth=%s\" --config.system-log-monitor=%s",
-		npdBinaryPath, serverURL, kubeletKubeconfigPath, npdConfigPath)
+		npdBinaryPath, serverURL, kubelet.KubeletKubeconfigPath, npdConfigPath)
 
 	npdService := `[Unit]
 Description=Node Problem Detector

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,6 +151,12 @@ func (c *Config) setNodeDefaults() {
 	if c.Node.Kubelet.ImageGCLowThreshold == 0 {
 		c.Node.Kubelet.ImageGCLowThreshold = 80 // stop GC when disk usage < 80%
 	}
+	// Set default DNS service IP if not provided
+	// Note: This default assumes the standard AKS service CIDR (10.0.0.0/16)
+	// Clusters with custom service CIDRs should specify this value explicitly
+	if c.Node.Kubelet.DNSServiceIP == "" {
+		c.Node.Kubelet.DNSServiceIP = "10.0.0.10"
+	}
 	// Initialize default kubelet resource reservations if not provided
 	if c.Node.Kubelet.KubeReserved == nil {
 		c.Node.Kubelet.KubeReserved = make(map[string]string)

--- a/pkg/config/structs.go
+++ b/pkg/config/structs.go
@@ -92,6 +92,7 @@ type KubeletConfig struct {
 	Verbosity            int               `json:"verbosity"`
 	ImageGCHighThreshold int               `json:"imageGCHighThreshold"`
 	ImageGCLowThreshold  int               `json:"imageGCLowThreshold"`
+	DNSServiceIP         string            `json:"dnsServiceIP"` // Cluster DNS service IP (default: 10.0.0.10 for AKS)
 }
 
 // PathsConfig holds file system paths used by the agent for Kubernetes and CNI configurations.

--- a/pkg/status/collector.go
+++ b/pkg/status/collector.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"go.goms.io/aks/AKSFlexNode/pkg/components/kubelet"
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
 )
@@ -202,7 +203,7 @@ func (c *Collector) isKubeletReady(ctx context.Context) string {
 	// Readiness condition status is one of: True, False, Unknown
 	args := []string{
 		"--kubeconfig",
-		"/var/lib/kubelet/kubeconfig",
+		kubelet.KubeletKubeconfigPath,
 		"get",
 		"node",
 		hostName,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,7 +236,7 @@ check_azure_cli_auth() {
             log_info "  3. Then re-run this installer with sudo"
             log_info ""
             echo -n "Do you want to continue anyway? (service principal auth only) [y/N]: "
-            read -r response
+            read -r response </dev/tty
             case "$response" in
                 [yY]|[yY][eE][sS])
                     log_info "Continuing without CLI authentication. Make sure to configure service principal."


### PR DESCRIPTION
- CNI Setup: Fixed permissions and ownership for Ubuntu 24.04 AppArmor compatibility and Cilium init container support
- Bridge Config Priority: Changed bridge config from 10-bridge.conf to 99-bridge.conf to allow CNI solutions like Cilium to override with higher priority
- Kubelet DNS: Added cluster DNS configuration with default service IP (10.0.0.10) for standard AKS clusters
- Code Cleanup: Consolidated constants and improved cross-package references