### PR TITLE
Fix local privilege escalation via AZURE_CONFIG_DIR and document RBAC over-grant

### DIFF
--- a/aks-flex-node-agent.service
+++ b/aks-flex-node-agent.service
@@ -15,37 +15,16 @@ TimeoutStopSec=60
 # Restart configuration for daemon resilience
 Restart=on-failure
 RestartSec=30
-# TODO: review the settings and permission here
 User=root
 Group=root
-SupplementaryGroups=PLACEHOLDER_USER_GROUP
+# AZURE_CONFIG_DIR points to a root-owned copy under /etc/aks-flex-node/azure,
+# NOT the installing user's ~/.azure (which would allow local privilege escalation
+# via malicious CLI extensions). See scripts/install.sh for the copy logic.
 Environment=AZURE_CONFIG_DIR=PLACEHOLDER_AZURE_CONFIG_DIR
 RuntimeDirectory=aks-flex-node
-RuntimeDirectoryMode=0755
+RuntimeDirectoryMode=0750
 StandardOutput=journal
 StandardError=journal
-
-# Security hardening (runs as root for system-level Kubernetes node operations)
-NoNewPrivileges=false
-ProtectSystem=false
-ProtectHome=false
-PrivateTmp=false
-PrivateDevices=false
-ProtectHostname=false
-ProtectClock=false
-ProtectKernelTunables=false
-ProtectKernelModules=false
-ProtectKernelLogs=false
-ProtectControlGroups=false
-RestrictNamespaces=false
-LockPersonality=false
-MemoryDenyWriteExecute=false
-RestrictRealtime=false
-RestrictSUIDSGID=false
-RemoveIPC=false
-
-# Allow access to specific paths that need modification (- prefix makes paths optional)
-ReadWritePaths=-/etc/kubernetes -/var/lib/kubelet -/var/lib/containerd -/etc/containerd -/opt/cni -/etc/cni -/etc/systemd/system -/etc/sysctl.d -/etc/modules-load.d -/var/log/aks-flex-node -/tmp -/etc/aks-flex-node -/run/aks-flex-node
 
 [Install]
 WantedBy=multi-user.target

--- a/aks-flex-node-agent.service
+++ b/aks-flex-node-agent.service
@@ -15,12 +15,10 @@ TimeoutStopSec=60
 # Restart configuration for daemon resilience
 Restart=on-failure
 RestartSec=30
-User=root
-Group=root
 # AZURE_CONFIG_DIR points to a root-owned copy under /etc/aks-flex-node/azure,
 # NOT the installing user's ~/.azure (which would allow local privilege escalation
 # via malicious CLI extensions). See scripts/install.sh for the copy logic.
-Environment=AZURE_CONFIG_DIR=PLACEHOLDER_AZURE_CONFIG_DIR
+Environment=AZURE_CONFIG_DIR=/etc/aks-flex-node/azure
 RuntimeDirectory=aks-flex-node
 RuntimeDirectoryMode=0750
 StandardOutput=journal

--- a/components/arc/v20260301/arc_rbac.go
+++ b/components/arc/v20260301/arc_rbac.go
@@ -65,6 +65,19 @@ func (a *installArcAction) getRoleAssignments(spec *arc.InstallArcSpec) []roleAs
 	clusterScope := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s", subscriptionID, resourceGroup, clusterName)
 
 	// Define required role assignments
+	//
+	// TODO(security): These roles are over-privileged for a worker node identity and should be
+	// restricted once the design is confirmed. Current grants defeat Kubernetes NodeRestriction
+	// because the node MSI is mapped to cluster-admin by Azure RBAC. Planned changes:
+	//   - Replace "AKS RBAC Cluster Admin" with "AKS RBAC Writer" (or a custom role) scoped to
+	//     the cluster, sufficient for kubelet node/pod/lease operations.
+	//   - Remove "AKS Cluster Admin Role" — listClusterAdminCredentials is only needed by the
+	//     operator's bootstrap credential, not the node identity.
+	//   - Replace RG-wide "Contributor" with "Reader" scoped to the Arc machine resource.
+	// Note: "Reader" is intentionally scoped at the subscription level to avoid hitting
+	// Azure's per-resource role assignment count limits when many flex nodes are registered.
+	// See: https://learn.microsoft.com/en-us/azure/aks/manage-azure-rbac
+	// See: https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshoot-limits?tabs=default#symptom---no-more-role-assignments-can-be-created
 	assignments := []roleAssignment{
 		{
 			roleName: "Reader",

--- a/pkg/components/arc/arc_base.go
+++ b/pkg/components/arc/arc_base.go
@@ -89,6 +89,8 @@ func (ab *base) getArcMachine(ctx context.Context) (*armhybridcompute.Machine, e
 	return &result.Machine, nil
 }
 
+// TODO(security): These roles are over-privileged — see components/arc/v20260301/arc_rbac.go for details.
+// Will be restricted to least-privilege once the node auth design is confirmed.
 func (ab *base) getRoleAssignments() []roleAssignment {
 	return []roleAssignment{
 		{"Reader (Target Cluster)", ab.config.GetTargetClusterID(), roleDefinitionIDs["Reader"]},

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -347,10 +347,7 @@ setup_systemd_service() {
         fi
     done
 
-    log_info "Configuring service file with root-owned Azure config directory ($azure_config_dir)..."
-    sed -i "s|PLACEHOLDER_AZURE_CONFIG_DIR|$azure_config_dir|g" /etc/systemd/system/aks-flex-node-agent.service
-    # Remove SupplementaryGroups placeholder — no longer needed since we don't read from user's home
-    sed -i "s|^SupplementaryGroups=PLACEHOLDER_USER_GROUP|# SupplementaryGroups removed for security|g" /etc/systemd/system/aks-flex-node-agent.service
+    log_info "Azure CLI auth files copied to root-owned $azure_config_dir"
 
     # Reload systemd
     systemctl daemon-reload

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -325,15 +325,32 @@ setup_systemd_service() {
     cp "$temp_dir/aks-flex-node-agent.service" /etc/systemd/system/
     chmod 644 /etc/systemd/system/aks-flex-node-agent.service
 
-    # Update the service file with the correct user path for Azure CLI access
+    # Copy Azure CLI config to a root-owned directory so the root service never reads
+    # from an unprivileged user's home directory (prevents local privilege escalation
+    # via malicious CLI extensions planted in ~/.azure/cliextensions/).
     local current_user
     current_user=$(logname 2>/dev/null || echo "${SUDO_USER:-$USER}")
     local current_user_home
     current_user_home=$(eval echo "~$current_user")
 
-    log_info "Configuring service file for current user ($current_user)..."
-    sed -i "s|PLACEHOLDER_AZURE_CONFIG_DIR|$current_user_home/.azure|g" /etc/systemd/system/aks-flex-node-agent.service
-    sed -i "s|PLACEHOLDER_USER_GROUP|$current_user|g" /etc/systemd/system/aks-flex-node-agent.service
+    local azure_config_dir="/etc/aks-flex-node/azure"
+    mkdir -p "$azure_config_dir"
+    chmod 700 "$azure_config_dir"
+    chown root:root "$azure_config_dir"
+
+    # Copy only the authentication-related files (token cache, profile), never extensions
+    for f in azureProfile.json msal_token_cache.json msal_token_cache.bin clouds.config; do
+        if [ -f "$current_user_home/.azure/$f" ]; then
+            cp "$current_user_home/.azure/$f" "$azure_config_dir/"
+            chmod 600 "$azure_config_dir/$f"
+            chown root:root "$azure_config_dir/$f"
+        fi
+    done
+
+    log_info "Configuring service file with root-owned Azure config directory ($azure_config_dir)..."
+    sed -i "s|PLACEHOLDER_AZURE_CONFIG_DIR|$azure_config_dir|g" /etc/systemd/system/aks-flex-node-agent.service
+    # Remove SupplementaryGroups placeholder — no longer needed since we don't read from user's home
+    sed -i "s|^SupplementaryGroups=PLACEHOLDER_USER_GROUP|# SupplementaryGroups removed for security|g" /etc/systemd/system/aks-flex-node-agent.service
 
     # Reload systemd
     systemctl daemon-reload


### PR DESCRIPTION
## Summary

- Fix a local privilege escalation where the systemd unit pointed `AZURE_CONFIG_DIR` at the installing user's `~/.azure`, allowing an unprivileged user to plant a malicious Azure CLI extension that the root agent would auto-load
- Document the Arc node MSI over-privileged RBAC grants (cluster-admin, subscription Reader, RG Contributor) with a TODO to restrict once the node auth design is confirmed

## AZURE_CONFIG_DIR fix (`aks-flex-node-agent.service`, `scripts/install.sh`)

**Problem:** `install.sh` substituted `AZURE_CONFIG_DIR=/home/<user>/.azure` into the root service unit and added `SupplementaryGroups=<user>` to grant read access. Since `~/.azure` is fully writable by the unprivileged installer, that user could drop a malicious CLI extension in `~/.azure/cliextensions/` and gain root code execution whenever the agent invoked `az`.

**Fix:**
- `install.sh` now copies only auth-related files (`azureProfile.json`, `msal_token_cache.*`, `clouds.config`) into a root-owned `/etc/aks-flex-node/azure` (mode 0700). CLI extensions are never copied.
- The service file hardcodes `AZURE_CONFIG_DIR=/etc/aks-flex-node/azure` — no more placeholder substitution.
- Removed `SupplementaryGroups=PLACEHOLDER_USER_GROUP`.
- Removed redundant `User=root`/`Group=root` (systemd defaults).
- Tightened `RuntimeDirectoryMode` from 0755 to 0750.
- Removed all the `ProtectXXX=false` / `ReadWritePaths` directives that just restated systemd defaults.

## RBAC documentation (`arc_rbac.go`, `arc_base.go`)

Added TODO comments documenting that the current Arc node MSI role assignments are over-privileged and defeat Kubernetes NodeRestriction. The node MSI is granted `AKS RBAC Cluster Admin` (maps to cluster-admin), `AKS Cluster Admin Role` (listClusterAdminCredentials), subscription-wide `Reader`, and RG-wide `Contributor`. Planned restrictions are listed in the comments; Reader remains at subscription scope due to [Azure role assignment count limits](https://learn.microsoft.com/en-us/azure/role-based-access-control/troubleshoot-limits?tabs=default#symptom---no-more-role-assignments-can-be-created).