### PR TITLE
Make Target cluster resource ID regex pattern case insensitive

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,7 +188,8 @@ func (c *Config) setNpdDefaults() {
 
 // AKSClusterResourceIDPattern is AKS cluster resource ID regex pattern with capture groups
 // Format: /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.ContainerService/managedClusters/{cluster-name}
-var AKSClusterResourceIDPattern = regexp.MustCompile(`^/subscriptions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/resourceGroups/([a-zA-Z0-9_\-\.]+)/providers/Microsoft\.ContainerService/managedClusters/([a-zA-Z0-9_\-\.]+)$`)
+// Pattern is case insensitive to handle variations in Azure resource path casing
+var AKSClusterResourceIDPattern = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/resourcegroups/([a-zA-Z0-9_\-\.]+)/providers/microsoft\.containerservice/managedclusters/([a-zA-Z0-9_\-\.]+)$`)
 
 // validateAzureResourceID validates the format of an AKS cluster resource ID using regex pattern matching
 func validateAzureResourceID(resourceID string) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -356,6 +356,36 @@ func TestValidateAzureResourceID(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "case insensitive - lowercase provider",
+			resourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/microsoft.containerservice/managedClusters/test-cluster",
+			wantErr:    false,
+		},
+		{
+			name:       "case insensitive - uppercase provider",
+			resourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/MICROSOFT.CONTAINERSERVICE/managedClusters/test-cluster",
+			wantErr:    false,
+		},
+		{
+			name:       "case insensitive - mixed case provider",
+			resourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/microsoft.ContainerService/managedClusters/test-cluster",
+			wantErr:    false,
+		},
+		{
+			name:       "case insensitive - uppercase path segments",
+			resourceID: "/SUBSCRIPTIONS/12345678-1234-1234-1234-123456789012/RESOURCEGROUPS/test-rg/PROVIDERS/Microsoft.ContainerService/MANAGEDCLUSTERS/test-cluster",
+			wantErr:    false,
+		},
+		{
+			name:       "case insensitive - mixed case path segments",
+			resourceID: "/Subscriptions/12345678-1234-1234-1234-123456789012/ResourceGroups/test-rg/Providers/Microsoft.ContainerService/ManagedClusters/test-cluster",
+			wantErr:    false,
+		},
+		{
+			name:       "case insensitive - all lowercase",
+			resourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourcegroups/test-rg/providers/microsoft.containerservice/managedclusters/test-cluster",
+			wantErr:    false,
+		},
+		{
 			name:       "invalid subscription ID format",
 			resourceID: "/subscriptions/invalid-subscription-id/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
 			wantErr:    true,


### PR DESCRIPTION
Fix for issue: #45 