### PR TITLE
Configure kubelet client CA for konnectivity authentication

### DIFF
--- a/pkg/components/kubelet/consts.go
+++ b/pkg/components/kubelet/consts.go
@@ -5,6 +5,7 @@ const (
 	etcDefaultDir     = "/etc/default"
 	kubeletServiceDir = "/etc/systemd/system/kubelet.service.d"
 	etcKubernetesDir  = "/etc/kubernetes"
+	kubernetesPKIDir  = "/etc/kubernetes/pki"
 
 	// Kubelet-specific directories
 	kubeletManifestsDir    = "/etc/kubernetes/manifests"
@@ -23,6 +24,9 @@ const (
 	kubeletVarDir              = "/var/lib/kubelet"
 	KubeletKubeconfigPath      = "/var/lib/kubelet/kubeconfig"
 	kubeletTokenScriptPath     = "/var/lib/kubelet/token.sh"
+
+	// PKI certificate paths
+	apiserverClientCAPath = "/etc/kubernetes/pki/apiserver-client-ca.crt"
 
 	// Azure resource identifiers
 	aksServiceResourceID = "6dae42f8-4368-4678-94ff-3960e28e3630"

--- a/pkg/components/kubelet/kubelet_installer.go
+++ b/pkg/components/kubelet/kubelet_installer.go
@@ -2,6 +2,7 @@ package kubelet
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -165,6 +166,7 @@ func (i *Installer) createRequiredDirectories() error {
 		kubeletManifestsDir,    // For pod manifests
 		kubeletVolumePluginDir, // For volume plugins
 		kubeletVarDir,          // For kubelet data
+		kubernetesPKIDir,       // For PKI certificates
 	}
 
 	for _, dir := range directories {
@@ -216,6 +218,7 @@ KUBELET_FLAGS="\
   --anonymous-auth=false \
   --authentication-token-webhook=true \
   --authorization-mode=Webhook \
+  --client-ca-file=%s \
   --cgroup-driver=systemd \
   --cgroups-per-qos=true \
   --enforce-node-allocatable=pods \
@@ -238,6 +241,7 @@ KUBELET_FLAGS="\
   "`,
 		strings.Join(labels, ","),
 		i.config.Node.Kubelet.Verbosity,
+		apiserverClientCAPath,
 		i.config.Node.Kubelet.DNSServiceIP,
 		mapToEvictionThresholds(i.config.Node.Kubelet.EvictionHard, ","),
 		mapToKeyValuePairs(i.config.Node.Kubelet.KubeReserved, ","),
@@ -505,6 +509,30 @@ func (i *Installer) writeTokenScript(tokenScript string) error {
 	return nil
 }
 
+// writeClientCACertificate writes the API server client CA certificate to disk for kubelet authentication
+func (i *Installer) writeClientCACertificate(caCertData string) error {
+	if caCertData == "" {
+		i.logger.Debug("No CA certificate data provided, skipping client CA file creation")
+		return nil
+	}
+
+	i.logger.Info("Writing API server client CA certificate")
+
+	// Decode base64 CA certificate data
+	caCertBytes, err := base64.StdEncoding.DecodeString(caCertData)
+	if err != nil {
+		return fmt.Errorf("failed to decode CA certificate data: %w", err)
+	}
+
+	// Write CA certificate atomically with proper permissions
+	if err := utils.WriteFileAtomicSystem(apiserverClientCAPath, caCertBytes, 0o644); err != nil {
+		return fmt.Errorf("failed to write API server client CA certificate: %w", err)
+	}
+
+	i.logger.Infof("API server client CA certificate written to %s", apiserverClientCAPath)
+	return nil
+}
+
 // createKubeconfigWithExecCredential creates kubeconfig with exec credential provider for authentication
 func (i *Installer) createKubeconfigWithExecCredential(ctx context.Context) error {
 	// Fetch cluster credentials from Azure (for Arc/SP/MI modes)
@@ -518,6 +546,11 @@ func (i *Installer) createKubeconfigWithExecCredential(ctx context.Context) erro
 	serverURL, caCertData, err := utils.ExtractClusterInfo(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to extract cluster info from kubeconfig: %w", err)
+	}
+
+	// Write CA certificate to file for kubelet client authentication
+	if err := i.writeClientCACertificate(caCertData); err != nil {
+		return fmt.Errorf("failed to write client CA certificate: %w", err)
 	}
 
 	// Create cluster configuration based on whether we have CA cert
@@ -587,6 +620,11 @@ func (i *Installer) createKubeconfigWithBootstrapToken(ctx context.Context) erro
 	serverURL := i.config.Node.Kubelet.ServerURL
 	caCertData := i.config.Node.Kubelet.CACertData
 	bootstrapToken := i.config.Azure.BootstrapToken.Token
+
+	// Write CA certificate to file for kubelet client authentication
+	if err := i.writeClientCACertificate(caCertData); err != nil {
+		return fmt.Errorf("failed to write client CA certificate: %w", err)
+	}
 
 	// Get node hostname for audit logging
 	hostname, err := os.Hostname()

--- a/pkg/components/kubelet/kubelet_uninstaller.go
+++ b/pkg/components/kubelet/kubelet_uninstaller.go
@@ -44,6 +44,7 @@ func (u *UnInstaller) Execute(ctx context.Context) error {
 		kubeletKubeConfig,
 		kubeletBootstrapKubeConfig,
 		kubeletTokenScriptPath,
+		apiserverClientCAPath,
 	}
 
 	// Remove kubelet configuration directories


### PR DESCRIPTION
This pull request fixs issue #76 by improving PKI certificate handling and ensuring proper client authentication. The main changes include creating and managing the API server client CA certificate file, updating kubelet startup flags to reference this certificate, and ensuring proper cleanup during uninstallation. 

**PKI Certificate Management:**

* Added a new constant `kubernetesPKIDir` for PKI certificate storage and ensured its creation during installation. [[1]](diffhunk://#diff-1b0b7d18b4eac071adeeb13c082c36a8def2c5f139d6dd522c4f5b47b5737741R8) [[2]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R169)
* Introduced `apiserverClientCAPath` constant and implemented the `writeClientCACertificate` function to decode base64 CA certificate data and write it atomically to disk for kubelet authentication. [[1]](diffhunk://#diff-1b0b7d18b4eac071adeeb13c082c36a8def2c5f139d6dd522c4f5b47b5737741R28-R30) [[2]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R512-R535)
* Updated installer logic to invoke `writeClientCACertificate` when creating kubeconfig files, ensuring the client CA certificate is always written if provided. [[1]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R551-R555) [[2]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R624-R628)

**Kubelet Configuration:**

* Modified kubelet startup flags to include `--client-ca-file` referencing the new CA certificate path, improving authentication security. [[1]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R221) [[2]](diffhunk://#diff-f3bd23bd63dda6390195ce6e486b0aac476d53b83954d4972bbd37730b50cee0R244)

**Uninstallation Cleanup:**

* Ensured the client CA certificate file is removed during kubelet uninstallation for proper cleanup.