### PR TITLE
refactor: simplify GetArch implementation

### DIFF
--- a/pkg/components/cni/cni_setup_installer.go
+++ b/pkg/components/cni/cni_setup_installer.go
@@ -9,6 +9,7 @@ import (
 
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
+	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilhost"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilio"
 )
 
@@ -139,10 +140,7 @@ func (i *Installer) installCNIPlugins(ctx context.Context) error {
 	}
 
 	// Construct CNI download URL
-	_, cniDownloadURL, err := i.constructCNIDownloadURL()
-	if err != nil {
-		return fmt.Errorf("failed to construct CNI download URL: %w", err)
-	}
+	_, cniDownloadURL := i.constructCNIDownloadURL()
 
 	for tarFile, err := range utilio.DecompressTarGzFromRemote(ctx, cniDownloadURL) {
 		if err != nil {
@@ -173,16 +171,13 @@ func canSkipCNIPluginInstallation() bool {
 	return true
 }
 
-func (i *Installer) constructCNIDownloadURL() (string, string, error) {
+func (i *Installer) constructCNIDownloadURL() (string, string) {
 	cniVersion := getCNIVersion(i.config)
-	arch, err := utils.GetArc()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get architecture: %w", err)
-	}
+	arch := utilhost.GetArch()
 	url := fmt.Sprintf(cniDownLoadURL, cniVersion, arch, cniVersion)
 	fileName := fmt.Sprintf(cniFileName, arch, cniVersion)
 	i.logger.Infof("Constructed CNI download URL: %s", url)
-	return fileName, url, nil
+	return fileName, url
 }
 
 func getCNIVersion(cfg *config.Config) string {

--- a/pkg/components/containerd/containerd_installer.go
+++ b/pkg/components/containerd/containerd_installer.go
@@ -11,6 +11,7 @@ import (
 	"go.goms.io/aks/AKSFlexNode/pkg/components/cni"
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
+	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilhost"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilio"
 )
 
@@ -150,10 +151,7 @@ func (i *Installer) canSkipContainerdInstallation() bool {
 // it returns the file name and URL for downloading containerd
 func (i *Installer) constructContainerdDownloadURL() (string, string, error) {
 	containerdVersion := i.getContainerdVersion()
-	arch, err := utils.GetArc()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get architecture: %w", err)
-	}
+	arch := utilhost.GetArch()
 	url := fmt.Sprintf(containerdDownloadURL, containerdVersion, containerdVersion, arch)
 	fileName := fmt.Sprintf(containerdFileName, containerdVersion, arch)
 	i.logger.Infof("Constructed containerd download URL: %s", url)

--- a/pkg/components/kube_binaries/kube_binaries_installer.go
+++ b/pkg/components/kube_binaries/kube_binaries_installer.go
@@ -10,6 +10,7 @@ import (
 
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
+	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilhost"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilio"
 )
 
@@ -152,11 +153,7 @@ func (i *Installer) cleanupExistingInstallation() error {
 // constructKubeBinariesDownloadURL constructs the download URL for the specified Kubernetes version
 // it returns the file name and URL for downloading Kube binaries
 func (i *Installer) constructKubeBinariesDownloadURL() (string, string, error) {
-	arch, err := utils.GetArc()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get architecture: %w", err)
-	}
-
+	arch := utilhost.GetArch()
 	kubernetesVersion := i.config.GetKubernetesVersion()
 	urlTemplate := i.getKubernetesURLTemplate()
 	url := fmt.Sprintf(urlTemplate, kubernetesVersion, arch)

--- a/pkg/components/npd/npd_installer.go
+++ b/pkg/components/npd/npd_installer.go
@@ -9,6 +9,7 @@ import (
 	"go.goms.io/aks/AKSFlexNode/pkg/components/kubelet"
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
+	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilhost"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilio"
 )
 
@@ -186,10 +187,7 @@ func (i *Installer) cleanupExistingInstallation() error {
 
 func (i *Installer) getNpdDownloadURL() (string, string, error) {
 	npdVersion := i.getNpdVersion()
-	arch, err := utils.GetArc()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get architecture: %w", err)
-	}
+	arch := utilhost.GetArch()
 	// Construct the download URL based on the version
 	downloadURL := fmt.Sprintf(npdDownloadURL, npdVersion, npdVersion, arch)
 	fileName := fmt.Sprintf(npdFileName, npdVersion)

--- a/pkg/components/runc/runc_installer.go
+++ b/pkg/components/runc/runc_installer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.goms.io/aks/AKSFlexNode/pkg/config"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils"
+	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilhost"
 	"go.goms.io/aks/AKSFlexNode/pkg/utils/utilio"
 )
 
@@ -66,10 +67,7 @@ func (i *Installer) installRunc(ctx context.Context) error {
 // it returns the file name and URL for downloading containerd
 func (i *Installer) constructRuncDownloadURL() (string, string, error) {
 	runcVersion := i.getRuncVersion()
-	arch, err := utils.GetArc()
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get architecture: %w", err)
-	}
+	arch := utilhost.GetArch()
 	url := fmt.Sprintf(runcDownloadURL, runcVersion, arch)
 	fileName := fmt.Sprintf(runcFileName, arch)
 	i.logger.Infof("Constructed runc download URL: %s", url)

--- a/pkg/utils/utilhost/arch.go
+++ b/pkg/utils/utilhost/arch.go
@@ -1,0 +1,34 @@
+package utilhost
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	arch        string // arm64 / amd64
+	machineArch string // aarch64 / x86_64
+)
+
+func init() {
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "amd64"
+		machineArch = "x86_64"
+	case "arm64":
+		arch = "arm64"
+		machineArch = "aarch64"
+	default:
+		panic(fmt.Sprintf("unsupported architecture: %s", runtime.GOARCH))
+	}
+}
+
+// GetArch returns the architecture of the host with format like "amd64", "arm64".
+func GetArch() string {
+	return arch
+}
+
+// GetMachineArch returns the machine architecture of the host with format like "x86_64", "aarch64".
+func GetMachineArch() string {
+	return machineArch
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -210,27 +210,6 @@ func RemoveDirectories(directories []string, logger *logrus.Logger) []error {
 	return errors
 }
 
-// GetArc retrieves the system architecture in a format matching reference scripts
-func GetArc() (string, error) {
-	// Get architecture using same logic as reference script
-	arch, err := RunCommandWithOutput("uname", "-m")
-	if err != nil {
-		return "", fmt.Errorf("failed to get architecture: %w", err)
-	}
-	arch = strings.TrimSpace(arch)
-
-	// Map architecture names to match reference script logic
-	switch arch {
-	case "armv7l", "armv7":
-		arch = "arm"
-	case "aarch64":
-		arch = "arm64"
-	case "x86_64":
-		arch = "amd64"
-	}
-	return arch, nil
-}
-
 // ExtractClusterInfo extracts server URL and CA certificate data from kubeconfig
 func ExtractClusterInfo(kubeconfigData []byte) (string, string, error) {
 	config, err := clientcmd.Load(kubeconfigData)


### PR DESCRIPTION
The host arch can be inferred from binary's runtime config already as the binary needs to use the same arch like the host, so no need to run `uname -m` for this.