### PR TITLE
cri: emit containerd v2 schema config

### DIFF
--- a/components/cri/v20260301/assets/99-nvidia-runtime.toml
+++ b/components/cri/v20260301/assets/99-nvidia-runtime.toml
@@ -1,15 +1,15 @@
-[plugins."io.containerd.grpc.v1.cri"]
+[plugins.'io.containerd.cri.v1.runtime']
 cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
 enable_cdi = true
 
-[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
 {{- if not .DisableSetAsDefaultRuntime}}
 default_runtime_name = "{{.RuntimeClassName}}"
 {{- end}}
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{.RuntimeClassName}}]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.{{.RuntimeClassName}}]
 runtime_type = "io.containerd.runc.v2"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.{{.RuntimeClassName}}.options]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.{{.RuntimeClassName}}.options]
 BinaryName = "{{.RuntimePath}}"
 SystemdCgroup = true

--- a/components/cri/v20260301/assets/containerd.toml
+++ b/components/cri/v20260301/assets/containerd.toml
@@ -1,35 +1,37 @@
 imports = ["/etc/containerd/conf.d/*.toml"]
 
 oom_score = 0
-version = 2
+version = 3
 
-[plugins."io.containerd.grpc.v1.cri"]
+[plugins.'io.containerd.cri.v1.runtime']
 sandbox_image = "{{.SandboxImage}}"
 
-[plugins."io.containerd.grpc.v1.cri".containerd]
+[plugins.'io.containerd.cri.v1.runtime'.containerd]
 default_runtime_name = "runc"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc]
 runtime_type = "io.containerd.runc.v2"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
 BinaryName = "{{.RuncBinaryPath}}"
 SystemdCgroup = true
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.untrusted]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.untrusted]
 runtime_type = "io.containerd.runc.v2"
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.untrusted.options]
+[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.untrusted.options]
 BinaryName = "{{.RuncBinaryPath}}"
 
-[plugins."io.containerd.grpc.v1.cri".cni]
+[plugins.'io.containerd.cri.v1.runtime'.cni]
 bin_dir = "{{.CNIBinDir}}"
 conf_dir = "{{.CNIConfDir}}"
 
-[plugins."io.containerd.grpc.v1.cri".registry]
+[plugins.'io.containerd.cri.v1.images']
+
+[plugins.'io.containerd.cri.v1.images'.registry]
 config_path = "/etc/containerd/certs.d"
 
-[plugins."io.containerd.grpc.v1.cri".registry.headers]
+[plugins.'io.containerd.cri.v1.images'.registry.headers]
 X-Meta-Source-Client = ["azure/aks"]
 
 [metrics]


### PR DESCRIPTION
## Problem

`download.go` rejects containerd `<2.0.0`:

```go
if containerdVersion.Major < 2 {
    return nil, status.Errorf(codes.InvalidArgument, "containerd version %q is not supported, minimum required version is 2.0.0", ...)
}
```

But the rendered config templates use the **v1 plugin schema** (`[plugins.\"io.containerd.grpc.v1.cri\"]`). containerd v2 silently ignores unknown plugin paths and falls back to its internal defaults — so user-supplied `CNIBinDir`, `SandboxImage`, `RuncBinaryPath`, runtime classes, registry config, etc. all get **dropped on the floor**.

The most visible symptom: `bin_dir` ends up empty, so any CNI plugin lookup fails (`failed to find plugin in path []`) and pods are stuck in `ContainerCreating`.

```
$ containerd config dump | grep -A2 cri.v1.runtime.cni
[plugins.'io.containerd.cri.v1.runtime'.cni]
  bin_dir = ''           # <-- should be /opt/cni/bin
  conf_dir = '/etc/cni/net.d'
```

## Fix

Move both templates to the containerd v2 schema:
- `version = 3`
- `[plugins.'io.containerd.cri.v1.runtime']` for sandbox / cni / runtimes
- `[plugins.'io.containerd.cri.v1.images']` for registry config

No other behavior change — same template variables, same rendered values, same untrusted runtime + AKS registry header preserved.

## Validation

Verified end-to-end on a 16× H200 (2× ND96isr_H200_v5 nodes) joined to an AKS-flex cluster via `aks-flex-node v0.0.18`:
- `containerd config dump` shows correct `bin_dir`, `conf_dir`, `sandbox_image`, runc path
- gpu-operator pulls all images
- `nvidia-cuda-validator` Completes
- DRA `ResourceSlice`s published (`gpu.nvidia.com`, `compute-domain.nvidia.com`)

`go test ./...` passes.