### PR TITLE
Update usage doc

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -502,6 +502,24 @@ subjects:
   kind: Group
   name: system:bootstrappers:aks-flex-node
 EOF
+
+# Create node role binding for list and check node
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+EOF
 ```
 
 ### Installation
@@ -563,9 +581,11 @@ tee /etc/aks-flex-node/config.json > /dev/null <<EOF
   "kubernetes": {
     "version": "1.30.0"
   },
-  "kubelet": {
-    "serverURL": "$SERVER_URL",
-    "caCertData": "$CA_CERT_DATA"
+  "node": {
+    "kubelet": {
+      "serverURL": "$SERVER_URL",
+      "caCertData": "$CA_CERT_DATA"
+    }
   },
   "agent": {
     "logLevel": "info",
@@ -734,6 +754,7 @@ kubectl get secret bootstrap-token-<token-id> -n kube-system -o yaml
 # Verify RBAC bindings
 kubectl get clusterrolebinding aks-flex-node-bootstrapper
 kubectl get clusterrolebinding aks-flex-node-auto-approve-csr
+kubectl get clusterrolebinding aks-flex-node-role
 
 # Check certificate signing requests
 kubectl get csr


### PR DESCRIPTION
This pull request updates the `docs/usage.md` documentation to improve the configuration and setup process for AKS Flex nodes. The main focus is on enhancing node certificate management and restructuring the configuration file for clarity.

RBAC and Node Certificate Management:

* Added a new `ClusterRoleBinding` to auto-approve kubelet certificate signing requests for nodes in the `system:bootstrappers:aks-flex-node` group, improving node bootstrap automation.

Configuration File Structure:

* Moved the `serverURL` and `caCertData` fields from the `bootstrapToken` section into a new top-level `kubelet` section in the `/etc/aks-flex-node/config.json` file for better organization. [[1]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L538-L539) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R566-R569)