### PR TITLE
fix: override systemd unit

### DIFF
--- a/components/cri/v20260301/service.go
+++ b/components/cri/v20260301/service.go
@@ -129,31 +129,7 @@ func (s *startContainerdServiceAction) ensureSystemdUnit(ctx context.Context, re
 		return err
 	}
 
-	if unitUpdated {
-		if err := s.systemd.DaemonReload(ctx); err != nil {
-			return err
-		}
-	}
-
-	needsRestart := restart || unitUpdated
-
-	status, err := s.systemd.GetUnitStatus(ctx, systemdUnitContainerd)
-	switch {
-	case errors.Is(err, systemd.ErrUnitNotFound):
-		// This shouldn't happen since we just ensured the unit file exists,
-		// but handle it defensively.
-		return s.systemd.StartUnit(ctx, systemdUnitContainerd)
-	case err != nil:
-		return err
-	default:
-		if status.ActiveState != systemd.UnitActiveStateActive {
-			return s.systemd.StartUnit(ctx, systemdUnitContainerd)
-		}
-		if needsRestart {
-			return s.systemd.ReloadOrRestartUnit(ctx, systemdUnitContainerd)
-		}
-		return nil
-	}
+	return systemd.EnsureUnitRunning(ctx, s.systemd, systemdUnitContainerd, unitUpdated, restart || unitUpdated)
 }
 
 // ensureGPUDropInConfigs manages GPU-related containerd drop-in configs.

--- a/components/cri/v20260301/service.go
+++ b/components/cri/v20260301/service.go
@@ -117,18 +117,6 @@ func (s *startContainerdServiceAction) ensureContainerdConfig(
 }
 
 func (s *startContainerdServiceAction) ensureSystemdUnit(ctx context.Context, restart bool) error {
-	_, err := s.systemd.GetUnitStatus(ctx, systemdUnitContainerd)
-	switch {
-	case errors.Is(err, systemd.ErrUnitNotFound):
-		return s.createSystemdUnit(ctx)
-	case err != nil:
-		return err
-	default:
-		return s.updateSystemdUnit(ctx, restart)
-	}
-}
-
-func (s *startContainerdServiceAction) createSystemdUnit(ctx context.Context) error {
 	b := &bytes.Buffer{}
 	if err := assetsTemplate.ExecuteTemplate(b, "containerd.service", map[string]any{
 		"ContainerdBinPath": containerdBinPath,
@@ -136,31 +124,36 @@ func (s *startContainerdServiceAction) createSystemdUnit(ctx context.Context) er
 		return err
 	}
 
-	if err := s.systemd.WriteUnitFile(ctx, systemdUnitContainerd, b.Bytes()); err != nil {
+	unitUpdated, err := s.systemd.EnsureUnitFile(ctx, systemdUnitContainerd, b.Bytes())
+	if err != nil {
 		return err
 	}
 
-	if err := s.systemd.DaemonReload(ctx); err != nil {
-		return err
-	}
-
-	if err := s.systemd.StartUnit(ctx, systemdUnitContainerd); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *startContainerdServiceAction) updateSystemdUnit(ctx context.Context, restart bool) error {
-	// TODO: should we allow updating containerd.service?
-
-	if restart {
-		if err := s.systemd.ReloadOrRestartUnit(ctx, systemdUnitContainerd); err != nil {
+	if unitUpdated {
+		if err := s.systemd.DaemonReload(ctx); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	needsRestart := restart || unitUpdated
+
+	status, err := s.systemd.GetUnitStatus(ctx, systemdUnitContainerd)
+	switch {
+	case errors.Is(err, systemd.ErrUnitNotFound):
+		// This shouldn't happen since we just ensured the unit file exists,
+		// but handle it defensively.
+		return s.systemd.StartUnit(ctx, systemdUnitContainerd)
+	case err != nil:
+		return err
+	default:
+		if status.ActiveState != systemd.UnitActiveStateActive {
+			return s.systemd.StartUnit(ctx, systemdUnitContainerd)
+		}
+		if needsRestart {
+			return s.systemd.ReloadOrRestartUnit(ctx, systemdUnitContainerd)
+		}
+		return nil
+	}
 }
 
 // ensureGPUDropInConfigs manages GPU-related containerd drop-in configs.

--- a/components/kubeadm/v20260301/join.go
+++ b/components/kubeadm/v20260301/join.go
@@ -189,34 +189,29 @@ func (n *nodeJoinAction) writeKubeadmJoinConfig(
 }
 
 func (n *nodeJoinAction) ensureKubeletUnit(ctx context.Context) error {
-	_, err := n.systemd.GetUnitStatus(ctx, systemdUnitKubelet)
-	switch {
-	case errors.Is(err, systemd.ErrUnitNotFound):
-		// proceed to create
-	case err != nil:
-		return err
-	default:
-		return nil // unit already exists, nothing to do
-	}
-
-	if err := n.systemd.WriteUnitFile(
+	unitUpdated, err := n.systemd.EnsureUnitFile(
 		ctx,
 		systemdUnitKubelet,
 		systemdUnitKubeletFile,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("kubelet unit: %w", err)
 	}
-	if err := n.systemd.WriteDropInFile(
+
+	dropInUpdated, err := n.systemd.EnsureDropInFile(
 		ctx,
 		systemdUnitKubelet,
 		systemdDropInKubeadm,
 		systemdDropInKubeadmFile,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("kubelet unit drop-in: %w", err)
 	}
 
-	if err := n.systemd.DaemonReload(ctx); err != nil {
-		return fmt.Errorf("systemd daemon reload: %w", err)
+	if unitUpdated || dropInUpdated {
+		if err := n.systemd.DaemonReload(ctx); err != nil {
+			return fmt.Errorf("systemd daemon reload: %w", err)
+		}
 	}
 
 	if err := n.systemd.EnableUnit(ctx, systemdUnitKubelet); err != nil {

--- a/components/kubelet/v20260301/kubelet_service.go
+++ b/components/kubelet/v20260301/kubelet_service.go
@@ -15,21 +15,6 @@ func (s *startKubeletServiceAction) ensureSystemdUnit(
 	needsRestart bool,
 	spec *kubelet.StartKubeletServiceSpec,
 ) error {
-	_, err := s.systemd.GetUnitStatus(ctx, systemdUnitKubelet)
-	switch {
-	case errors.Is(err, systemd.ErrUnitNotFound):
-		return s.createSystemdUnit(ctx, spec)
-	case err != nil:
-		return err
-	default:
-		return s.updateSystemdUnit(ctx, needsRestart)
-	}
-}
-
-func (s *startKubeletServiceAction) createSystemdUnit(
-	ctx context.Context,
-	spec *kubelet.StartKubeletServiceSpec,
-) error {
 	kubeletConfig := spec.GetKubeletConfig()
 
 	var (
@@ -64,29 +49,32 @@ func (s *startKubeletServiceAction) createSystemdUnit(
 		return err
 	}
 
-	if err := s.systemd.WriteUnitFile(ctx, systemdUnitKubelet, b.Bytes()); err != nil {
+	unitUpdated, err := s.systemd.EnsureUnitFile(ctx, systemdUnitKubelet, b.Bytes())
+	if err != nil {
 		return err
 	}
 
-	if err := s.systemd.DaemonReload(ctx); err != nil {
-		return err
-	}
-
-	if err := s.systemd.StartUnit(ctx, systemdUnitKubelet); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *startKubeletServiceAction) updateSystemdUnit(ctx context.Context, restart bool) error {
-	// TODO: should we allow updating kubelet.service?
-
-	if restart {
-		if err := s.systemd.ReloadOrRestartUnit(ctx, systemdUnitKubelet); err != nil {
+	if unitUpdated {
+		if err := s.systemd.DaemonReload(ctx); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	needsRestart = needsRestart || unitUpdated
+
+	status, err := s.systemd.GetUnitStatus(ctx, systemdUnitKubelet)
+	switch {
+	case errors.Is(err, systemd.ErrUnitNotFound):
+		return s.systemd.StartUnit(ctx, systemdUnitKubelet)
+	case err != nil:
+		return err
+	default:
+		if status.ActiveState != systemd.UnitActiveStateActive {
+			return s.systemd.StartUnit(ctx, systemdUnitKubelet)
+		}
+		if needsRestart {
+			return s.systemd.ReloadOrRestartUnit(ctx, systemdUnitKubelet)
+		}
+		return nil
+	}
 }

--- a/components/kubelet/v20260301/kubelet_service.go
+++ b/components/kubelet/v20260301/kubelet_service.go
@@ -3,7 +3,6 @@ package v20260301
 import (
 	"bytes"
 	"context"
-	"errors"
 
 	"github.com/Azure/AKSFlexNode/components/kubelet"
 	"github.com/Azure/AKSFlexNode/pkg/config"
@@ -54,27 +53,5 @@ func (s *startKubeletServiceAction) ensureSystemdUnit(
 		return err
 	}
 
-	if unitUpdated {
-		if err := s.systemd.DaemonReload(ctx); err != nil {
-			return err
-		}
-	}
-
-	needsRestart = needsRestart || unitUpdated
-
-	status, err := s.systemd.GetUnitStatus(ctx, systemdUnitKubelet)
-	switch {
-	case errors.Is(err, systemd.ErrUnitNotFound):
-		return s.systemd.StartUnit(ctx, systemdUnitKubelet)
-	case err != nil:
-		return err
-	default:
-		if status.ActiveState != systemd.UnitActiveStateActive {
-			return s.systemd.StartUnit(ctx, systemdUnitKubelet)
-		}
-		if needsRestart {
-			return s.systemd.ReloadOrRestartUnit(ctx, systemdUnitKubelet)
-		}
-		return nil
-	}
+	return systemd.EnsureUnitRunning(ctx, s.systemd, systemdUnitKubelet, unitUpdated, needsRestart || unitUpdated)
 }

--- a/pkg/systemd/dbus.go
+++ b/pkg/systemd/dbus.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -117,46 +118,44 @@ func (d *dbusImpl) GetUnitStatus(ctx context.Context, unitName string) (dbus.Uni
 	return dbus.UnitStatus{}, ErrUnitNotFound
 }
 
-func (d *dbusImpl) writeSystemdFile(
-	path string,
-	content []byte,
-) error {
-	// current process runs with root privileges, hence we don't want to
-	// overwrite any pre-existing file to avoid unexpected consequences.
-	if err := ensureNotOverridingExistingFile(path); err != nil {
-		return err
+// ensureSystemdFile idempotently ensures the systemd file at the given path
+// has the desired content. It writes only if the content differs from what's
+// currently on disk or the file does not exist.
+// Returns true if the file was written.
+func (d *dbusImpl) ensureSystemdFile(path string, content []byte) (bool, error) {
+	currentContent, err := os.ReadFile(path) //#nosec G304 -- trusted path constructed from constant
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		// File doesn't exist, fall through to write it
+	case err != nil:
+		return false, err
+	default:
+		if bytes.Equal(bytes.TrimSpace(currentContent), bytes.TrimSpace(content)) {
+			return false, nil
+		}
 	}
 
 	if err := utilio.WriteFile(path, content, 0600); err != nil {
-		return err
+		return false, err
 	}
-
-	return nil
+	return true, nil
 }
 
-func (d *dbusImpl) WriteUnitFile(
+func (d *dbusImpl) EnsureUnitFile(
 	_ context.Context,
 	unitName string,
 	content []byte,
-) error {
+) (bool, error) {
 	unitPath := filepath.Join(etcSystemdSystemDir, unitName)
-
-	return d.writeSystemdFile(unitPath, content)
+	return d.ensureSystemdFile(unitPath, content)
 }
 
-func (d *dbusImpl) WriteDropInFile(
-	_ context.Context, unitName string, dropInName string, content []byte,
-) error {
-	return d.writeSystemdFile(
-		filepath.Join(etcSystemdSystemDir, unitName+".d", dropInName),
-		content,
-	)
-}
-
-func ensureNotOverridingExistingFile(path string) error {
-	_, err := os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("%q exists, refuse overriding", path)
-	}
-	return nil
+func (d *dbusImpl) EnsureDropInFile(
+	_ context.Context,
+	unitName string,
+	dropInName string,
+	content []byte,
+) (bool, error) {
+	dropInPath := filepath.Join(etcSystemdSystemDir, unitName+".d", dropInName)
+	return d.ensureSystemdFile(dropInPath, content)
 }

--- a/pkg/systemd/ensure.go
+++ b/pkg/systemd/ensure.go
@@ -1,0 +1,46 @@
+package systemd
+
+import (
+	"context"
+	"errors"
+)
+
+// EnsureUnitRunning ensures a systemd unit is active.
+//
+// When reloadDaemon is true, the systemd daemon is reloaded first so that it
+// picks up any unit file changes on disk. This must be set whenever the unit
+// file (or a drop-in) has been created or modified.
+//
+// When restartUnit is true and the unit is already active, it is
+// reloaded/restarted (e.g. because associated configuration changed).
+//
+// If the unit is not active regardless of the flags, it is started.
+func EnsureUnitRunning(
+	ctx context.Context,
+	m Manager,
+	unitName string,
+	reloadDaemon bool,
+	restartUnit bool,
+) error {
+	if reloadDaemon {
+		if err := m.DaemonReload(ctx); err != nil {
+			return err
+		}
+	}
+
+	status, err := m.GetUnitStatus(ctx, unitName)
+	switch {
+	case errors.Is(err, ErrUnitNotFound):
+		return m.StartUnit(ctx, unitName)
+	case err != nil:
+		return err
+	default:
+		if status.ActiveState != UnitActiveStateActive {
+			return m.StartUnit(ctx, unitName)
+		}
+		if reloadDaemon || restartUnit {
+			return m.ReloadOrRestartUnit(ctx, unitName)
+		}
+		return nil
+	}
+}

--- a/pkg/systemd/types.go
+++ b/pkg/systemd/types.go
@@ -31,8 +31,15 @@ type Manager interface {
 	// Returns ErrUnitNotFound if no unit with the specified name exists.
 	GetUnitStatus(ctx context.Context, unitName string) (dbus.UnitStatus, error)
 
-	// WriteUnitFile writes a systemd unit file with the given name and content.
-	WriteUnitFile(ctx context.Context, unitName string, content []byte) error
-	// WriteDropInFile writes a systemd drop-in file for the specified unit.
-	WriteDropInFile(ctx context.Context, unitName string, dropInName string, content []byte) error
+	// EnsureUnitFile idempotently ensures the systemd unit file in /etc/systemd/system/
+	// has the desired content. It writes the file only if the content differs from
+	// what's currently on disk. This is useful when overriding a vendor-provided unit
+	// file in /lib/systemd/system/ with a custom one.
+	// Returns true if the file was written (i.e., content changed or file was created).
+	EnsureUnitFile(ctx context.Context, unitName string, content []byte) (bool, error)
+	// EnsureDropInFile idempotently ensures a systemd drop-in file for the specified unit
+	// has the desired content. It writes the file only if the content differs from
+	// what's currently on disk.
+	// Returns true if the file was written (i.e., content changed or file was created).
+	EnsureDropInFile(ctx context.Context, unitName string, dropInName string, content []byte) (bool, error)
 }


### PR DESCRIPTION
This pull request refactors how systemd unit and drop-in files are managed across several components, introducing idempotent "ensure" methods that only write files when necessary and centralizing logic for starting and reloading units. The changes improve reliability and reduce unnecessary restarts or reloads by tracking when files have actually changed.

**Systemd file management improvements:**

* Replaces previous `WriteUnitFile` and `WriteDropInFile` methods with new `EnsureUnitFile` and `EnsureDropInFile` methods in the `systemd.Manager` interface, which only write files if their content has changed or if the file does not exist. These methods now return a boolean indicating whether the file was updated. (`pkg/systemd/types.go`, `pkg/systemd/dbus.go`) [[1]](diffhunk://#diff-56ee255cf7d4fd6fb00b9827c916714e95f4d46963c02ab5706fe9a5b1123efeL34-R44) [[2]](diffhunk://#diff-d60e9f9f6b072157e860ccce9e26c0cf66741bfb1d0836ac0618c5156951375eL120-R160)
* Updates all usages in `kubelet`, `kubeadm`, and `cri` components to use the new "ensure" methods, removing manual checks for file existence and content. (`components/kubelet/v20260301/kubelet_service.go`, `components/kubeadm/v20260301/join.go`, `components/cri/v20260301/service.go`) [[1]](diffhunk://#diff-704445567a979cd1eed67cbfc248355c18dbee0a414e9fb05d1f0adec4b49d1bL17-L31) [[2]](diffhunk://#diff-704445567a979cd1eed67cbfc248355c18dbee0a414e9fb05d1f0adec4b49d1bL67-R56) [[3]](diffhunk://#diff-7c3ce6a186e17b88f812d9886b8122019e3c345015ac91c865372888e77585e9L192-R215) [[4]](diffhunk://#diff-a5afc8d8f1032d893c061b3cd6c662d6b2b53a63b0e8479e77381dcbd88fddecL120-R132)

**Unit lifecycle and reload logic centralization:**

* Introduces a new `EnsureUnitRunning` helper function that encapsulates logic for reloading the systemd daemon and restarting or starting units only when necessary, based on whether unit files or drop-ins were updated. (`pkg/systemd/ensure.go`)
* Refactors component logic to use this new helper, simplifying code and ensuring consistent behavior across services. (`components/kubelet/v20260301/kubelet_service.go`, `components/cri/v20260301/service.go`) [[1]](diffhunk://#diff-704445567a979cd1eed67cbfc248355c18dbee0a414e9fb05d1f0adec4b49d1bL67-R56) [[2]](diffhunk://#diff-a5afc8d8f1032d893c061b3cd6c662d6b2b53a63b0e8479e77381dcbd88fddecL120-R132)

**Code cleanup:**

* Removes unused error handling and file existence checks, as these are now handled by the new "ensure" methods. (`components/kubelet/v20260301/kubelet_service.go`, `pkg/systemd/dbus.go`) [[1]](diffhunk://#diff-704445567a979cd1eed67cbfc248355c18dbee0a414e9fb05d1f0adec4b49d1bL6) [[2]](diffhunk://#diff-d60e9f9f6b072157e860ccce9e26c0cf66741bfb1d0836ac0618c5156951375eL120-R160)

These changes make systemd unit management more robust and reduce unnecessary operations, improving both reliability and maintainability.