### PR TITLE
Support ARC Bypass - use SP credential for kubelet to apiserver request

### DIFF
--- a/pkg/components/arc/arc_installer.go
+++ b/pkg/components/arc/arc_installer.go
@@ -30,6 +30,10 @@ func NewInstaller(logger *logrus.Logger) *Installer {
 
 // Validate validates prerequisites for Arc installation
 func (i *Installer) Validate(ctx context.Context) error {
+	if !i.config.IsARCEnabled() {
+		i.logger.Info("Azure Arc installation is disabled in configuration")
+		return nil
+	}
 	// Ensure SP or CLI auth is ready for Arc agent setup
 	if err := i.ensureAuthentication(ctx); err != nil {
 		i.logger.Errorf("Authentication setup failed: %v", err)
@@ -93,6 +97,10 @@ func (i *Installer) Execute(ctx context.Context) error {
 // This can be used by bootstrap steps to verify completion status
 // Uses the same reliable logic as status collector for consistency
 func (i *Installer) IsCompleted(ctx context.Context) bool {
+	if !i.config.IsARCEnabled() {
+		i.logger.Info("Azure Arc installation is disabled in configuration, skipping execution")
+		return true
+	}
 	i.logger.Debug("Checking Arc setup completion status")
 
 	// Check if Arc services are running

--- a/pkg/components/arc/arc_uninstaller.go
+++ b/pkg/components/arc/arc_uninstaller.go
@@ -31,6 +31,10 @@ func (u *UnInstaller) GetName() string {
 // IsCompleted checks if Arc cleanup has been completed
 // always returns false to ensure cleanup is attempted
 func (u *UnInstaller) IsCompleted(ctx context.Context) bool {
+	if !u.config.IsARCEnabled() {
+		u.logger.Info("Azure Arc installation is disabled in configuration")
+		return true
+	}
 	return false
 }
 

--- a/pkg/components/kubelet/kubelet_uninstaller.go
+++ b/pkg/components/kubelet/kubelet_uninstaller.go
@@ -43,6 +43,7 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 		kubeletConfigPath,
 		kubeletKubeConfig,
 		kubeletBootstrapKubeConfig,
+		kubeletTokenScriptPath,
 	}
 
 	// Remove kubelet configuration directories
@@ -83,6 +84,7 @@ func (u *UnInstaller) IsCompleted(ctx context.Context) bool {
 		kubeletConfigPath,
 		kubeletKubeConfig,
 		kubeletBootstrapKubeConfig,
+		kubeletTokenScriptPath, // Check token script cleanup
 	}
 
 	for _, file := range criticalFiles {

--- a/pkg/config/structs.go
+++ b/pkg/config/structs.go
@@ -47,6 +47,7 @@ type TargetClusterConfig struct {
 
 // ArcConfig holds Azure Arc machine configuration for registering the machine with Azure Arc.
 type ArcConfig struct {
+	Enabled       bool              `json:"enabled"`       // Whether to enable Azure Arc registration
 	MachineName   string            `json:"machineName"`   // Name for the Arc machine resource
 	Tags          map[string]string `json:"tags"`          // Tags to apply to the Arc machine
 	ResourceGroup string            `json:"resourceGroup"` // Azure resource group for Arc machine
@@ -217,4 +218,9 @@ func (cfg *Config) GetTenantID() string {
 // GetKubernetesVersion returns the Kubernetes version from configuration
 func (cfg *Config) GetKubernetesVersion() string {
 	return cfg.Kubernetes.Version
+}
+
+// IsARCEnabled checks if Azure Arc registration is enabled in the configuration
+func (cfg *Config) IsARCEnabled() bool {
+	return cfg.Azure.Arc != nil && cfg.Azure.Arc.Enabled
 }


### PR DESCRIPTION
- Added Service Principal (SP) support for direct AKS authentication when Arc is disabled
- Modified kubelet installer to use either Arc or SP-based token scripts
- Added configuration checks to conditionally enable/disable Arc functionality

A complete setup for using SP is like this:
```
RESOURCE_GROUP=wenx-rg
CLUSTER_NAME=play

MY_ID=$(az ad signed-in-user show --query id -o tsv)

az aks create -n $CLUSTER_NAME -g $RESOURCE_GROUP --node-count 1 --enable-aad --aad-admin-group-object-ids $MY_ID

# Get AKS resource ID
AKS_RESOURCE_ID=$(az aks show \
  --resource-group "$RESOURCE_GROUP" \
  --name "$CLUSTER_NAME" \
  --query "id" \
  --output tsv)

# Create SP with Owner role
az ad sp create-for-rbac \
  --name "aks-owner-sp" \
  --role "Owner" \
  --scopes "$AKS_RESOURCE_ID"

# This grants the "Node Bootstrapper" role to your SP
cat <<EOF | kubectl apply -f -
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: node-bootstrapper-sp-binding
subjects:
- kind: User
  name: "xxxxxxxxxxxxx"  # Your SP Object ID
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: system:node-bootstrapper
  apiGroup: rbac.authorization.k8s.io
EOF

# This grants your SP the permissions required to Run as a Node
# (Reading services, updating node status, posting events, etc.)

cat <<EOF | kubectl apply -f -
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: node-role-sp-binding
subjects:
- kind: User
  name: "xxxxxxxxxxxxx"  # Your SP's Object ID
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: system:node
  apiGroup: rbac.authorization.k8s.io
EOF
``` 

with FlexNode config:

```
ubuntu@poc:~$ cat flex-node-sp.json 
{
  "azure": {
    "subscriptionId": "xxxxxxxxxxxxx",
    "tenantId": "xxxxxxxxxxxxx",
    "servicePrincipal": {
      "clientId": "xxxxxxxxxxxxx",
      "clientSecret": "xxxxxxxxxxxxx",
      "tenantId": "xxxxxxxxxxxxx"
    },
    "cloud": "AzurePublicCloud",
    "targetCluster": {
      "resourceId": "/subscriptions/xxxxxxxxxxxxx/resourceGroups/wenx-rg/providers/Microsoft.ContainerService/managedClusters/play",
      "location": "eastus"
    }
  },
  "kubernetes": {
    "version": "1.32.7"
  },
  "agent": {
    "logLevel": "info",
    "logDir": "/var/log/aks-flex-node"
  }
}


```