### PR TITLE
Fix credential exposure in kubeconfig file permissions, azcmagent argv, and log file handling

### DIFF
--- a/components/arc/v20260301/arc_registration.go
+++ b/components/arc/v20260301/arc_registration.go
@@ -169,8 +169,8 @@ func (a *installArcAction) addAuthenticationArgs(ctx context.Context, args *[]st
 	// The token is short-lived (~60 minutes) which limits the exposure window, but it is
 	// still observable during the registration process. azcmagent does not currently support
 	// reading the token from stdin or an environment variable.
-	// Consider switching to --service-principal-cert or --use-azcli when feasible.
-	// See: https://learn.microsoft.com/en-us/azure/azure-arc/servers/azcmagent-connect
+	// TODO: Check if we can let azcmagent discover auth settings on its own (e.g. --use-azcli
+	// or VM MSI) instead of fetching a token ourselves and passing it on the command line.
 	*args = append(*args, "--access-token", accessToken)
 
 	a.logger.Debug("Authentication arguments added to Arc agent command")

--- a/components/arc/v20260301/arc_registration.go
+++ b/components/arc/v20260301/arc_registration.go
@@ -164,7 +164,13 @@ func (a *installArcAction) addAuthenticationArgs(ctx context.Context, args *[]st
 		return fmt.Errorf("failed to get access token: %w", err)
 	}
 
-	// Add access token to azcmagent arguments
+	// TODO(security): The access token is passed on the command line and is therefore visible
+	// to all local users via /proc/<pid>/cmdline for the lifetime of the azcmagent process.
+	// The token is short-lived (~60 minutes) which limits the exposure window, but it is
+	// still observable during the registration process. azcmagent does not currently support
+	// reading the token from stdin or an environment variable.
+	// Consider switching to --service-principal-cert or --use-azcli when feasible.
+	// See: https://learn.microsoft.com/en-us/azure/azure-arc/servers/azcmagent-connect
 	*args = append(*args, "--access-token", accessToken)
 
 	a.logger.Debug("Authentication arguments added to Arc agent command")

--- a/components/kubelet/v20260301/kubelet_config.go
+++ b/components/kubelet/v20260301/kubelet_config.go
@@ -186,8 +186,8 @@ func (s *startKubeletServiceAction) ensureKubeletKubeconfig(
 		return false, nil
 	}
 
-	// FIXME: consider using 0640?
-	if err := utilio.WriteFile(config.KubeletKubeconfigPath, desiredContent, 0644); err != nil {
+	// Write kubeconfig with restricted permissions — contains credentials (SP secret / MSI config)
+	if err := utilio.WriteFile(config.KubeletKubeconfigPath, desiredContent, 0600); err != nil {
 		return false, fmt.Errorf("write %q: %w", config.KubeletKubeconfigPath, err)
 	}
 	return true, nil
@@ -216,8 +216,8 @@ func (s *startKubeletServiceAction) ensureBootstrapKubeconfig(
 		return false, nil
 	}
 
-	// FIXME: consider using 0640?
-	if err := utilio.WriteFile(config.KubeletBootstrapKubeconfigPath, desiredContent, 0644); err != nil {
+	// Write bootstrap kubeconfig with restricted permissions — contains bootstrap token
+	if err := utilio.WriteFile(config.KubeletBootstrapKubeconfigPath, desiredContent, 0600); err != nil {
 		return false, fmt.Errorf("write %q: %w", config.KubeletBootstrapKubeconfigPath, err)
 	}
 	return true, nil

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,8 +9,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Azure/AKSFlexNode/pkg/utils"
-	"github.com/Azure/AKSFlexNode/pkg/utils/utilio"
 	"github.com/sirupsen/logrus"
 )
 
@@ -153,25 +151,9 @@ func setupLogFileWriter(logDir string) (io.Writer, error) {
 
 	logFilePath := filepath.Join(logDir, "aks-flex-node.log")
 
-	// Create the log file if it doesn't exist
-	if err := createLogFileIfNotExists(logFilePath); err != nil {
-		return nil, fmt.Errorf("failed to create log file '%s': %w", logFilePath, err)
-	}
-
-	// Try to open log file for writing, handle permission issues
-	file, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_APPEND, 0666)
+	// Open log file for appending, creating it with 0600 if it doesn't exist
+	file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600) //#nosec G304 - logFilePath is from trusted agent config
 	if err != nil {
-		// If it's a permission error and we're not running as root, try to fix permissions
-		if os.IsPermission(err) {
-			// Try to fix permissions using system command
-			if fixErr := utils.RunSystemCommand("chmod", "666", logFilePath); fixErr == nil {
-				// Retry opening the file after fixing permissions
-				file, err = os.OpenFile(logFilePath, os.O_WRONLY|os.O_APPEND, 0666)
-				if err == nil {
-					return file, nil
-				}
-			}
-		}
 		return nil, fmt.Errorf("failed to open log file '%s': %w", logFilePath, err)
 	}
 
@@ -204,45 +186,6 @@ func setupLogFile(logger *logrus.Logger, logDir string) error {
 		return err
 	}
 	logger.SetOutput(writer)
-	return nil
-}
-
-// createLogFileIfNotExists creates a log file using appropriate method based on path privileges
-func createLogFileIfNotExists(logFilePath string) error {
-	// Check if file already exists
-	if utils.FileExists(logFilePath) {
-		return nil
-	}
-
-	// For systemd services, try direct file creation first since the service
-	// should have the correct user/group and the log directory should already exist
-	if isRunningUnderSystemd() {
-		// Try direct file creation with appropriate permissions
-		file, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY, 0644)
-		if err == nil {
-			_ = file.Close()
-			return nil
-		}
-		// If direct creation fails, fall through to the system method
-		fmt.Printf("Warning: Direct log file creation failed (%v), trying system method...\n", err)
-	}
-
-	// Use WriteFileAtomicSystem to create an empty log file with proper permissions
-	if err := utilio.WriteFile(logFilePath, []byte{}, 0644); err != nil {
-		return err
-	}
-
-	// Ensure proper ownership for the current user after file creation
-	// Skip this for systemd services as they should already have correct ownership
-	if !isRunningUnderSystemd() {
-		currentUser := os.Getenv("USER")
-		if currentUser != "" {
-			if err := utils.RunSystemCommand("chown", currentUser+":"+currentUser, logFilePath); err != nil {
-				fmt.Printf("Warning: Failed to change ownership of %s to %s: %v\n", logFilePath, currentUser, err)
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Restrict kubelet kubeconfig and bootstrap-kubeconfig file permissions from 0644 to 0600
- Document ARM access token `/proc/cmdline` exposure as a known limitation of `azcmagent`
- Remove `chmod 666` log file fallback — open with 0600 and fail on error

## Kubelet kubeconfig file permissions (`kubelet_config.go`)

`ensureKubeletKubeconfig()` and `ensureBootstrapKubeconfig()` wrote credential-bearing files with mode 0644 (world-readable). In SP mode the kubeconfig embeds `AZURE_CLIENT_SECRET` in the exec env block; in bootstrap-token mode it contains the raw `<id>.<secret>` token. Changed both to 0600, matching the kubeadm code path (`components/kubeadm/v20260301/join.go`) and CIS Kubernetes Benchmark 4.1.5/4.1.9.

## ARM token on azcmagent command line (`arc_registration.go`)

`addAuthenticationArgs()` passes `--access-token <jwt>` on the command line, making the token visible via `/proc/<pid>/cmdline` to all local users. After researching the [azcmagent connect docs](https://learn.microsoft.com/en-us/azure/azure-arc/servers/azcmagent-connect), `azcmagent` does not support reading the token from stdin or environment variables — `--access-token` on argv is the only option. The token is short-lived (~60 minutes) which limits the exposure window. Added a TODO documenting this limitation and a follow-up to investigate whether `azcmagent` can discover auth settings on its own (e.g. `--use-azcli` or VM MSI) to avoid passing tokens on the command line entirely.

## Log file permission fallback (`logger.go`)

When opening the log file hit EACCES, the agent ran `chmod 666` to make it world-writable. Since the agent runs as root, this fallback was both unnecessary and insecure. Removed the workaround entirely — now opens with 0600 and returns the error on failure.