### PR TITLE
node: preserve configured kubelet node IP

### DIFF
--- a/pkg/daemon/kubelet_defaults.go
+++ b/pkg/daemon/kubelet_defaults.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"path/filepath"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+	"github.com/Azure/AKSFlexNode/pkg/utils/utilio"
+	"github.com/Azure/unbounded/pkg/agent/phases"
+)
+
+const kubeletDefaultsPath = "etc/default/kubelet"
+
+type configureKubeletDefaultsTask struct {
+	cfg        config.KubeletConfig
+	machineDir string
+}
+
+func ConfigureKubeletDefaults(cfg *config.Config, machineDir string) phases.Task {
+	return &configureKubeletDefaultsTask{
+		cfg:        cfg.Node.Kubelet,
+		machineDir: machineDir,
+	}
+}
+
+func (t *configureKubeletDefaultsTask) Name() string { return "configure-kubelet-defaults" }
+
+func (t *configureKubeletDefaultsTask) Do(context.Context) error {
+	content, err := renderKubeletDefaults(t.cfg)
+	if err != nil {
+		return err
+	}
+	if len(content) == 0 {
+		return nil
+	}
+
+	path := filepath.Join(t.machineDir, kubeletDefaultsPath)
+	if err := utilio.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("writing kubelet defaults: %w", err)
+	}
+	return nil
+}
+
+func renderKubeletDefaults(cfg config.KubeletConfig) ([]byte, error) {
+	if cfg.NodeIP == "" {
+		return nil, nil
+	}
+	addr, err := netip.ParseAddr(cfg.NodeIP)
+	if err != nil {
+		return nil, fmt.Errorf("node.kubelet.nodeIP %q is not a valid IP address: %w", cfg.NodeIP, err)
+	}
+
+	return []byte(fmt.Sprintf(
+		"# Managed by aks-flex-node. Do not edit directly.\nKUBELET_EXTRA_ARGS=--node-ip=%s\n",
+		addr.String(),
+	)), nil
+}

--- a/pkg/daemon/kubelet_defaults.go
+++ b/pkg/daemon/kubelet_defaults.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
+	"os"
 	"path/filepath"
 
 	"github.com/Azure/AKSFlexNode/pkg/config"
@@ -11,13 +14,17 @@ import (
 	"github.com/Azure/unbounded/pkg/agent/phases"
 )
 
-const kubeletDefaultsPath = "etc/default/kubelet"
+const (
+	kubeletDefaultsPath   = "etc/default/kubelet"
+	kubeletDefaultsHeader = "# Managed by aks-flex-node. Do not edit directly.\n"
+)
 
 type configureKubeletDefaultsTask struct {
 	cfg        config.KubeletConfig
 	machineDir string
 }
 
+// ConfigureKubeletDefaults writes the environment file consumed by unbounded's kubelet unit.
 func ConfigureKubeletDefaults(cfg *config.Config, machineDir string) phases.Task {
 	return &configureKubeletDefaultsTask{
 		cfg:        cfg.Node.Kubelet,
@@ -28,16 +35,16 @@ func ConfigureKubeletDefaults(cfg *config.Config, machineDir string) phases.Task
 func (t *configureKubeletDefaultsTask) Name() string { return "configure-kubelet-defaults" }
 
 func (t *configureKubeletDefaultsTask) Do(context.Context) error {
+	path := filepath.Join(t.machineDir, kubeletDefaultsPath)
 	content, err := renderKubeletDefaults(t.cfg)
 	if err != nil {
 		return err
 	}
 	if len(content) == 0 {
-		return nil
+		return removeManagedKubeletDefaults(path)
 	}
 
-	path := filepath.Join(t.machineDir, kubeletDefaultsPath)
-	if err := utilio.WriteFile(path, content, 0o644); err != nil {
+	if err := utilio.WriteFile(path, content, 0o644); err != nil { //nolint:gosec // kubelet defaults contain no secrets and follow /etc/default readability
 		return fmt.Errorf("writing kubelet defaults: %w", err)
 	}
 	return nil
@@ -53,7 +60,24 @@ func renderKubeletDefaults(cfg config.KubeletConfig) ([]byte, error) {
 	}
 
 	return []byte(fmt.Sprintf(
-		"# Managed by aks-flex-node. Do not edit directly.\nKUBELET_EXTRA_ARGS=--node-ip=%s\n",
+		kubeletDefaultsHeader+"KUBELET_EXTRA_ARGS=--node-ip=%s\n",
 		addr.String(),
 	)), nil
+}
+
+func removeManagedKubeletDefaults(path string) error {
+	existing, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec // path is constructed under the machine rootfs
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading kubelet defaults: %w", err)
+	}
+	if !bytes.HasPrefix(existing, []byte(kubeletDefaultsHeader)) {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing kubelet defaults: %w", err)
+	}
+	return nil
 }

--- a/pkg/daemon/kubelet_defaults_test.go
+++ b/pkg/daemon/kubelet_defaults_test.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+func TestConfigureKubeletDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg          config.KubeletConfig
+		wantFile     bool
+		wantContains []string
+		wantErr      string
+	}{
+		"empty node ip skips file": {
+			cfg: config.KubeletConfig{},
+		},
+		"writes ipv4 node ip": {
+			cfg:      config.KubeletConfig{NodeIP: "10.247.1.4"},
+			wantFile: true,
+			wantContains: []string{
+				"# Managed by aks-flex-node. Do not edit directly.",
+				"KUBELET_EXTRA_ARGS=--node-ip=10.247.1.4",
+			},
+		},
+		"normalizes ipv6 node ip": {
+			cfg:      config.KubeletConfig{NodeIP: "2001:db8:0:0:0:0:0:1"},
+			wantFile: true,
+			wantContains: []string{
+				"KUBELET_EXTRA_ARGS=--node-ip=2001:db8::1",
+			},
+		},
+		"rejects invalid node ip": {
+			cfg:     config.KubeletConfig{NodeIP: "eth0; rm -rf /"},
+			wantErr: "node.kubelet.nodeIP",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			machineDir := t.TempDir()
+			task := (&configureKubeletDefaultsTask{
+				cfg:        tt.cfg,
+				machineDir: machineDir,
+			})
+			if task.Name() != "configure-kubelet-defaults" {
+				t.Fatalf("Name() = %q, want configure-kubelet-defaults", task.Name())
+			}
+
+			err := task.Do(t.Context())
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Do() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Do(): %v", err)
+			}
+
+			path := filepath.Join(machineDir, kubeletDefaultsPath)
+			got, err := os.ReadFile(path)
+			if !tt.wantFile {
+				if !os.IsNotExist(err) {
+					t.Fatalf("ReadFile(%s) error = %v, want not exist", path, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadFile(%s): %v", path, err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(string(got), want) {
+					t.Fatalf("defaults file = %q, want containing %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/daemon/kubelet_defaults_test.go
+++ b/pkg/daemon/kubelet_defaults_test.go
@@ -13,28 +13,34 @@ func TestConfigureKubeletDefaults(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		cfg          config.KubeletConfig
-		wantFile     bool
-		wantContains []string
-		wantErr      string
+		cfg         config.KubeletConfig
+		preContent  string
+		wantContent string
+		wantFile    bool
+		wantErr     string
 	}{
 		"empty node ip skips file": {
 			cfg: config.KubeletConfig{},
 		},
+		"empty node ip removes managed file": {
+			cfg:        config.KubeletConfig{},
+			preContent: kubeletDefaultsHeader + "KUBELET_EXTRA_ARGS=--node-ip=10.247.1.4\n",
+		},
+		"empty node ip preserves unmanaged file": {
+			cfg:         config.KubeletConfig{},
+			preContent:  "KUBELET_EXTRA_ARGS=--v=2\n",
+			wantFile:    true,
+			wantContent: "KUBELET_EXTRA_ARGS=--v=2\n",
+		},
 		"writes ipv4 node ip": {
-			cfg:      config.KubeletConfig{NodeIP: "10.247.1.4"},
-			wantFile: true,
-			wantContains: []string{
-				"# Managed by aks-flex-node. Do not edit directly.",
-				"KUBELET_EXTRA_ARGS=--node-ip=10.247.1.4",
-			},
+			cfg:         config.KubeletConfig{NodeIP: "10.247.1.4"},
+			wantFile:    true,
+			wantContent: kubeletDefaultsHeader + "KUBELET_EXTRA_ARGS=--node-ip=10.247.1.4\n",
 		},
 		"normalizes ipv6 node ip": {
-			cfg:      config.KubeletConfig{NodeIP: "2001:db8:0:0:0:0:0:1"},
-			wantFile: true,
-			wantContains: []string{
-				"KUBELET_EXTRA_ARGS=--node-ip=2001:db8::1",
-			},
+			cfg:         config.KubeletConfig{NodeIP: "2001:db8:0:0:0:0:0:1"},
+			wantFile:    true,
+			wantContent: kubeletDefaultsHeader + "KUBELET_EXTRA_ARGS=--node-ip=2001:db8::1\n",
 		},
 		"rejects invalid node ip": {
 			cfg:     config.KubeletConfig{NodeIP: "eth0; rm -rf /"},
@@ -47,6 +53,16 @@ func TestConfigureKubeletDefaults(t *testing.T) {
 			t.Parallel()
 
 			machineDir := t.TempDir()
+			path := filepath.Join(machineDir, kubeletDefaultsPath)
+			if tt.preContent != "" {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				if err := os.WriteFile(path, []byte(tt.preContent), 0o644); err != nil {
+					t.Fatalf("WriteFile(%s): %v", path, err)
+				}
+			}
+
 			task := (&configureKubeletDefaultsTask{
 				cfg:        tt.cfg,
 				machineDir: machineDir,
@@ -66,7 +82,6 @@ func TestConfigureKubeletDefaults(t *testing.T) {
 				t.Fatalf("Do(): %v", err)
 			}
 
-			path := filepath.Join(machineDir, kubeletDefaultsPath)
 			got, err := os.ReadFile(path)
 			if !tt.wantFile {
 				if !os.IsNotExist(err) {
@@ -77,10 +92,8 @@ func TestConfigureKubeletDefaults(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadFile(%s): %v", path, err)
 			}
-			for _, want := range tt.wantContains {
-				if !strings.Contains(string(got), want) {
-					t.Fatalf("defaults file = %q, want containing %q", got, want)
-				}
+			if string(got) != tt.wantContent {
+				t.Fatalf("defaults file = %q, want %q", got, tt.wantContent)
 			}
 		})
 	}

--- a/pkg/daemon/start.go
+++ b/pkg/daemon/start.go
@@ -42,6 +42,7 @@ func StartNode(
 			npd.Download(cfg, gs.RootFS.MachineDir),
 			InstallBinary(gs.RootFS.MachineDir),
 			cni.WriteCNIConfig(gs.RootFS.MachineDir),
+			ConfigureKubeletDefaults(cfg, gs.RootFS.MachineDir),
 		),
 		nodestart.StartNode(log, gs.NodeStart),
 		nodestart.WaitForKubelet(log, machineName),


### PR DESCRIPTION
## What

Preserve `node.kubelet.nodeIP` during node startup by writing `/etc/default/kubelet` inside the nspawn rootfs when a node IP is configured. The generated defaults file sets `KUBELET_EXTRA_ARGS=--node-ip=<ip>`, which unbounded's kubelet unit already consumes via its existing environment file.

If `node.kubelet.nodeIP` is later unset, the task removes the aks-flex-node-managed defaults file so stale `--node-ip` values do not persist. Unmanaged `/etc/default/kubelet` files are left untouched.

## Why

Multihomed provider hosts need kubelet to register with the provider NIC IP rather than relying on kubelet's default interface selection. This keeps node identity explicit for hosts where non-provider interfaces, such as IB/storage networks, have overlapping or more attractive addresses.

## Non-goals

- Does not include the hostrouting/static-route work from #159.
- Does not change unbounded's config schema or kubelet templates.
- Does not choose or discover the provider NIC IP; callers must continue setting `node.kubelet.nodeIP`.

## Testing

- `git diff --check`
- `go test ./pkg/daemon ./pkg/cmd/start`
- `make build`
- `make lint`
- Azure PR checks passed: build, test, lint, code quality, dependency review, security scan, gosec, CLA, and `E2E Tests - nodes join / E2E Tests (MSI + Token)`.

## Risk

Low when `node.kubelet.nodeIP` is unset and no managed defaults file exists because the task is a no-op. When it is set, invalid values fail before writing kubelet defaults; rollback is to unset `node.kubelet.nodeIP` or revert this change.