### PR TITLE
Add support for containerd v2

### DIFF
--- a/pkg/components/containerd/consts.go
+++ b/pkg/components/containerd/consts.go
@@ -1,5 +1,10 @@
 package containerd
 
+import (
+	"strconv"
+	"strings"
+)
+
 const (
 	systemBinDir               = "/usr/bin"
 	defaultContainerdBinaryDir = "/usr/bin/containerd"
@@ -13,7 +18,8 @@ var containerdDirs = []string{
 	defaultContainerdConfigDir,
 }
 
-var containerdBinaries = []string{
+// containerdV1Binaries lists all binaries included in containerd 1.x releases
+var containerdV1Binaries = []string{
 	"ctr",
 	"containerd",
 	"containerd-shim",
@@ -22,7 +28,68 @@ var containerdBinaries = []string{
 	"containerd-stress",
 }
 
+// containerdV2Binaries lists all binaries included in containerd 2.x releases
+// Note: containerd-shim and containerd-shim-runc-v1 were removed in v2.x
+var containerdV2Binaries = []string{
+	"ctr",
+	"containerd",
+	"containerd-shim-runc-v2",
+	"containerd-stress",
+}
+
+// getAllContainerdBinaries returns all possible containerd binaries across all versions
+// This is useful for cleanup operations that need to remove binaries from any version
+func getAllContainerdBinaries() []string {
+	seen := make(map[string]bool)
+	var all []string
+
+	for _, binary := range containerdV1Binaries {
+		if !seen[binary] {
+			all = append(all, binary)
+			seen[binary] = true
+		}
+	}
+
+	for _, binary := range containerdV2Binaries {
+		if !seen[binary] {
+			all = append(all, binary)
+			seen[binary] = true
+		}
+	}
+
+	return all
+}
+
 var (
 	containerdFileName    = "containerd-%s-linux-%s.tar.gz"
 	containerdDownloadURL = "https://github.com/containerd/containerd/releases/download/v%s/" + containerdFileName
 )
+
+// getContainerdBinariesForVersion returns the list of binaries that should exist
+// for the given containerd version. In containerd 2.x, containerd-shim and
+// containerd-shim-runc-v1 are removed.
+func getContainerdBinariesForVersion(version string) []string {
+	majorVersion := getMajorVersion(version)
+
+	if majorVersion >= 2 {
+		return containerdV2Binaries
+	}
+
+	return containerdV1Binaries
+}
+
+// getMajorVersion extracts the major version number from a version string
+// Examples: "1.7.20" -> 1, "2.0.0" -> 2
+func getMajorVersion(version string) int {
+	parts := strings.Split(version, ".")
+	if len(parts) == 0 {
+		return 0
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0
+	}
+
+	return major
+}

--- a/pkg/components/containerd/consts_test.go
+++ b/pkg/components/containerd/consts_test.go
@@ -1,0 +1,158 @@
+package containerd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetMajorVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected int
+	}{
+		{
+			name:     "containerd 1.x version",
+			version:  "1.7.20",
+			expected: 1,
+		},
+		{
+			name:     "containerd 2.x version",
+			version:  "2.0.0",
+			expected: 2,
+		},
+		{
+			name:     "containerd 2.x with patch",
+			version:  "2.1.5",
+			expected: 2,
+		},
+		{
+			name:     "empty version",
+			version:  "",
+			expected: 0,
+		},
+		{
+			name:     "invalid version",
+			version:  "invalid",
+			expected: 0,
+		},
+		{
+			name:     "single digit version",
+			version:  "1",
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMajorVersion(tt.version)
+			if result != tt.expected {
+				t.Errorf("getMajorVersion(%q) = %d, want %d", tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetContainerdBinariesForVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected []string
+	}{
+		{
+			name:    "containerd 1.x includes all binaries",
+			version: "1.7.20",
+			expected: []string{
+				"ctr",
+				"containerd",
+				"containerd-shim",
+				"containerd-shim-runc-v1",
+				"containerd-shim-runc-v2",
+				"containerd-stress",
+			},
+		},
+		{
+			name:    "containerd 2.x excludes deprecated shim binaries",
+			version: "2.0.0",
+			expected: []string{
+				"ctr",
+				"containerd",
+				"containerd-shim-runc-v2",
+				"containerd-stress",
+			},
+		},
+		{
+			name:    "containerd 2.1.x excludes deprecated shim binaries",
+			version: "2.1.5",
+			expected: []string{
+				"ctr",
+				"containerd",
+				"containerd-shim-runc-v2",
+				"containerd-stress",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getContainerdBinariesForVersion(tt.version)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("getContainerdBinariesForVersion(%q) = %v, want %v", tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetContainerdBinariesForVersion_ExcludesDeprecated(t *testing.T) {
+	// Test that containerd 2.x explicitly excludes the deprecated binaries
+	v2Binaries := getContainerdBinariesForVersion("2.0.0")
+
+	v1OnlyBinaries := []string{"containerd-shim", "containerd-shim-runc-v1"}
+	for _, v1Only := range v1OnlyBinaries {
+		for _, binary := range v2Binaries {
+			if binary == v1Only {
+				t.Errorf("containerd 2.x should not include v1-only binary: %s", v1Only)
+			}
+		}
+	}
+
+	// Verify containerd-shim-runc-v2 is still included
+	found := false
+	for _, binary := range v2Binaries {
+		if binary == "containerd-shim-runc-v2" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("containerd 2.x should include containerd-shim-runc-v2")
+	}
+}
+
+func TestGetAllContainerdBinaries(t *testing.T) {
+	allBinaries := getAllContainerdBinaries()
+
+	// Should include all v1 binaries
+	expectedV1 := []string{"ctr", "containerd", "containerd-shim", "containerd-shim-runc-v1", "containerd-shim-runc-v2", "containerd-stress"}
+	for _, expected := range expectedV1 {
+		found := false
+		for _, binary := range allBinaries {
+			if binary == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("getAllContainerdBinaries() should include v1 binary: %s", expected)
+		}
+	}
+
+	// Should not have duplicates
+	seen := make(map[string]bool)
+	for _, binary := range allBinaries {
+		if seen[binary] {
+			t.Errorf("getAllContainerdBinaries() contains duplicate: %s", binary)
+		}
+		seen[binary] = true
+	}
+}

--- a/pkg/components/containerd/containerd_uninstaller.go
+++ b/pkg/components/containerd/containerd_uninstaller.go
@@ -56,8 +56,8 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 
 // IsCompleted checks if containerd has been completely removed
 func (u *UnInstaller) IsCompleted(ctx context.Context) bool {
-	// Check if any containerd binaries still exist
-	for _, binary := range containerdBinaries {
+	// Check if any containerd binaries still exist (check all versions)
+	for _, binary := range getAllContainerdBinaries() {
 		if utils.BinaryExists(binary) {
 			return false
 		}
@@ -98,8 +98,8 @@ func (u *UnInstaller) removeContainerdBinaries() error {
 	u.logger.Info("Removing containerd binaries")
 
 	var binaryPaths []string
-	// Add system binary paths
-	for _, binary := range containerdBinaries {
+	// Add system binary paths (include all versions for complete cleanup)
+	for _, binary := range getAllContainerdBinaries() {
 		binaryPaths = append(binaryPaths, filepath.Join(systemBinDir, binary))
 	}
 

--- a/pkg/components/runc/runc_installer.go
+++ b/pkg/components/runc/runc_installer.go
@@ -80,7 +80,7 @@ func (i *Installer) installRunc() error {
 	return nil
 }
 
-// constructContainerdDownloadURL constructs the download URL for the specified containerd version
+// constructRuncDownloadURL constructs the download URL for the specified Runc version
 // it returns the file name and URL for downloading containerd
 func (i *Installer) constructRuncDownloadURL() (string, string, error) {
 	runcVersion := i.getRuncVersion()


### PR DESCRIPTION
This pull request improves how containerd binaries are managed across different versions, ensuring correct installation, cleanup, and uninstallation for both 1.x and 2.x releases. It introduces version-aware logic for handling binaries, adds comprehensive tests, and updates installer and uninstaller code to use the new logic.

**Containerd binary management improvements:**

* Split the list of containerd binaries into `containerdV1Binaries` and `containerdV2Binaries` to reflect differences between 1.x and 2.x releases, and added helper functions (`getContainerdBinariesForVersion`, `getAllContainerdBinaries`, `getMajorVersion`) to select binaries based on version. [[1]](diffhunk://#diff-43085aa92a085f05fbbdf12a9e2056d030f24cd36c6427c01c5cae921dc1f7daR3-R7) [[2]](diffhunk://#diff-43085aa92a085f05fbbdf12a9e2056d030f24cd36c6427c01c5cae921dc1f7daL16-R22) [[3]](diffhunk://#diff-43085aa92a085f05fbbdf12a9e2056d030f24cd36c6427c01c5cae921dc1f7daR31-R95)
* Updated installer and uninstaller logic in `containerd_installer.go` and `containerd_uninstaller.go` to use version-appropriate binary lists for installation, permission setting, existence checks, and cleanup, ensuring deprecated binaries are properly removed during upgrades. [[1]](diffhunk://#diff-3f3153ba1f38a4dc3ae9f6bea182b6c56c8cc0e39f63e1d9d9dc4ce7d4272c09L124-R125) [[2]](diffhunk://#diff-3f3153ba1f38a4dc3ae9f6bea182b6c56c8cc0e39f63e1d9d9dc4ce7d4272c09L135-R138) [[3]](diffhunk://#diff-3f3153ba1f38a4dc3ae9f6bea182b6c56c8cc0e39f63e1d9d9dc4ce7d4272c09L182-R186) [[4]](diffhunk://#diff-71a9a01cfffd4edd774e459d2af97dbf14863632edf53eacd2d8b4de7b27a57dL59-R60) [[5]](diffhunk://#diff-71a9a01cfffd4edd774e459d2af97dbf14863632edf53eacd2d8b4de7b27a57dL101-R102)

**Testing enhancements:**

* Added `consts_test.go` with comprehensive unit tests for version parsing and binary selection logic, covering edge cases and ensuring the new helper functions behave as expected.

**Documentation improvements:**

* Fixed a comment typo in `runc_installer.go` to accurately describe the `constructRuncDownloadURL` function.…d cleanup logic