### PR TITLE
Normalize default node name casing

### DIFF
--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -97,6 +97,11 @@ The suite validates three join paths:
 | `vm-e2e-token-*` | Bootstrap Token | Kubernetes bootstrap token, RBAC, generated config, and `aks-flex-node start` flow. |
 | `vm-e2e-kubeadm-*` | Bootstrap Token | Kubeadm-style bootstrap resources plus generated config and `aks-flex-node start` flow. |
 
+The bootstrap-token VM is provisioned with an uppercase guest OS hostname while
+its Azure resource name remains lowercase. This verifies that an omitted
+`agent.nodeName` is derived from the normalized hostname and still joins the
+cluster under the lowercase VM name.
+
 Each join path uploads the locally built binary, renders a config file, installs the binary through `scripts/install.sh` with `AKS_FLEX_NODE_LOCAL_BINARY`, and starts the node through a transient systemd unit. The installed agent service is then validated with systemd checks.
 
 ## Repave Validation

--- a/hack/e2e/infra/main.bicep
+++ b/hack/e2e/infra/main.bicep
@@ -160,6 +160,8 @@ module vmToken 'modules/vm.bicep' = {
   params: {
     location: location
     vmName: tokenVmName
+    // Use uppercase guest hostname to validate default node name normalization.
+    computerName: toUpper(tokenVmName)
     vmSize: vmSize
     adminUsername: adminUsername
     sshPublicKey: sshPublicKey

--- a/hack/e2e/infra/modules/vm.bicep
+++ b/hack/e2e/infra/modules/vm.bicep
@@ -11,6 +11,9 @@ param location string
 @description('VM name (also used as prefix for NIC and public IP names).')
 param vmName string
 
+@description('Guest OS hostname. Defaults to vmName.')
+param computerName string = vmName
+
 @description('VM size.')
 param vmSize string
 
@@ -95,7 +98,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
   properties: {
     hardwareProfile: { vmSize: vmSize }
     osProfile: {
-      computerName: vmName
+      computerName: computerName
       adminUsername: adminUsername
       linuxConfiguration: {
         disablePasswordAuthentication: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,7 +234,7 @@ func (cfg AzureConfig) ResourceManagerTokenScope() (string, error) {
 
 // resolveNodeName resolves the Kubernetes Node name once and stores it on the
 // config so bootstrap, daemon watches, and lifecycle operations use one value.
-func (cfg *Config) resolveNodeName() (string, error) {
+func (cfg *Config) resolveNodeName(hostnameFunc func() (string, error)) (string, error) {
 	if nodeName := strings.TrimSpace(cfg.Agent.NodeName); nodeName != "" {
 		if err := validateNodeName(nodeName); err != nil {
 			return "", err
@@ -242,16 +242,16 @@ func (cfg *Config) resolveNodeName() (string, error) {
 		cfg.Agent.NodeName = nodeName
 		return nodeName, nil
 	}
-	hostname, err := os.Hostname()
+	hostname, err := hostnameFunc()
 	if err != nil {
 		return "", fmt.Errorf("get host hostname for node name: %w", err)
 	}
-	hostname = strings.TrimSpace(hostname)
+	hostname = strings.ToLower(strings.TrimSpace(hostname))
 	if hostname == "" {
 		return "", fmt.Errorf("host hostname is empty")
 	}
 	if err := validateNodeName(hostname); err != nil {
-		return "", fmt.Errorf("host hostname: %w", err)
+		return "", fmt.Errorf("host hostname: %w; set agent.nodeName to a valid lowercase Kubernetes node name", err)
 	}
 	cfg.Agent.NodeName = hostname
 	return hostname, nil
@@ -550,7 +550,7 @@ var validMachineOperationModes = map[string]bool{
 func (c *Config) validate() error {
 	c.setDefaults()
 
-	if _, err := c.resolveNodeName(); err != nil {
+	if _, err := c.resolveNodeName(os.Hostname); err != nil {
 		return fmt.Errorf("resolve node name: %w", err)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,7 +87,7 @@ func TestSetDefaults(t *testing.T) {
 
 func TestResolveNodeName(t *testing.T) {
 	cfg := &Config{}
-	got, err := cfg.resolveNodeName()
+	got, err := cfg.resolveNodeName(os.Hostname)
 	if err != nil {
 		t.Fatalf("resolveNodeName: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestResolveNodeName(t *testing.T) {
 	}
 
 	cfg.Agent.NodeName = "custom-node"
-	got, err = cfg.resolveNodeName()
+	got, err = cfg.resolveNodeName(os.Hostname)
 	if err != nil {
 		t.Fatalf("resolveNodeName with existing node name: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestResolveNodeName(t *testing.T) {
 	}
 
 	cfg.Agent.NodeName = "  custom-node-2  "
-	got, err = cfg.resolveNodeName()
+	got, err = cfg.resolveNodeName(os.Hostname)
 	if err != nil {
 		t.Fatalf("resolveNodeName with spaced node name: %v", err)
 	}
@@ -119,8 +119,27 @@ func TestResolveNodeName(t *testing.T) {
 
 func TestResolveNodeNameRejectsInvalidConfiguredName(t *testing.T) {
 	cfg := &Config{Agent: AgentConfig{NodeName: "Invalid_Node"}}
-	if _, err := cfg.resolveNodeName(); err == nil || !strings.Contains(err.Error(), "valid Kubernetes DNS subdomain") {
+	if _, err := cfg.resolveNodeName(os.Hostname); err == nil || !strings.Contains(err.Error(), "valid Kubernetes DNS subdomain") {
 		t.Fatalf("resolveNodeName error = %v, want DNS subdomain error", err)
+	}
+}
+
+func TestResolveNodeNameLowercasesHostname(t *testing.T) {
+	cfg := &Config{}
+	got, err := cfg.resolveNodeName(func() (string, error) { return "  PHost01  ", nil })
+	if err != nil {
+		t.Fatalf("resolveNodeName: %v", err)
+	}
+	if got != "phost01" || cfg.Agent.NodeName != "phost01" {
+		t.Fatalf("resolved node name=%q cfg=%q, want phost01", got, cfg.Agent.NodeName)
+	}
+}
+
+func TestResolveNodeNameRejectsInvalidHostnameWithSuggestion(t *testing.T) {
+	cfg := &Config{}
+	_, err := cfg.resolveNodeName(func() (string, error) { return "Invalid_Node", nil })
+	if err == nil || !strings.Contains(err.Error(), "set agent.nodeName") {
+		t.Fatalf("resolveNodeName error = %v, want agent.nodeName suggestion", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #184.

## Summary
- Lowercase the host hostname when deriving the default Kubernetes node name.
- Keep explicit `agent.nodeName` validation strict.
- Add unit tests for uppercase hostnames and invalid hostname guidance.
- Extend e2e infra so the bootstrap-token VM uses an uppercase guest hostname while joining under its lowercase VM name.

## Testing
- `go test ./pkg/config`
- `az bicep build --file hack/e2e/infra/main.bicep --stdout`
