### PR TITLE
Fix/k8s 1.35 compatibility

### DIFF
--- a/pkg/components/kubelet/kubelet_installer.go
+++ b/pkg/components/kubelet/kubelet_installer.go
@@ -217,7 +217,6 @@ KUBELET_FLAGS="\
   --image-gc-low-threshold=%d  \
   --max-pods=%d  \
   --node-status-update-frequency=10s  \
-  --pod-infra-container-image=%s  \
   --pod-max-pids=-1  \
   --protect-kernel-defaults=true  \
   --read-only-port=0  \
@@ -232,8 +231,7 @@ KUBELET_FLAGS="\
 		mapToKeyValuePairs(i.config.Node.Kubelet.KubeReserved, ","),
 		i.config.Node.Kubelet.ImageGCHighThreshold,
 		i.config.Node.Kubelet.ImageGCLowThreshold,
-		i.config.Node.MaxPods,
-		i.config.Containerd.PauseImage)
+		i.config.Node.MaxPods)
 
 	// Ensure /etc/default directory exists
 	if err := utils.RunSystemCommand("mkdir", "-p", etcDefaultDir); err != nil {


### PR DESCRIPTION
    Remove deprecated --pod-infra-container-image flag for K8s 1.35+
    
    The --pod-infra-container-image flag was removed in Kubernetes 1.35.0.
    This flag is no longer supported and causes kubelet to fail to start with:
      'unknown flag: --pod-infra-container-image'
    
    The pause container image is now automatically managed by the container
    runtime (containerd) and doesn't need to be specified to kubelet.
    
    Fixes kubelet startup failure on Kubernetes 1.35+