### PR TITLE
doc: add components api doc

### DIFF
--- a/docs/components-api.md
+++ b/docs/components-api.md
@@ -115,7 +115,7 @@ In environments where pre-built VHD images are not available, the action list in
   { "metadata": { "type": "...DownloadCRIBinaries" },  "spec": { "containerdVersion": "2.0.1", "runcVersion": "1.2.4" } },
   { "metadata": { "type": "...StartContainerdService" }, "spec": { "sandboxImage": "mcr.microsoft.com/oss/containerd/pause:3.6" } },
   { "metadata": { "type": "...DownloadKubeBinaries" }, "spec": { "kubernetesVersion": "1.32.1" } },
-  { "metadata": { "type": "...KubadmNodeJoin" },       "spec": { "controlPlane": { "server": "https://cp.example.com:6443", "certificateAuthorityData": "..." }, "kubelet": { "bootstrapAuthInfo": { "token": "..." } } } }
+  { "metadata": { "type": "...KubadmNodeJoin" },       "spec": { "controlPlane": { "server": "...", "certificateAuthorityData": "..." }, "kubelet": { "bootstrapAuthInfo": { "token": "..." } } } }
 ]
 ```
 


### PR DESCRIPTION
This pull request proposes a new components organization process for managing the flex node lifecycle (baking/bootstrapping/updating etc).

The new node join process can be completed by a single command on a user provided configuration file:

```
aks-flex-node apply -f <config.json>
```

Sample configuration:

```json
[
  {
    "metadata": {
      "type": "aks.flex.components.linux.v20260301.ConfigureBaseOS",
      "name": "configure-base-os"
    },
    "spec": {}
  },
  {
    "metadata": {
      "type": "aks.flex.components.cri.v20260301.DownloadCRIBinaries",
      "name": "download-cri-binaries"
    },
    "spec": {
      "containerd_version": "2.0.4",
      "runc_version": "1.2.5"
    }
  },
  {
    "metadata": {
      "type": "aks.flex.components.kubebins.v20260301.DownloadKubeBinaries",
      "name": "download-kube-binaries"
    },
    "spec": {
      "kubernetes_version": "1.32.3"
    }
  },
  {
    "metadata": {
      "type": "aks.flex.components.cri.v20260301.StartContainerdService",
      "name": "start-containerd-service"
    },
    "spec": {}
  },
  {
    "metadata": {
      "type": "aks.flex.components.kubeadm.v20260301.KubadmNodeJoin",
      "name": "kubeadm-node-join"
    },
    "spec": {
      "control_plane": {
        "server": "https://<fqdn>:443",
        "certificate_authority_data": "<ca>"
      },
      "kubelet": {
        "bootstrap_auth_info": {
          "token": "<bootstrap-token>"
        },
        "node_labels": {
          "kubernetes.azure.com/managed": "false",
          "kubernetes.azure.com/cluster": "<cluster-info>"
        }
      }
    }
  }
]
```

A full implementation of this design can be found in #83 (demo has been shared internally).

Related:
- #77 