### PR TITLE
docs: add GPU node setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AKS Flex Node transforms any Ubuntu VM into a semi-managed AKS worker node by:
 ## Documentation
 
 - **[Usage Guide](docs/usage.md)** - Installation, configuration, and usage instructions
-- **[GPU Flex Node Setup](docs/usages/gpu-node-setup.md)** - PM-facing GPU node setup flow, image contract, validation, and troubleshooting
+- **[GPU Flex Node Setup](docs/usages/gpu-node-setup.md)** - GPU node setup flow, image contract, validation, and troubleshooting
 - **[Design Documentation](docs/design.md)** - System design, data flow, Azure integration, and technical specifications
 - **[Development Guide](docs/development.md)** - Building from source, testing, and contributing
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ AKS Flex Node transforms any Ubuntu VM into a semi-managed AKS worker node by:
 ## Documentation
 
 - **[Usage Guide](docs/usage.md)** - Installation, configuration, and usage instructions
+- **[GPU Flex Node Setup](docs/usages/gpu-node-setup.md)** - PM-facing GPU node setup flow, image contract, validation, and troubleshooting
 - **[Design Documentation](docs/design.md)** - System design, data flow, Azure integration, and technical specifications
 - **[Development Guide](docs/development.md)** - Building from source, testing, and contributing
 

--- a/docs/examples/bootstrap-token-config.json
+++ b/docs/examples/bootstrap-token-config.json
@@ -1,0 +1,26 @@
+{
+  "azure": {
+    "subscriptionId": "${SUBSCRIPTION_ID}",
+    "tenantId": "${TENANT_ID}",
+    "cloud": "AzurePublicCloud",
+    "bootstrapToken": {
+      "token": "${BOOTSTRAP_TOKEN}"
+    },
+    "arc": { "enabled": false },
+    "targetCluster": {
+      "resourceId": "${AKS_RESOURCE_ID}",
+      "location": "${LOCATION}"
+    }
+  },
+  "node": {
+    "kubelet": {
+      "serverURL": "${SERVER_URL}",
+      "caCertData": "${CA_CERT_DATA}"
+    }
+  },
+  "agent": {
+    "logLevel": "info",
+    "logDir": "/var/log/aks-flex-node"
+  },
+  "kubernetes": { "version": "${KUBERNETES_VERSION}" }
+}

--- a/docs/examples/bootstrap-token-rbac.yaml
+++ b/docs/examples/bootstrap-token-rbac.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bootstrap-token-${TOKEN_ID}
+  namespace: kube-system
+type: bootstrap.kubernetes.io/token
+stringData:
+  description: "AKS Flex Node bootstrap token"
+  token-id: "${TOKEN_ID}"
+  token-secret: "${TOKEN_SECRET}"
+  expiration: "${EXPIRATION}"
+  usage-bootstrap-authentication: "true"
+  usage-bootstrap-signing: "true"
+  auth-extra-groups: "system:bootstrappers:aks-flex-node"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-auto-approve-csr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,6 +6,8 @@ This guide provides three complete setup paths for AKS Flex Node:
 2. **[Setup with Service Principal](#setup-with-service-principal)** - More scalable for secure production environment
 3. **[Setup with Bootstrap Token](#setup-with-bootstrap-token)** - Simplest setup with minimum dependancy for dynamic hyperscale environments
 
+For GPU-capable hosts, see the **[GPU Flex Node setup](usages/gpu-node-setup.md)** guide. It explains the driver and image contract, cluster GPU components, validation commands, and troubleshooting.
+
 ## Comparison: Arc vs Service Principal vs Bootstrap Token
 
 Use this comparison to choose the deployment path that best fits your requirements:

--- a/docs/usages/gpu-node-setup.md
+++ b/docs/usages/gpu-node-setup.md
@@ -49,20 +49,35 @@ The NVIDIA driver is the main contract to get right.
 
 AKS Flex Node assumes the host can already load the GPU kernel driver and expose NVIDIA devices. In current Flex GPU validation, this is achieved by choosing a GPU-capable DSVM/HPC image that already includes the driver stack for the target GPU family.
 
-Valid image options include:
+### Why an image with the driver preinstalled is easier
 
-1. **GPU-capable DSVM/HPC image.** Use a marketplace image such as an Ubuntu HPC or data science VM image that is built for GPU workloads, then validate the driver on first boot.
-2. **AKS managed GPU-capable image or image ID.** Use a validated AKS managed GPU image where the driver is provided by AKS managed GPU bootstrap. Confirm the image ID, OS, kernel, containerd version, and driver version before using it for Flex Nodes.
-3. **Custom or prebaked image.** Install and bake the NVIDIA driver yourself before running AKS Flex Node, then validate the image with the exact GPU SKU.
-4. **Other GPU-capable marketplace image.** Select another image only after validating that it provides the required driver, kernel modules, container runtime support, and GPU devices.
+Choose an image that already has the NVIDIA driver baked in whenever possible. It removes the most error-prone step from GPU node setup:
+
+- **No first-boot driver build.** The kernel module is already signed and matched to the kernel in the image. There is no DKMS step that can fail on a fresh boot and leave the node unusable.
+- **Deterministic driver version.** The driver version is part of the image, so every node from the same image reports the same `nvidia.com/gpu.driver.*` labels. Drift between nodes is much easier to spot.
+- **Faster node ready time.** Bootstrap does not have to install kernel headers, fetch or compile the driver, or reboot before kubelet starts. The node reaches `Ready` in minutes instead of tens of minutes.
+- **Smaller blast radius for AKS Flex Node.** AKS Flex Node only has to install AKS worker components. If the GPU never works, the failure points to the image, not to AKS Flex Node bootstrap.
+- **Air-gapped and restricted networks are tractable.** A prebaked image does not need outbound access to NVIDIA, kernel mirrors, or driver package repositories at first boot.
+- **Consistent toolkit compatibility.** When the driver is pinned, NVIDIA Container Toolkit and GPU Operator validation reduces to a single matrix entry per image, not a per-node compatibility check.
+
+If the image does not include the driver, you must own and operate driver installation: build matching kernel modules, sign them for Secure Boot if applicable, rebuild on every kernel update, and validate `nvidia-smi` before considering the node usable.
+
+### Image option categories
+
+Valid image option categories include:
+
+1. **GPU-capable Ubuntu HPC / DSVM marketplace image.** The current Flex GPU validation uses `microsoft-dsvm/ubuntu-hpc/2204/latest`, which ships with an NVIDIA driver stack suitable for the validated GPU host SKUs. Other SKUs and versions under the same `microsoft-dsvm/ubuntu-hpc` offer are candidate alternatives to validate per region and per GPU family.
+2. **AKS managed GPU-capable image or image ID.** If you can use an AKS managed GPU image (for example, an image referenced from an existing AKS GPU node pool such as the AzureLinux V3 GPU image series), the driver is provided by the AKS managed GPU bootstrap path rather than baked into a marketplace image. This is only an alternative when you can resolve and consume the AKS managed image ID and reproduce the AKS GPU bootstrap contract on the Flex host. Do not treat it as a generally supported standalone option.
+3. **Custom or prebaked image.** Bake the NVIDIA driver (and Fabric Manager when required by the GPU SKU), nvidia-container-toolkit or equivalent runtime integration, and any required kernel modules. Validate the image on the target GPU SKU before running AKS Flex Node. This is the most portable productizable fallback because you own the contract.
+4. **Other GPU-capable marketplace or partner images.** Marketplace images such as NVIDIA-published CUDA images or partner Ubuntu GPU images may work, but treat them as candidates to validate rather than supported images. Confirm driver version, kernel module signatures, container runtime integration, and Secure Boot posture before adoption.
 
 Do not rely on AKS Flex Node to repair a missing or incompatible GPU driver after bootstrap.
 
 ## Example image options
 
-Use placeholders in automation and pin images for repeatable validation. Avoid depending on `latest` for production rollouts unless the rollout process records and validates the resolved image version.
+These are concrete examples for the categories above. Pin images for repeatable validation. Avoid depending on `latest` for production rollouts unless the rollout process records and validates the resolved image version.
 
-### DSVM/HPC marketplace image
+### Current Flex GPU validation image (Ubuntu HPC 22.04)
 
 ```yaml
 imageReference:
@@ -73,7 +88,37 @@ imageReference:
 securityType: Standard
 ```
 
-This pattern is useful when the image already contains the expected NVIDIA driver stack for the GPU host SKU. Validate the resolved image version before broad rollout.
+This is the image used for current Flex H100/H200 validation. It contains an NVIDIA driver stack appropriate for the validated GPU host SKUs. Validate the resolved image version (`az vm image show`) before broad rollout, and pin the version when stable.
+
+### Other Ubuntu HPC SKUs and versions to validate
+
+The `microsoft-dsvm/ubuntu-hpc` offer publishes multiple SKUs and versions. Availability and content vary by region and by GPU family.
+
+```bash
+# List candidate Ubuntu HPC SKUs in your region.
+az vm image list-skus \
+  --publisher microsoft-dsvm \
+  --offer ubuntu-hpc \
+  --location <region> \
+  --output table
+
+# List versions for a specific SKU, then pin one for validation.
+az vm image list \
+  --publisher microsoft-dsvm \
+  --offer ubuntu-hpc \
+  --sku "2204" \
+  --location <region> \
+  --all \
+  --output table
+```
+
+Examples to evaluate as candidates (availability and GPU family coverage vary by region):
+
+- `microsoft-dsvm/ubuntu-hpc/2204` — Ubuntu 22.04 HPC, baseline for current Flex H100/H200 validation.
+- `microsoft-dsvm/ubuntu-hpc/2404` — Ubuntu 24.04 HPC, candidate for newer kernels. Validate driver version and AKS Flex Node compatibility before use.
+- `microsoft-dsvm/ubuntu-hpc/2404-gb` — Ubuntu 24.04 HPC variant aligned with Grace/Blackwell-class hosts. This is **not** the current Flex H100/H200 path; treat it as a separate validation effort for GB-class hardware.
+
+Always confirm the resolved driver version inside the image (for example, `nvidia-smi` on a one-shot VM built from it) before adding the image to a node class used by AKS Flex Node.
 
 ### AKS managed image ID
 
@@ -83,13 +128,41 @@ imageID: /subscriptions/<subscription-id>/resourceGroups/<image-resource-group>/
 
 Use this when a specific AKS managed GPU-capable image has been validated for the target GPU family. Record the resolved node image label, OS image, kernel, containerd version, and NVIDIA driver version.
 
+As a reference shape, AKS managed A100 node pools currently use AzureLinux V3 GPU images. The image reference looks like:
+
+```text
+# Shape only; resolve the current ID from your AKS GPU node pool.
+/subscriptions/<subscription-id>/resourceGroups/AKS-AzureLinux/providers/Microsoft.Compute/galleries/AKSAzureLinux/images/V3gen2/versions/<image-version>
+
+# Node image label exposed by AKS, for example:
+AKSAzureLinux-V3gen2-<image-version>
+```
+
+Reusing this kind of image with AKS Flex Node is only meaningful if you can resolve and consume the image ID and reproduce the AKS GPU bootstrap contract on a Flex host. In AKS managed GPU node pools the driver is delivered through the managed GPU bootstrap path (with `ClusterPolicy.spec.driver.enabled=false` on the GPU Operator), not as a baked-in marketplace driver. Do not treat this as a generally supported standalone option for AKS Flex Node.
+
 ### Custom or prebaked image
 
 ```yaml
 imageID: /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/galleries/<gallery>/images/<custom-gpu-image>/versions/<version>
 ```
 
-Use this when you own driver installation and image hardening. The image should be tested before AKS Flex Node bootstrap.
+Use this when you own driver installation and image hardening. A productizable prebaked image generally includes:
+
+- NVIDIA driver matched to the kernel in the image.
+- Fabric Manager when required by the GPU SKU (for example, multi-GPU SXM systems).
+- nvidia-container-toolkit (or an equivalent runtime integration) compatible with the GPU Operator and DRA versions used in the cluster.
+- Kernel module signatures if Secure Boot is in scope.
+
+Validate the image on the exact GPU SKU (`nvidia-smi`, `nvidia-smi -L`, `lsmod | grep nvidia`, container runtime smoke test) before AKS Flex Node bootstrap.
+
+### Other GPU-capable marketplace or partner images
+
+Other GPU-capable marketplace images (for example, NVIDIA-published CUDA-on-Ubuntu images or partner GPU images) may also work as the host image. Treat them as candidates to validate, not as supported images, until they have passed the same driver, runtime, and Flex Node bootstrap checks as the images above. Confirm:
+
+- Driver and CUDA versions against the workloads you plan to run.
+- Container runtime integration with GPU Operator and DRA.
+- Secure Boot signing posture, if applicable.
+- Whether the image expects outbound network access for first-boot driver setup.
 
 ## Cluster GPU components
 

--- a/docs/usages/gpu-node-setup.md
+++ b/docs/usages/gpu-node-setup.md
@@ -67,9 +67,10 @@ If the image does not include the driver, you must own and operate driver instal
 Valid image option categories include:
 
 1. **GPU-capable Ubuntu HPC / DSVM marketplace image.** The current Flex GPU validation uses `microsoft-dsvm/ubuntu-hpc/2204/latest`, which ships with an NVIDIA driver stack suitable for the validated GPU host SKUs. Other SKUs and versions under the same `microsoft-dsvm/ubuntu-hpc` offer are candidate alternatives to validate per region and per GPU family.
-2. **AKS managed GPU-capable image or image ID.** If you can use an AKS managed GPU image (for example, an image referenced from an existing AKS GPU node pool such as the AzureLinux V3 GPU image series), the driver is provided by the AKS managed GPU bootstrap path rather than baked into a marketplace image. This is only an alternative when you can resolve and consume the AKS managed image ID and reproduce the AKS GPU bootstrap contract on the Flex host. Do not treat it as a generally supported standalone option.
-3. **Custom or prebaked image.** Bake the NVIDIA driver (and Fabric Manager when required by the GPU SKU), nvidia-container-toolkit or equivalent runtime integration, and any required kernel modules. Validate the image on the target GPU SKU before running AKS Flex Node. This is the most portable productizable fallback because you own the contract.
-4. **Other GPU-capable marketplace or partner images.** Marketplace images such as NVIDIA-published CUDA images or partner Ubuntu GPU images may work, but treat them as candidates to validate rather than supported images. Confirm driver version, kernel module signatures, container runtime integration, and Secure Boot posture before adoption.
+2. **Custom or prebaked image.** Bake the NVIDIA driver (and Fabric Manager when required by the GPU SKU), nvidia-container-toolkit or equivalent runtime integration, and any required kernel modules. Validate the image on the target GPU SKU before running AKS Flex Node. This is the most portable productizable fallback because you own the contract.
+3. **Other GPU-capable marketplace or partner images.** Marketplace images such as NVIDIA-published CUDA images or partner Ubuntu GPU images may work, but treat them as candidates to validate rather than supported images. Confirm driver version, kernel module signatures, container runtime integration, and Secure Boot posture before adoption.
+
+> **Note:** AKS managed GPU node pools are not a host-image option for AKS Flex Node. Those node pools install the NVIDIA driver at node boot through the AKS managed GPU bootstrap path; the marketplace/AKS image itself is not a baked GPU image you can hand to AKS Flex Node. Pick a baked image (Ubuntu HPC or your own prebake) or a partner image you have validated.
 
 Do not rely on AKS Flex Node to repair a missing or incompatible GPU driver after bootstrap.
 
@@ -119,26 +120,6 @@ Examples to evaluate as candidates (availability and GPU family coverage vary by
 - `microsoft-dsvm/ubuntu-hpc/2404-gb` — Ubuntu 24.04 HPC variant aligned with Grace/Blackwell-class hosts. This is **not** the current Flex H100/H200 path; treat it as a separate validation effort for GB-class hardware.
 
 Always confirm the resolved driver version inside the image (for example, `nvidia-smi` on a one-shot VM built from it) before adding the image to a node class used by AKS Flex Node.
-
-### AKS managed image ID
-
-```yaml
-imageID: /subscriptions/<subscription-id>/resourceGroups/<image-resource-group>/providers/Microsoft.Compute/galleries/<gallery>/images/<image-name>/versions/<image-version>
-```
-
-Use this when a specific AKS managed GPU-capable image has been validated for the target GPU family. Record the resolved node image label, OS image, kernel, containerd version, and NVIDIA driver version.
-
-As a reference shape, AKS managed A100 node pools currently use AzureLinux V3 GPU images. The image reference looks like:
-
-```text
-# Shape only; resolve the current ID from your AKS GPU node pool.
-/subscriptions/<subscription-id>/resourceGroups/AKS-AzureLinux/providers/Microsoft.Compute/galleries/AKSAzureLinux/images/V3gen2/versions/<image-version>
-
-# Node image label exposed by AKS, for example:
-AKSAzureLinux-V3gen2-<image-version>
-```
-
-Reusing this kind of image with AKS Flex Node is only meaningful if you can resolve and consume the image ID and reproduce the AKS GPU bootstrap contract on a Flex host. In AKS managed GPU node pools the driver is delivered through the managed GPU bootstrap path (with `ClusterPolicy.spec.driver.enabled=false` on the GPU Operator), not as a baked-in marketplace driver. Do not treat this as a generally supported standalone option for AKS Flex Node.
 
 ### Custom or prebaked image
 

--- a/docs/usages/gpu-node-setup.md
+++ b/docs/usages/gpu-node-setup.md
@@ -1,0 +1,244 @@
+# GPU Flex Node setup
+
+This guide explains the general flow for adding GPU-capable AKS Flex Nodes to an AKS cluster.
+
+> **Status:** GPU Flex Node support is under active validation. Use a validated image and confirm the driver, container runtime, and GPU device labels before scheduling production workloads.
+
+## Overview
+
+AKS Flex Node turns a prepared host into an AKS worker node. For GPU hosts, the extra requirement is that the host must already have a working NVIDIA kernel driver before AKS Flex Node bootstraps Kubernetes components.
+
+The high-level flow is:
+
+1. Choose a GPU-capable host image or prebaked image.
+2. Install or verify the NVIDIA host driver on that image.
+3. Install AKS Flex Node and join the host to the AKS cluster.
+4. Install cluster GPU components such as NVIDIA GPU Operator, GPU Feature Discovery, and NVIDIA DRA driver.
+5. Validate that the node is `Ready`, reports the expected GPU labels, and can run a GPU workload.
+
+Expected result: the Flex Node appears in `kubectl get nodes` as `Ready`, has NVIDIA GPU labels from GPU Feature Discovery, and can run pods that request GPU resources through the configured GPU scheduling path.
+
+## Before you begin
+
+You need:
+
+- An AKS cluster with admin access through `kubectl`.
+- One or more GPU-capable hosts or virtual machines.
+- A GPU host image that matches the hardware SKU.
+- Root access on the target host.
+- Outbound network access from the host to the AKS API server and required package and container registries.
+- A cluster GPU add-on plan, such as NVIDIA GPU Operator plus NVIDIA DRA driver.
+
+> **Important:** AKS Flex Node does not install the NVIDIA kernel driver. The GPU host driver must already be available before AKS Flex Node bootstraps the host.
+
+## What this flow does
+
+The setup flow separates host preparation from cluster GPU scheduling:
+
+| Layer | Responsibility |
+| --- | --- |
+| Host image | Provides the operating system, kernel, and NVIDIA kernel driver. |
+| AKS Flex Node | Installs and configures the AKS worker-node components, including kubelet and containerd. |
+| GPU Operator components | Configure cluster GPU discovery and runtime integration. In this flow, they do not install the host driver when driver installation is disabled. |
+| NVIDIA DRA driver | Exposes GPUs through Kubernetes Dynamic Resource Allocation when DRA is used. |
+| GPU Feature Discovery | Adds labels such as GPU product, driver version, and GPU count to nodes. |
+
+## Driver and image contract
+
+The NVIDIA driver is the main contract to get right.
+
+AKS Flex Node assumes the host can already load the GPU kernel driver and expose NVIDIA devices. In current Flex GPU validation, this is achieved by choosing a GPU-capable DSVM/HPC image that already includes the driver stack for the target GPU family.
+
+Valid image options include:
+
+1. **GPU-capable DSVM/HPC image.** Use a marketplace image such as an Ubuntu HPC or data science VM image that is built for GPU workloads, then validate the driver on first boot.
+2. **AKS managed GPU-capable image or image ID.** Use a validated AKS managed GPU image where the driver is provided by AKS managed GPU bootstrap. Confirm the image ID, OS, kernel, containerd version, and driver version before using it for Flex Nodes.
+3. **Custom or prebaked image.** Install and bake the NVIDIA driver yourself before running AKS Flex Node, then validate the image with the exact GPU SKU.
+4. **Other GPU-capable marketplace image.** Select another image only after validating that it provides the required driver, kernel modules, container runtime support, and GPU devices.
+
+Do not rely on AKS Flex Node to repair a missing or incompatible GPU driver after bootstrap.
+
+## Example image options
+
+Use placeholders in automation and pin images for repeatable validation. Avoid depending on `latest` for production rollouts unless the rollout process records and validates the resolved image version.
+
+### DSVM/HPC marketplace image
+
+```yaml
+imageReference:
+  publisher: microsoft-dsvm
+  offer: ubuntu-hpc
+  sku: "2204"
+  version: latest
+securityType: Standard
+```
+
+This pattern is useful when the image already contains the expected NVIDIA driver stack for the GPU host SKU. Validate the resolved image version before broad rollout.
+
+### AKS managed image ID
+
+```yaml
+imageID: /subscriptions/<subscription-id>/resourceGroups/<image-resource-group>/providers/Microsoft.Compute/galleries/<gallery>/images/<image-name>/versions/<image-version>
+```
+
+Use this when a specific AKS managed GPU-capable image has been validated for the target GPU family. Record the resolved node image label, OS image, kernel, containerd version, and NVIDIA driver version.
+
+### Custom or prebaked image
+
+```yaml
+imageID: /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/galleries/<gallery>/images/<custom-gpu-image>/versions/<version>
+```
+
+Use this when you own driver installation and image hardening. The image should be tested before AKS Flex Node bootstrap.
+
+## Cluster GPU components
+
+Install the cluster GPU components after the host image contract is clear.
+
+Common components are:
+
+- **NVIDIA GPU Operator:** manages GPU-related Kubernetes components. If `ClusterPolicy.spec.driver.enabled=false`, it does not install the host NVIDIA kernel driver.
+- **NVIDIA Container Toolkit:** configures container runtime integration so GPU devices can be passed to containers.
+- **GPU Feature Discovery (GFD):** labels GPU nodes with product, driver, runtime, and GPU count details.
+- **NVIDIA DRA driver:** exposes GPU devices through Kubernetes Dynamic Resource Allocation. DRA `DeviceClass` objects commonly include names such as `gpu.nvidia.com` and `mig.nvidia.com`.
+
+> **Note:** DRA and legacy extended resources are different scheduling paths. In DRA-based clusters, a node can have GPU labels and DRA devices even when legacy `nvidia.com/gpu` node capacity is `0`. Validate the resource path your workloads use instead of assuming legacy capacity will be populated.
+
+## Example Flex node configuration
+
+The exact API shape depends on the provisioning layer used with AKS Flex Node. The example below shows the important GPU fields to capture in a Karpenter-style node class and node pool. Replace names, SKUs, image values, and labels with values from your environment.
+
+```yaml
+apiVersion: karpenter.azure.com/v1alpha2
+kind: AzureFlexNodeClass
+metadata:
+  name: gpu-flex-h100
+spec:
+  imageReference:
+    publisher: microsoft-dsvm
+    offer: ubuntu-hpc
+    sku: "2204"
+    version: latest
+  securityType: Standard
+  osDiskSizeGB: 256
+  tags:
+    workload: gpu
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: gpu-flex
+spec:
+  template:
+    metadata:
+      labels:
+        aks-flex-node.azure.com/gpu: "true"
+    spec:
+      nodeClassRef:
+        group: karpenter.azure.com
+        kind: AzureFlexNodeClass
+        name: gpu-flex-h100
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: karpenter.azure.com/sku
+          operator: In
+          values: ["<gpu-vm-size>"]
+```
+
+If you use a pinned image ID instead of marketplace image fields, replace `imageReference` with the validated `imageID`.
+
+## Validation
+
+Run these checks after the host joins the cluster.
+
+### Confirm the Flex Node is ready
+
+```bash
+kubectl get nodes -l aks-flex-node.azure.com/gpu=true -o wide
+```
+
+Example output:
+
+```text
+NAME                  STATUS   ROLES    AGE   VERSION   INTERNAL-IP   OS-IMAGE              KERNEL-VERSION       CONTAINER-RUNTIME
+gpu-flex-node-000001  Ready    <none>   18m   v1.34.x   10.0.0.10     Ubuntu 22.04.5 LTS    5.15.0-xxxx-azure    containerd://2.0.x
+```
+
+### Confirm GPU labels
+
+```bash
+kubectl get node <gpu-flex-node-name> --show-labels \
+  | tr ',' '\n' \
+  | grep -E 'nvidia.com/gpu|feature.node.kubernetes.io'
+```
+
+Useful labels include:
+
+```text
+nvidia.com/gpu.count=8
+nvidia.com/gpu.driver.major=580
+nvidia.com/gpu.driver.minor=126
+nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3
+feature.node.kubernetes.io/system-os_release.ID=ubuntu
+```
+
+Label names and values vary by GPU model, driver version, and GFD version. Use them as validation signals, not as a hardcoded contract.
+
+### Confirm GPU Operator behavior
+
+```bash
+kubectl get clusterpolicy -o yaml | grep -A3 'driver:'
+```
+
+If the policy shows `enabled: false` under `spec.driver`, the GPU Operator is not installing the host NVIDIA driver. That is expected for flows where the driver comes from the image.
+
+### Confirm DRA resources when using DRA
+
+```bash
+kubectl get deviceclasses
+kubectl get resourceclaims -A
+kubectl get pods -A | grep -E 'nvidia|dra|gpu'
+```
+
+Example `DeviceClass` names:
+
+```text
+gpu.nvidia.com
+mig.nvidia.com
+```
+
+If your workloads use DRA, validate that the workload creates and binds the expected `ResourceClaim`. If your workloads use legacy GPU requests, validate legacy `nvidia.com/gpu` capacity separately.
+
+### Validate on the host
+
+On the target host, confirm the driver and runtime before blaming Kubernetes scheduling:
+
+```bash
+nvidia-smi
+lsmod | grep nvidia
+systemctl is-active containerd
+journalctl -u aks-flex-node-agent --no-pager -n 100
+```
+
+Expected result: `nvidia-smi` can see the GPUs, NVIDIA kernel modules are loaded, containerd is active, and the AKS Flex Node agent has no bootstrap errors.
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| Node is not `Ready` | Check `journalctl -u aks-flex-node-agent`, kubelet logs, outbound connectivity to the AKS API server, and bootstrap credentials. |
+| Node is `Ready` but has no GPU labels | Confirm GFD is installed and running, then verify `nvidia-smi` and loaded NVIDIA kernel modules on the host. |
+| GPU Operator reports driver errors | Confirm whether `spec.driver.enabled` is intended to be `false`. If driver installation is disabled, fix the host image instead of expecting the operator to install the driver. |
+| Legacy `nvidia.com/gpu` capacity is `0` | Check whether the cluster uses DRA. DRA devices can be available even when legacy extended resource capacity is not populated. |
+| Workload remains pending | Compare the workload's GPU request style with the cluster setup: DRA `ResourceClaim` and `DeviceClass` vs legacy `resources.limits["nvidia.com/gpu"]`. |
+| Driver version differs across nodes | Confirm the image ID or resolved marketplace image version used for each node class. Pin images when repeatability matters. |
+
+## Caveats
+
+- AKS Flex Node does not install the NVIDIA kernel driver.
+- GPU Operator driver installation may be disabled by design. Do not describe the operator as the driver installer unless `spec.driver.enabled=true` and that path has been validated.
+- Image, driver, kernel, and containerd versions are part of the GPU node contract. Record them with every validation run.
+- Do not hardcode validation cluster names in runbooks or automation. Use placeholders such as `<cluster-name>`, `<resource-group>`, and `<gpu-flex-node-name>`.
+- Current validated Flex GPU nodes may not use newer host routing fields or other experimental CRD paths. Document those paths only when the live CRs actually use them.

--- a/docs/usages/gpu-node-setup.md
+++ b/docs/usages/gpu-node-setup.md
@@ -1,173 +1,205 @@
 # GPU Flex Node setup
 
-This guide explains the general flow for adding GPU-capable AKS Flex Nodes to an AKS cluster.
+How to add a GPU host to an AKS cluster as an AKS Flex Node.
 
-> **Status:** GPU Flex Node support is under active validation. Use a validated image and confirm the driver, container runtime, and GPU device labels before scheduling production workloads.
+> **Status:** GPU Flex Node support is under active validation.
 
 ## Overview
 
-AKS Flex Node turns a prepared host into an AKS worker node. For GPU hosts, the extra requirement is that the host must already have a working NVIDIA kernel driver before AKS Flex Node bootstraps Kubernetes components.
+AKS Flex Node joins a prepared host to an AKS cluster. For GPU hosts there are two extra responsibilities that AKS Flex Node does **not** take on:
 
-The high-level flow is:
+1. The host must already have a working **NVIDIA kernel driver** before bootstrap.
+2. After the node joins, you must **manually install the cluster GPU stack** (GPU Operator, container toolkit, GPU Feature Discovery).
 
-1. Choose a GPU-capable host image or prebaked image.
-2. Install or verify the NVIDIA host driver on that image.
-3. Install AKS Flex Node and join the host to the AKS cluster.
-4. Install cluster GPU components such as NVIDIA GPU Operator, GPU Feature Discovery, and NVIDIA DRA driver.
-5. Validate that the node is `Ready`, reports the expected GPU labels, and can run a GPU workload.
-
-Expected result: the Flex Node appears in `kubectl get nodes` as `Ready`, has NVIDIA GPU labels from GPU Feature Discovery, and can run pods that request GPU resources through the configured GPU scheduling path.
+Plan for both before you start.
 
 ## Before you begin
 
-You need:
-
-- An AKS cluster with admin access through `kubectl`.
-- One or more GPU-capable hosts or virtual machines.
-- A GPU host image that matches the hardware SKU.
-- Root access on the target host.
-- Outbound network access from the host to the AKS API server and required package and container registries.
-- A cluster GPU add-on plan, such as NVIDIA GPU Operator plus NVIDIA DRA driver.
-
-> **Important:** AKS Flex Node does not install the NVIDIA kernel driver. The GPU host driver must already be available before AKS Flex Node bootstraps the host.
-
-## What this flow does
-
-The setup flow separates host preparation from cluster GPU scheduling:
-
-| Layer | Responsibility |
-| --- | --- |
-| Host image | Provides the operating system, kernel, and NVIDIA kernel driver. |
-| AKS Flex Node | Installs and configures the AKS worker-node components, including kubelet and containerd. |
-| GPU Operator components | Configure cluster GPU discovery and runtime integration. In this flow, they do not install the host driver when driver installation is disabled. |
-| NVIDIA DRA driver | Exposes GPUs through Kubernetes Dynamic Resource Allocation when DRA is used. |
-| GPU Feature Discovery | Adds labels such as GPU product, driver version, and GPU count to nodes. |
+- An AKS cluster with `kubectl` admin access.
+- A GPU host with root access and outbound reach to the AKS API server.
+- A GPU host image that already includes the NVIDIA driver.
+- Helm installed on your workstation to install the cluster GPU stack.
+- Optional: a Karpenter provider that can provision AKS Flex Node hosts.
 
 ## Driver and image contract
 
-The NVIDIA driver is the main contract to get right.
+AKS Flex Node does **not** install the NVIDIA kernel driver. Pick an image where the driver is already baked in. The benefits:
 
-AKS Flex Node assumes the host can already load the GPU kernel driver and expose NVIDIA devices. In current Flex GPU validation, this is achieved by choosing a GPU-capable DSVM/HPC image that already includes the driver stack for the target GPU family.
+- No first-boot driver build or DKMS failure.
+- Deterministic driver version across nodes.
+- Faster `Ready` time; no kernel-headers/reboot dance.
+- Works in restricted networks.
+- Failures point at the image, not at Flex Node bootstrap.
 
-### Why an image with the driver preinstalled is easier
+If the image has no driver, you own driver installation, signing for Secure Boot, and kernel-update rebuilds.
 
-Choose an image that already has the NVIDIA driver baked in whenever possible. It removes the most error-prone step from GPU node setup:
+### Image options
 
-- **No first-boot driver build.** The kernel module is already signed and matched to the kernel in the image. There is no DKMS step that can fail on a fresh boot and leave the node unusable.
-- **Deterministic driver version.** The driver version is part of the image, so every node from the same image reports the same `nvidia.com/gpu.driver.*` labels. Drift between nodes is much easier to spot.
-- **Faster node ready time.** Bootstrap does not have to install kernel headers, fetch or compile the driver, or reboot before kubelet starts. The node reaches `Ready` in minutes instead of tens of minutes.
-- **Smaller blast radius for AKS Flex Node.** AKS Flex Node only has to install AKS worker components. If the GPU never works, the failure points to the image, not to AKS Flex Node bootstrap.
-- **Air-gapped and restricted networks are tractable.** A prebaked image does not need outbound access to NVIDIA, kernel mirrors, or driver package repositories at first boot.
-- **Consistent toolkit compatibility.** When the driver is pinned, NVIDIA Container Toolkit and GPU Operator validation reduces to a single matrix entry per image, not a per-node compatibility check.
+1. **Ubuntu HPC marketplace image (current validation).** `microsoft-dsvm/ubuntu-hpc/2204/latest`. Other SKUs/versions in the same offer are candidates to validate per region and GPU family:
+   - `microsoft-dsvm/ubuntu-hpc/2204` — baseline for current Flex H100/H200 validation.
+   - `microsoft-dsvm/ubuntu-hpc/2404` — newer kernel; validate before use.
+   - `microsoft-dsvm/ubuntu-hpc/2404-gb` — Grace/Blackwell variant; **not** the current Flex H100/H200 path.
+2. **Custom prebaked image.** Bake the NVIDIA driver, Fabric Manager (multi-GPU SXM), nvidia-container-toolkit, and any required signed kernel modules. Most portable fallback because you own the contract.
+3. **Other GPU marketplace or partner images.** Treat as candidates to validate.
 
-If the image does not include the driver, you must own and operate driver installation: build matching kernel modules, sign them for Secure Boot if applicable, rebuild on every kernel update, and validate `nvidia-smi` before considering the node usable.
+> **Note:** AKS managed GPU node pools are not a host-image option. They install the driver at boot through the AKS managed GPU bootstrap path, so the image itself is not baked with the driver and cannot be reused as-is by AKS Flex Node.
 
-### Image option categories
-
-Valid image option categories include:
-
-1. **GPU-capable Ubuntu HPC / DSVM marketplace image.** The current Flex GPU validation uses `microsoft-dsvm/ubuntu-hpc/2204/latest`, which ships with an NVIDIA driver stack suitable for the validated GPU host SKUs. Other SKUs and versions under the same `microsoft-dsvm/ubuntu-hpc` offer are candidate alternatives to validate per region and per GPU family.
-2. **Custom or prebaked image.** Bake the NVIDIA driver (and Fabric Manager when required by the GPU SKU), nvidia-container-toolkit or equivalent runtime integration, and any required kernel modules. Validate the image on the target GPU SKU before running AKS Flex Node. This is the most portable productizable fallback because you own the contract.
-3. **Other GPU-capable marketplace or partner images.** Marketplace images such as NVIDIA-published CUDA images or partner Ubuntu GPU images may work, but treat them as candidates to validate rather than supported images. Confirm driver version, kernel module signatures, container runtime integration, and Secure Boot posture before adoption.
-
-> **Note:** AKS managed GPU node pools are not a host-image option for AKS Flex Node. Those node pools install the NVIDIA driver at node boot through the AKS managed GPU bootstrap path; the marketplace/AKS image itself is not a baked GPU image you can hand to AKS Flex Node. Pick a baked image (Ubuntu HPC or your own prebake) or a partner image you have validated.
-
-Do not rely on AKS Flex Node to repair a missing or incompatible GPU driver after bootstrap.
-
-## Example image options
-
-These are concrete examples for the categories above. Pin images for repeatable validation. Avoid depending on `latest` for production rollouts unless the rollout process records and validates the resolved image version.
-
-### Current Flex GPU validation image (Ubuntu HPC 22.04)
-
-```yaml
-imageReference:
-  publisher: microsoft-dsvm
-  offer: ubuntu-hpc
-  sku: "2204"
-  version: latest
-securityType: Standard
-```
-
-This is the image used for current Flex H100/H200 validation. It contains an NVIDIA driver stack appropriate for the validated GPU host SKUs. Validate the resolved image version (`az vm image show`) before broad rollout, and pin the version when stable.
-
-### Other Ubuntu HPC SKUs and versions to validate
-
-The `microsoft-dsvm/ubuntu-hpc` offer publishes multiple SKUs and versions. Availability and content vary by region and by GPU family.
+List and pin candidate Ubuntu HPC versions:
 
 ```bash
-# List candidate Ubuntu HPC SKUs in your region.
-az vm image list-skus \
-  --publisher microsoft-dsvm \
-  --offer ubuntu-hpc \
-  --location <region> \
-  --output table
-
-# List versions for a specific SKU, then pin one for validation.
-az vm image list \
-  --publisher microsoft-dsvm \
-  --offer ubuntu-hpc \
-  --sku "2204" \
-  --location <region> \
-  --all \
-  --output table
+az vm image list-skus --publisher microsoft-dsvm --offer ubuntu-hpc --location <region> --output table
+az vm image list --publisher microsoft-dsvm --offer ubuntu-hpc --sku "2204" --location <region> --all --output table
 ```
 
-Examples to evaluate as candidates (availability and GPU family coverage vary by region):
+## Cluster GPU stack (manual)
 
-- `microsoft-dsvm/ubuntu-hpc/2204` — Ubuntu 22.04 HPC, baseline for current Flex H100/H200 validation.
-- `microsoft-dsvm/ubuntu-hpc/2404` — Ubuntu 24.04 HPC, candidate for newer kernels. Validate driver version and AKS Flex Node compatibility before use.
-- `microsoft-dsvm/ubuntu-hpc/2404-gb` — Ubuntu 24.04 HPC variant aligned with Grace/Blackwell-class hosts. This is **not** the current Flex H100/H200 path; treat it as a separate validation effort for GB-class hardware.
+After the Flex node is `Ready`, **you must install the cluster GPU stack yourself**. AKS Flex Node does not deploy any of this. Install at least:
 
-Always confirm the resolved driver version inside the image (for example, `nvidia-smi` on a one-shot VM built from it) before adding the image to a node class used by AKS Flex Node.
+- **NVIDIA GPU Operator** — manages cluster GPU components. Set `driver.enabled=false` because the driver comes from the host image.
+- **NVIDIA Container Toolkit** — wires GPU devices into the container runtime.
+- **GPU Feature Discovery (GFD)** — labels nodes with GPU product, driver, and count.
 
-### Custom or prebaked image
+Example Helm install with the driver disabled:
 
-```yaml
-imageID: /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/galleries/<gallery>/images/<custom-gpu-image>/versions/<version>
+```bash
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
+helm install --create-namespace -n gpu-operator gpu-operator nvidia/gpu-operator \
+  --set driver.enabled=false \
+  --set toolkit.enabled=true \
+  --set gfd.enabled=true
 ```
 
-Use this when you own driver installation and image hardening. A productizable prebaked image generally includes:
+Confirm the operator picked up the host driver and is not trying to install one:
 
-- NVIDIA driver matched to the kernel in the image.
-- Fabric Manager when required by the GPU SKU (for example, multi-GPU SXM systems).
-- nvidia-container-toolkit (or an equivalent runtime integration) compatible with the GPU Operator and DRA versions used in the cluster.
-- Kernel module signatures if Secure Boot is in scope.
+```bash
+kubectl -n gpu-operator get pods
+kubectl get clusterpolicy -o jsonpath='{.items[0].spec.driver.enabled}'  # expect: false
+```
 
-Validate the image on the exact GPU SKU (`nvidia-smi`, `nvidia-smi -L`, `lsmod | grep nvidia`, container runtime smoke test) before AKS Flex Node bootstrap.
+If you skip this step, the node will be `Ready` but pods will not get GPUs.
 
-### Other GPU-capable marketplace or partner images
+> **Optional:** NVIDIA DRA driver exposes GPUs through Kubernetes Dynamic Resource Allocation (`DeviceClass` names such as `gpu.nvidia.com`, `mig.nvidia.com`). In DRA clusters, a node can have GPU labels and DRA devices even when legacy `nvidia.com/gpu` capacity is `0`. Install only if your workloads use DRA.
 
-Other GPU-capable marketplace images (for example, NVIDIA-published CUDA-on-Ubuntu images or partner GPU images) may also work as the host image. Treat them as candidates to validate, not as supported images, until they have passed the same driver, runtime, and Flex Node bootstrap checks as the images above. Confirm:
+## Provisioning paths
 
-- Driver and CUDA versions against the workloads you plan to run.
-- Container runtime integration with GPU Operator and DRA.
-- Secure Boot signing posture, if applicable.
-- Whether the image expects outbound network access for first-boot driver setup.
+There are two common ways to reach the same host state:
 
-## Cluster GPU components
+1. **Direct host bootstrap.** You create the GPU VM or bare metal host yourself, install or select the GPU-capable image, then run AKS Flex Node bootstrap on that host.
+2. **Karpenter-managed provisioning.** Karpenter creates the GPU VM from a Flex node class and node pool, renders the AKS Flex Node user data, and lets `aks-flex-node` join the VM to the AKS cluster.
 
-Install the cluster GPU components after the host image contract is clear.
+The current GPU validation flow uses the Karpenter-managed path. The Karpenter resources still rely on the same driver contract: the selected image must already provide a working NVIDIA driver before AKS Flex Node runs.
 
-Common components are:
+## Direct host bootstrap
 
-- **NVIDIA GPU Operator:** manages GPU-related Kubernetes components. If `ClusterPolicy.spec.driver.enabled=false`, it does not install the host NVIDIA kernel driver.
-- **NVIDIA Container Toolkit:** configures container runtime integration so GPU devices can be passed to containers.
-- **GPU Feature Discovery (GFD):** labels GPU nodes with product, driver, runtime, and GPU count details.
-- **NVIDIA DRA driver:** exposes GPU devices through Kubernetes Dynamic Resource Allocation. DRA `DeviceClass` objects commonly include names such as `gpu.nvidia.com` and `mig.nvidia.com`.
+Use direct host bootstrap when you manage the GPU host lifecycle outside Karpenter. This path is useful for a single validation VM, a manually provisioned bare metal host, or an environment where another system owns VM creation.
 
-> **Note:** DRA and legacy extended resources are different scheduling paths. In DRA-based clusters, a node can have GPU labels and DRA devices even when legacy `nvidia.com/gpu` node capacity is `0`. Validate the resource path your workloads use instead of assuming legacy capacity will be populated.
+### 1. Provision a GPU-capable host
 
-## Example Flex node configuration
+Create the VM or prepare the bare metal host with:
 
-The exact API shape depends on the provisioning layer used with AKS Flex Node. The example below shows the important GPU fields to capture in a Karpenter-style node class and node pool. Replace names, SKUs, image values, and labels with values from your environment.
+- Ubuntu 22.04 or 24.04.
+- Outbound HTTPS reachability to the AKS API server.
+- A GPU-capable image or prebaked custom image with the NVIDIA driver already installed.
+- Any host-specific networking required to reach the AKS VNet, overlay, or gateway.
+
+Before running AKS Flex Node, confirm the host driver works:
+
+```bash
+nvidia-smi
+lsmod | grep nvidia
+```
+
+If these fail, fix the image or driver installation first. AKS Flex Node bootstrap should not be the first component to discover a missing or mismatched driver.
+
+### 2. Prepare AKS bootstrap credentials
+
+On your workstation, create a bootstrap token and RBAC bindings with the shared bootstrap-token example. This is the same setup used by the general node-joining flow; the GPU-specific requirement is that the target host image already has a working NVIDIA driver.
+
+```bash
+RESOURCE_GROUP="<aks-resource-group>"
+CLUSTER_NAME="<aks-cluster-name>"
+
+az aks get-credentials \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --admin \
+  --overwrite-existing
+
+TOKEN_ID="$(openssl rand -hex 3 | tr '[:upper:]' '[:lower:]')"
+TOKEN_SECRET="$(openssl rand -hex 8 | tr '[:upper:]' '[:lower:]')"
+BOOTSTRAP_TOKEN="${TOKEN_ID}.${TOKEN_SECRET}"
+EXPIRATION="$(date -u -d "+24 hours" +"%Y-%m-%dT%H:%M:%SZ")"
+
+curl -fsSL https://raw.githubusercontent.com/Azure/AKSFlexNode/main/docs/examples/bootstrap-token-rbac.yaml \
+  | envsubst \
+  | kubectl apply -f -
+```
+
+Collect the values the host config needs:
+
+```bash
+TENANT_ID=$(az account show --query tenantId -o tsv)
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+AKS_RESOURCE_ID=$(az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --query id -o tsv)
+LOCATION=$(az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --query location -o tsv)
+KUBERNETES_VERSION=$(az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --query kubernetesVersion -o tsv)
+SERVER_URL=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+CA_CERT_DATA=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+```
+
+Copy those values, plus `BOOTSTRAP_TOKEN`, to a root shell on the GPU host.
+
+### 3. Install AKS Flex Node on the host
+
+```bash
+sudo su
+curl -fsSL https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/install.sh | bash
+aks-flex-node version
+```
+
+### 4. Write the host config
+
+Render the shared bootstrap-token config example instead of hand-writing the JSON:
+
+```bash
+mkdir -p /etc/aks-flex-node
+curl -fsSL https://raw.githubusercontent.com/Azure/AKSFlexNode/main/docs/examples/bootstrap-token-config.json \
+  | envsubst \
+  > /etc/aks-flex-node/config.json
+
+cat /etc/aks-flex-node/config.json
+```
+
+### 5. Bootstrap and watch the node
+
+```bash
+aks-flex-node start --config /etc/aks-flex-node/config.json
+journalctl -u aks-flex-node-agent -f
+```
+
+From your workstation:
+
+```bash
+kubectl get nodes -o wide
+kubectl describe node <gpu-flex-node-name>
+```
+
+After the node is `Ready`, install the cluster GPU stack from the previous section if it is not already installed. The host driver is local to the node; GPU Operator, GFD, toolkit, and DRA are cluster components.
+
+## Example Karpenter resources
+
+Karpenter-style shape; replace SKU, image, region, networking, and labels.
 
 ```yaml
-apiVersion: karpenter.azure.com/v1alpha2
+apiVersion: flex.aks.azure.com/v1alpha1
 kind: AzureFlexNodeClass
 metadata:
   name: gpu-flex-h100
 spec:
+  subscriptionID: "<subscription-id>"
+  location: "<region>"
+  resourceGroup: "<flex-node-resource-group>"
+  subnetID: "<subnet-resource-id>"
   imageReference:
     publisher: microsoft-dsvm
     offer: ubuntu-hpc
@@ -175,8 +207,8 @@ spec:
     version: latest
   securityType: Standard
   osDiskSizeGB: 256
-  tags:
-    workload: gpu
+  allocateNodePublicIP: false
+  maxPodsPerNode: 110
 ---
 apiVersion: karpenter.sh/v1
 kind: NodePool
@@ -189,110 +221,51 @@ spec:
         aks-flex-node.azure.com/gpu: "true"
     spec:
       nodeClassRef:
-        group: karpenter.azure.com
+        group: flex.aks.azure.com
         kind: AzureFlexNodeClass
         name: gpu-flex-h100
       requirements:
-        - key: kubernetes.io/arch
-          operator: In
-          values: ["amd64"]
-        - key: karpenter.azure.com/sku
+        - key: node.kubernetes.io/instance-type
           operator: In
           values: ["<gpu-vm-size>"]
+      taints:
+        - key: nvidia.com/gpu
+          effect: NoSchedule
+  limits:
+    nvidia.com/gpu: "8"
 ```
 
-If you use a pinned image ID instead of marketplace image fields, replace `imageReference` with the validated `imageID`.
+After applying the node class and node pool, deploy a workload that matches the node pool requirements. Karpenter provisions the GPU VM, and the rendered user data runs AKS Flex Node bootstrap on the host.
 
 ## Validation
 
-Run these checks after the host joins the cluster.
-
-### Confirm the Flex Node is ready
-
 ```bash
+# Node Ready
 kubectl get nodes -l aks-flex-node.azure.com/gpu=true -o wide
-```
 
-Example output:
+# GPU labels (populated by GFD)
+kubectl get node <gpu-flex-node-name> --show-labels | tr ',' '\n' | grep nvidia.com/gpu
 
-```text
-NAME                  STATUS   ROLES    AGE   VERSION   INTERNAL-IP   OS-IMAGE              KERNEL-VERSION       CONTAINER-RUNTIME
-gpu-flex-node-000001  Ready    <none>   18m   v1.34.x   10.0.0.10     Ubuntu 22.04.5 LTS    5.15.0-xxxx-azure    containerd://2.0.x
-```
-
-### Confirm GPU labels
-
-```bash
-kubectl get node <gpu-flex-node-name> --show-labels \
-  | tr ',' '\n' \
-  | grep -E 'nvidia.com/gpu|feature.node.kubernetes.io'
-```
-
-Useful labels include:
-
-```text
-nvidia.com/gpu.count=8
-nvidia.com/gpu.driver.major=580
-nvidia.com/gpu.driver.minor=126
-nvidia.com/gpu.product=NVIDIA-H100-80GB-HBM3
-feature.node.kubernetes.io/system-os_release.ID=ubuntu
-```
-
-Label names and values vary by GPU model, driver version, and GFD version. Use them as validation signals, not as a hardcoded contract.
-
-### Confirm GPU Operator behavior
-
-```bash
-kubectl get clusterpolicy -o yaml | grep -A3 'driver:'
-```
-
-If the policy shows `enabled: false` under `spec.driver`, the GPU Operator is not installing the host NVIDIA driver. That is expected for flows where the driver comes from the image.
-
-### Confirm DRA resources when using DRA
-
-```bash
-kubectl get deviceclasses
-kubectl get resourceclaims -A
-kubectl get pods -A | grep -E 'nvidia|dra|gpu'
-```
-
-Example `DeviceClass` names:
-
-```text
-gpu.nvidia.com
-mig.nvidia.com
-```
-
-If your workloads use DRA, validate that the workload creates and binds the expected `ResourceClaim`. If your workloads use legacy GPU requests, validate legacy `nvidia.com/gpu` capacity separately.
-
-### Validate on the host
-
-On the target host, confirm the driver and runtime before blaming Kubernetes scheduling:
-
-```bash
+# Host driver and runtime
 nvidia-smi
 lsmod | grep nvidia
-systemctl is-active containerd
-journalctl -u aks-flex-node-agent --no-pager -n 100
+systemctl is-active containerd aks-flex-node-agent
 ```
 
-Expected result: `nvidia-smi` can see the GPUs, NVIDIA kernel modules are loaded, containerd is active, and the AKS Flex Node agent has no bootstrap errors.
+Expect: node `Ready`, `nvidia.com/gpu.product` and `nvidia.com/gpu.count` labels present, `nvidia-smi` lists the GPUs, agent and containerd active.
 
 ## Troubleshooting
 
-| Symptom | What to check |
+| Symptom | Check |
 | --- | --- |
-| Node is not `Ready` | Check `journalctl -u aks-flex-node-agent`, kubelet logs, outbound connectivity to the AKS API server, and bootstrap credentials. |
-| Node is `Ready` but has no GPU labels | Confirm GFD is installed and running, then verify `nvidia-smi` and loaded NVIDIA kernel modules on the host. |
-| GPU Operator reports driver errors | Confirm whether `spec.driver.enabled` is intended to be `false`. If driver installation is disabled, fix the host image instead of expecting the operator to install the driver. |
-| Legacy `nvidia.com/gpu` capacity is `0` | Check whether the cluster uses DRA. DRA devices can be available even when legacy extended resource capacity is not populated. |
-| Workload remains pending | Compare the workload's GPU request style with the cluster setup: DRA `ResourceClaim` and `DeviceClass` vs legacy `resources.limits["nvidia.com/gpu"]`. |
-| Driver version differs across nodes | Confirm the image ID or resolved marketplace image version used for each node class. Pin images when repeatability matters. |
+| Node not `Ready` | `journalctl -u aks-flex-node-agent`, API-server reachability, bootstrap creds. |
+| Node `Ready`, no GPU labels | GPU Operator and GFD installed? `nvidia-smi` works on host? |
+| GPU Operator complains about driver | Should be `driver.enabled=false`. Fix the image, not the operator. |
+| Pods pending for GPU | Workload uses DRA but DRA driver isn't installed, or uses legacy `nvidia.com/gpu` but cluster is DRA-only. Match request style to install. |
+| Driver version drift | Pin the image version. |
 
 ## Caveats
 
 - AKS Flex Node does not install the NVIDIA kernel driver.
-- GPU Operator driver installation may be disabled by design. Do not describe the operator as the driver installer unless `spec.driver.enabled=true` and that path has been validated.
-- Image, driver, kernel, and containerd versions are part of the GPU node contract. Record them with every validation run.
-- Do not hardcode validation cluster names in runbooks or automation. Use placeholders such as `<cluster-name>`, `<resource-group>`, and `<gpu-flex-node-name>`.
-- Current validated Flex GPU nodes may not use newer host routing fields or other experimental CRD paths. Document those paths only when the live CRs actually use them.
+- AKS Flex Node does not install GPU Operator, nvidia-container-toolkit, GFD, or DRA. These are manual.
+- Image + driver + kernel + containerd versions are part of the GPU node contract. Record them per validation run.


### PR DESCRIPTION
## What

Adds a GPU Flex Node setup guide under `docs/usages/` and links it from the README and usage guide.

The guide covers the GPU setup flow, image options, cluster GPU components, direct-host bootstrap using shared bootstrap-token examples, Karpenter-managed provisioning, validation commands, and troubleshooting.

## Why

GPU Flex Node setup has an important host-driver contract that needs to be easy to explain to readers: AKS Flex Node does not install the NVIDIA kernel driver. The GPU host driver must already be available before AKS Flex Node bootstraps the host. In current Flex GPU validation, that is handled by selecting a GPU-capable DSVM/HPC image; other valid paths are a validated AKS managed GPU-capable image/image ID, a prebaked custom image, or another GPU-capable marketplace/custom image that has been validated.

## Non-goals

- Does not change AKS Flex Node runtime behavior or provisioning logic.
- Does not claim GPU Operator installs the host driver in the validated flow.
- Does not document hostRouting or other CRD paths as active for current Flex H100/H200 validation.
- Does not hardcode validation cluster names.

## Testing

- `git diff --check`
- Relative markdown link check for changed markdown files
- JSON/YAML syntax check for bootstrap-token examples
- Guarded changed docs for over-specific validation cluster names and unsupported hostRouting/aksFlexNode claims
- `make test` was attempted and failed in existing `pkg/config` tests because this workstation hostname (`Kevins-MacBook-Pro.local`) is rejected as an invalid Kubernetes DNS subdomain by node-name validation. This is unrelated to the docs-only changes.

## Risk

Documentation-only. The main risk is inaccurate setup guidance; the guide explicitly calls out the NVIDIA driver caveat and separates DRA, GPU Operator, GFD, and legacy GPU capacity behavior to avoid overstating the validated flow.




