### PR TITLE
ci: add explicit permissions to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Fix for release creation failure caused by the release job lacking an explicit permissions block: 

<img width="761" height="238" alt="image" src="https://github.com/user-attachments/assets/42b8ea38-0a17-4c10-b937-895e338ec943" />
