### PR TITLE
Disable swap for kubelet

### DIFF
--- a/aks-flex-node-sudoers
+++ b/aks-flex-node-sudoers
@@ -99,6 +99,7 @@ aks-flex-node ALL=(root) NOPASSWD:SETENV: /usr/bin/test *, /bin/test *
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /sbin/sysctl --system
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /sbin/modprobe overlay
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /sbin/modprobe br_netfilter
+aks-flex-node ALL=(root) NOPASSWD:SETENV: /sbin/swapoff -a
 
 # Configuration file management and reading
 aks-flex-node ALL=(root) NOPASSWD:SETENV: /bin/tee /etc/sysctl.d/k8s.conf

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,7 +20,7 @@ import (
 
 // sudoCommandLists holds the command lists for sudo determination
 var (
-	alwaysNeedsSudo = []string{"apt", "apt-get", "dpkg", "systemctl", "mount", "umount", "modprobe", "sysctl", "azcmagent", "usermod", "kubectl"}
+	alwaysNeedsSudo = []string{"apt", "apt-get", "dpkg", "systemctl", "mount", "umount", "modprobe", "sysctl", "azcmagent", "usermod", "kubectl", "swapoff"}
 	conditionalSudo = []string{"mkdir", "cp", "chmod", "chown", "mv", "tar", "rm", "bash", "install", "ln", "cat"}
 	systemPaths     = []string{"/etc/", "/usr/", "/var/", "/opt/", "/boot/", "/sys/"}
 )


### PR DESCRIPTION
kubelet has a hard requirement that swap be completely disabled. vm.swappiness = 0 ensures minimal swap usage but it didn't solve the root problem. We need swapoff -a to removes swap from /proc/swaps so kubelet can start properly.

Sample error msg:

v-1 kubelet[12704]: I0205 10:58:14.917056 12704 manager.go:233] Version: {KernelVersion:6.8.0-94-generic ContainerOsVersion:Ubuntu 22.04.5 LTS DockerVersion: Docke>
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: I0205 10:58:14.917138 12704 server.go:772] "--cgroups-per-qos enabled, but --cgroup-root was not specified. defaulting to /"
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: I0205 10:58:14.917220 12704 swap_util.go:115] "Swap is on" /proc/swaps contents=<
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: Filename Type Size Used Priority
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: /swapfile file 3991548 0 -2
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: >
Feb 05 10:58:14 bmoore-v-1 kubelet[12704]: E0205 10:58:14.917245 12704 run.go:72] "command failed" err="failed to run Kubelet: running with swap on is not supported, please disable swap >
Feb 05 10:58:14 bmoore-v-1 systemd[1]: kubelet.service: Main process exited, code=exited, status=1/FAILURE
Feb 05 10:58:14 bmoore-v-1 systemd[1]: kubelet.service: Failed with result 'exit-code'.
Feb 05 10:58:15 bmoore-v-1 systemd[1]: kubelet.service: Scheduled restart job, restart counter is at 5.
Feb 05 10:58:15 bmoore-v-1 systemd[1]: Stopped Kubelet.
Feb 05 10:58:15 bmoore-v-1 systemd[1]: kubelet.service: Start request repeated too quickly.
Feb 05 10:58:15 bmoore-v-1 systemd[1]: kubelet.service: Failed with result 'exit-code'.
Feb 05 10:58:15 bmoore-v-1 systemd[1]: Failed to start Kubelet.