### PR TITLE
Update scripts to allow bypass CLI login during install and remove CLI during uninstall 

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -48,7 +48,7 @@ confirm_uninstall() {
     echo "• Data directory ($DATA_DIR)"
     echo "• Log directory ($LOG_DIR)"
     echo "• Sudo permissions (/etc/sudoers.d/aks-flex-node)"
-    echo "• Azure Arc agent and connection"
+    echo "• Azure CLI"
     echo ""
     echo -e "${YELLOW}NOTE: This will first run 'aks-flex-node unbootstrap' to clean up cluster and Arc resources.${NC}"
         echo ""
@@ -208,6 +208,27 @@ remove_binary() {
     fi
 }
 
+remove_azure_cli() {
+    log_info "Removing Azure CLI..."
+
+    if command -v az &> /dev/null; then
+        # Uninstall Azure CLI package
+        log_info "Uninstalling Azure CLI package..."
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get remove -y azure-cli 2>/dev/null || true
+        apt-get purge -y azure-cli 2>/dev/null || true
+
+        # Verify removal
+        if command -v az &> /dev/null; then
+            log_warning "az command still available after cleanup - manual removal may be required"
+        else
+            log_success "Azure CLI removed successfully"
+        fi
+    else
+        log_info "Azure CLI not found - already removed or never installed"
+    fi
+}
+
 show_completion_message() {
     log_success "AKS Flex Node uninstallation completed!"
     echo ""
@@ -218,6 +239,7 @@ show_completion_message() {
     echo "✅ Configuration and data directories"
     echo "✅ Log files"
     echo "✅ Sudo permissions"
+    echo "✅ Azure CLI"
     echo ""
     echo -e "${GREEN}Complete uninstallation finished!${NC}"
     echo ""
@@ -247,7 +269,8 @@ main() {
     remove_service_user
     remove_directories
     remove_binary
-   
+    remove_azure_cli
+
     # Show completion message
     show_completion_message
 }


### PR DESCRIPTION
This pull request introduces improvements to the install and uninstall scripts for AKS Flex Node, focusing on better automation and cleanup of dependencies. The most significant changes are the addition of an option to skip prompts during installation and the automated removal of the Azure CLI during uninstallation.

**Installer improvements:**

* Added support for a `--yes` or `-y` flag in `install.sh` to allow non-interactive installation by automatically assuming "yes" to prompts. This is managed via the new `ASSUME_YES` variable and logic in the main function and authentication checks. [[1]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR24) [[2]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccL238-R247) [[3]](diffhunk://#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09ccR483-R487)

**Uninstaller enhancements:**

* Added a new `remove_azure_cli` function in `uninstall.sh` to automatically uninstall the Azure CLI if it was installed, including package removal and verification. [[1]](diffhunk://#diff-b7db6ed0e38e1f3aba281b4eb3154cfffcd9a239f329d5a7488b1986a78e4040R211-R231) [[2]](diffhunk://#diff-b7db6ed0e38e1f3aba281b4eb3154cfffcd9a239f329d5a7488b1986a78e4040R272)
* Updated the uninstall confirmation and completion messages to include Azure CLI in the list of removed items, making the process and its effects clearer to users. [[1]](diffhunk://#diff-b7db6ed0e38e1f3aba281b4eb3154cfffcd9a239f329d5a7488b1986a78e4040L51-R51) [[2]](diffhunk://#diff-b7db6ed0e38e1f3aba281b4eb3154cfffcd9a239f329d5a7488b1986a78e4040R242)

**Other improvements:**

* Improved messaging in the authentication check to clarify the consequences of continuing without CLI authentication and to mention the new bootstrap token option.
* Minor fix: Removed unnecessary input redirection when installing Azure CLI in `install.sh`.