### PR TITLE
Align FlexNode config with RP bootstrap data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ E2E_RESOURCE_GROUP=rg-aksflexnode-e2e-tests
 # Azure region for E2E test resources
 E2E_LOCATION=westus2
 
+# Target AKS agent pool name written to E2E node configs
+E2E_TARGET_AGENT_POOL_NAME=aksflexnodes
+
 # ============================================================================
 # Required: Runner VM Configuration
 # ============================================================================

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ On your workstation, save the config helper script, setup node RBAC permissions,
 RESOURCE_GROUP="<resource-group>"
 CLUSTER_NAME="<cluster-name>"
 SUBSCRIPTION_ID="<subscription-id>"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
 curl -fsSLo ./aks-flex-config https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/aks-flex-config
 chmod +x ./aks-flex-config
@@ -49,6 +50,7 @@ chmod +x ./aks-flex-config
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```
@@ -65,7 +67,8 @@ The rendered config should look like this. Comments are shown here only to expla
   "azure": {
     "subscriptionId": "<subscription-id>", // Azure subscription that owns the AKS cluster.
     "tenantId": "<tenant-id>", // Microsoft Entra tenant for the subscription.
-    "cloud": "AzurePublicCloud", // Azure cloud environment.
+    "resourceManagerEndpoint": "https://management.azure.com", // Azure Resource Manager endpoint for ARM calls.
+    "targetAgentPoolName": "<agent-pool-name>", // AKS agent pool used for FlexNode machine registration.
     "bootstrapToken": {
       "token": "<token-id>.<token-secret>" // Kubernetes bootstrap token created by generate-node-config.
     },

--- a/docs/labs/aks-private-cluster-cilium.md
+++ b/docs/labs/aks-private-cluster-cilium.md
@@ -134,6 +134,7 @@ AKS_REGION="<aks-region>"
 VM_REGION="<vm-region>"
 AKS_VNET="<aks-vnet-name>"
 FLEX_VNET="<flex-vnet-name>"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
 az account set --subscription "$SUBSCRIPTION_ID"
 
@@ -340,6 +341,7 @@ chmod +x ./aks-flex-config
   --resource-group "$AKS_RG" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```

--- a/docs/labs/aks-private-cluster-unbounded-net.md
+++ b/docs/labs/aks-private-cluster-unbounded-net.md
@@ -142,6 +142,7 @@ AKS_REGION="<aks-region>"
 VM_REGION="<vm-region>"
 AKS_VNET="<aks-vnet-name>"
 FLEX_VNET="<flex-vnet-name>"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
 az account set --subscription "$SUBSCRIPTION_ID"
 
@@ -395,6 +396,7 @@ chmod +x ./aks-flex-config
   --resource-group "$AKS_RG" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```

--- a/docs/labs/aks-public-cluster-unbounded-net-wireguard.md
+++ b/docs/labs/aks-public-cluster-unbounded-net-wireguard.md
@@ -93,6 +93,7 @@ AKS_REGION="eastus2"
 VM_REGION="southcentralus"
 AKS_VNET="aks-public-unbounded-vnet"
 FLEX_VNET="flex-public-unbounded-vnet"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
 az account set --subscription "$SUBSCRIPTION_ID"
 
@@ -440,6 +441,7 @@ chmod +x ./aks-flex-config
   --resource-group "$AKS_RG" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```

--- a/docs/labs/gpu-node-setup.md
+++ b/docs/labs/gpu-node-setup.md
@@ -118,6 +118,7 @@ On your workstation, use `aks-flex-config` to create the bootstrap RBAC and rend
 RESOURCE_GROUP="<aks-resource-group>"
 CLUSTER_NAME="<aks-cluster-name>"
 SUBSCRIPTION_ID="<subscription-id>"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
 curl -fsSLo ./aks-flex-config https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/aks-flex-config
 chmod +x ./aks-flex-config
@@ -131,6 +132,7 @@ chmod +x ./aks-flex-config
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```

--- a/docs/usages/aks-flex-config.md
+++ b/docs/usages/aks-flex-config.md
@@ -26,6 +26,7 @@ Most commands use the same AKS cluster selectors:
 RESOURCE_GROUP="<resource-group>"
 CLUSTER_NAME="<cluster-name>"
 SUBSCRIPTION_ID="<subscription-id>"
+AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 ```
 
 | Flag | Required | Description |
@@ -52,6 +53,11 @@ This applies the bootstrap-related `ClusterRoleBinding` objects for the `system:
 `generate-node-config` fetches AKS metadata and renders a config file. It requires exactly one auth mode.
 
 Use `--output <path>` to write a config file with mode `0600`. If omitted, the config is written to stdout.
+The helper writes `azure.resourceManagerEndpoint` with the public ARM endpoint and writes the selected agent pool name to `azure.targetAgentPoolName`. If `--agent-pool-name` is omitted, it defaults to the historical `aksflexnodes` pool name.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--agent-pool-name` | no | FlexNode agent pool name written into the generated config. Defaults to `aksflexnodes`. |
 
 ### Bootstrap Token
 
@@ -60,6 +66,7 @@ Use `--output <path>` to write a config file with mode `0600`. If omitted, the c
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```
@@ -73,6 +80,7 @@ Bootstrap-token mode creates a Kubernetes bootstrap token `Secret`, reads the AK
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --identity \
   --output ./aks-flex-node-config.json
 ```
@@ -84,6 +92,7 @@ For user-assigned managed identity, pass the client ID with `--username`:
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --identity \
   --username "<managed-identity-client-id>" \
   --output ./aks-flex-node-config.json
@@ -98,6 +107,7 @@ Service principal flags follow the `az login --service-principal` convention:
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --service-principal \
   --username "<client-id>" \
   --password "<client-secret>" \
@@ -114,6 +124,7 @@ Service principal flags follow the `az login --service-principal` convention:
   --resource-group "$RESOURCE_GROUP" \
   --cluster-name "$CLUSTER_NAME" \
   --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
   --arc \
   --arc-machine-name "<arc-machine-name>" \
   --arc-resource-group "<arc-resource-group>" \

--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -23,12 +23,12 @@ aks-flex-node start --config /etc/aks-flex-node/config.json
 
 | Name | Type | Description | Sample Value |
 |------|------|-------------|--------------|
-| `azure.subscriptionId` | string | Azure subscription that owns the target AKS cluster. | `44654aed-2753-4b88-9142-af7132933b6b` |
-| `azure.tenantId` | string | Microsoft Entra tenant ID for the subscription. | `70a036f6-8e4d-4615-bad6-149c02e7720d` |
+| `azure.subscriptionId` | string | Optional Azure subscription that owns the target AKS cluster. Defaults from `azure.targetCluster.resourceId` when omitted. | `44654aed-2753-4b88-9142-af7132933b6b` |
+| `azure.tenantId` | string | Microsoft Entra tenant ID. Required only when Azure Arc is enabled. | `70a036f6-8e4d-4615-bad6-149c02e7720d` |
 | `azure.cloud` | string | Optional legacy Azure cloud environment label. Resource Manager calls use `azure.resourceManagerEndpoint`. | `AzurePublicCloud` in legacy configs |
 | `azure.resourceManagerEndpoint` | string | Optional Azure Resource Manager endpoint emitted by RP bootstrap data. Defaults to `https://management.azure.com`. | `https://management.azure.com` |
 | `azure.targetCluster` | object | Target AKS cluster metadata. | `{}` |
-| `azure.targetAgentPoolName` | string | Required target AKS agent pool for FlexNode machine registration (`TargetAgentPoolName` in the agent config). | `flexnode-edge` |
+| `azure.targetAgentPoolName` | string | Optional target AKS agent pool for FlexNode machine registration (`TargetAgentPoolName` in the agent config). Defaults to `aksflexnodes`. | `flexnode-edge` |
 
 ## Target Cluster
 
@@ -39,7 +39,7 @@ aks-flex-node start --config /etc/aks-flex-node/config.json
 
 ## Authentication
 
-Exactly one authentication mode must be configured.
+At least one join or Azure authentication method must be configured. `azure.bootstrapToken` can be combined with one Azure authentication method (`azure.arc`, `azure.managedIdentity`, or `azure.servicePrincipal`) so kubelet bootstrap and ARM Machine registration can use different credentials. Only one Azure authentication method can be enabled at a time.
 
 | Name | Type | Description | Sample Value |
 |------|------|-------------|--------------|
@@ -137,7 +137,11 @@ AKS Flex Node also accepts the bootstrap payload returned by the AKS RP `listBoo
 | `components.runc` | `runc.version` |
 | `networking.dnsServiceIP` | `node.kubelet.dnsServiceIP` |
 | `networking.cniVersion` | `cni.version` |
+| `node.maxPods` | `node.maxPods` |
+| `node.labels` | `node.labels` |
+| `node.taints` | `node.taints` |
 | `node.kubelet.clusterFQDN` | `node.kubelet.serverURL` |
+| `node.kubelet.caCertData` | `node.kubelet.caCertData` |
 
 ## Sample Configurations
 

--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -25,8 +25,10 @@ aks-flex-node start --config /etc/aks-flex-node/config.json
 |------|------|-------------|--------------|
 | `azure.subscriptionId` | string | Azure subscription that owns the target AKS cluster. | `44654aed-2753-4b88-9142-af7132933b6b` |
 | `azure.tenantId` | string | Microsoft Entra tenant ID for the subscription. | `70a036f6-8e4d-4615-bad6-149c02e7720d` |
-| `azure.cloud` | string | Azure cloud environment. Currently only Azure Public Cloud is supported. | `AzurePublicCloud` |
+| `azure.cloud` | string | Optional legacy Azure cloud environment label. Resource Manager calls use `azure.resourceManagerEndpoint`. | `AzurePublicCloud` in legacy configs |
+| `azure.resourceManagerEndpoint` | string | Optional Azure Resource Manager endpoint emitted by RP bootstrap data. Defaults to `https://management.azure.com`. | `https://management.azure.com` |
 | `azure.targetCluster` | object | Target AKS cluster metadata. | `{}` |
+| `azure.targetAgentPoolName` | string | Required target AKS agent pool for FlexNode machine registration (`TargetAgentPoolName` in the agent config). | `flexnode-edge` |
 
 ## Target Cluster
 
@@ -124,6 +126,19 @@ Exactly one authentication mode must be configured.
 | `cni.version` | string | Optional CNI plugin version override. | `v1.6.2` |
 | `npd.version` | string | Optional node-problem-detector version override. | `v1.35.1` |
 
+## AKS RP Bootstrap Data
+
+AKS Flex Node also accepts the bootstrap payload returned by the AKS RP `listBootstrapData` operation. At load time, RP-only fields are normalized into the runtime config shape and are not retained as separate config sections.
+
+| RP Bootstrap Field | Runtime Config Field |
+|--------------------|----------------------|
+| `components.kubernetes` | `kubernetes.version` |
+| `components.containerd` | `containerd.version` |
+| `components.runc` | `runc.version` |
+| `networking.dnsServiceIP` | `node.kubelet.dnsServiceIP` |
+| `networking.cniVersion` | `cni.version` |
+| `node.kubelet.clusterFQDN` | `node.kubelet.serverURL` |
+
 ## Sample Configurations
 
 ### Bootstrap Token
@@ -135,7 +150,8 @@ Use this for the quickstart path where the host joins with Kubernetes TLS bootst
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "bootstrapToken": {
       "token": "<token-id>.<token-secret>"
     },
@@ -168,7 +184,8 @@ Use this for an Azure VM with a managed identity assigned.
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "managedIdentity": {},
     "arc": { "enabled": false },
     "targetCluster": {
@@ -193,7 +210,8 @@ Use this when the host should be registered as an Arc-enabled server.
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "arc": {
       "enabled": true,
       "machineName": "<arc-machine-name>",
@@ -225,7 +243,8 @@ Use this when the host should authenticate with static service principal credent
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "servicePrincipal": {
       "tenantId": "<tenant-id>",
       "clientId": "<client-id>",

--- a/docs/usages/joining-nodes.md
+++ b/docs/usages/joining-nodes.md
@@ -35,7 +35,8 @@ Minimal config shape:
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "managedIdentity": {},
     "arc": { "enabled": false },
     "targetCluster": {
@@ -59,7 +60,8 @@ Minimal config shape:
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "arc": {
       "enabled": true,
       "machineName": "<arc-machine-name>",
@@ -88,7 +90,8 @@ Minimal config shape:
   "azure": {
     "subscriptionId": "<subscription-id>",
     "tenantId": "<tenant-id>",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "<agent-pool-name>",
     "servicePrincipal": {
       "tenantId": "<tenant-id>",
       "clientId": "<client-id>",

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -80,6 +80,7 @@ Additional environment variables:
 | `E2E_KUBERNETES_VERSION` | `1.35.0` | Kubernetes version used in generated node configs. |
 | `E2E_CONTAINERD_VERSION` | `2.0.4` | Containerd version used in generated node configs. |
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
+| `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Target AKS agent pool name written to generated node configs. |
 | `E2E_SSH_WAIT_TIMEOUT` | `300` | Timeout in seconds while waiting for SSH. |
 | `E2E_NODE_JOIN_TIMEOUT` | `300` | Timeout in seconds while waiting for node bootstrap. |
 | `E2E_POD_READY_TIMEOUT` | `120` | Timeout in seconds while waiting for smoke pods. |

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -184,6 +184,7 @@ load_config() {
   E2E_KUBERNETES_VERSION="${E2E_KUBERNETES_VERSION:-1.35.0}"
   E2E_CONTAINERD_VERSION="${E2E_CONTAINERD_VERSION:-2.0.4}"
   E2E_RUNC_VERSION="${E2E_RUNC_VERSION:-1.1.12}"
+  E2E_TARGET_AGENT_POOL_NAME="${E2E_TARGET_AGENT_POOL_NAME:-aksflexnodes}"
 
   # Timeouts (seconds)
   E2E_SSH_WAIT_TIMEOUT="${E2E_SSH_WAIT_TIMEOUT:-300}"
@@ -196,6 +197,7 @@ load_config() {
   log_info "  Location:         ${E2E_LOCATION}"
   log_info "  Subscription:     ${AZURE_SUBSCRIPTION_ID}"
   log_info "  Name Suffix:      ${E2E_NAME_SUFFIX}"
+  log_info "  Agent Pool:       ${E2E_TARGET_AGENT_POOL_NAME}"
   log_info "  Skip Cleanup:     ${E2E_SKIP_CLEANUP}"
 }
 

--- a/hack/e2e/lib/node-join-kubeadm.sh
+++ b/hack/e2e/lib/node-join-kubeadm.sh
@@ -291,7 +291,8 @@ node_join_kubeadm() {
   "azure": {
     "subscriptionId": "${subscription_id}",
     "tenantId": "${tenant_id}",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "${E2E_TARGET_AGENT_POOL_NAME}",
     "bootstrapToken": {
       "token": "${bootstrap_token}"
     },

--- a/hack/e2e/lib/node-join-msi.sh
+++ b/hack/e2e/lib/node-join-msi.sh
@@ -44,7 +44,8 @@ node_join_msi() {
   "azure": {
     "subscriptionId": "${subscription_id}",
     "tenantId": "${tenant_id}",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "${E2E_TARGET_AGENT_POOL_NAME}",
     "managedIdentity": {},
     "targetCluster": {
       "resourceId": "${cluster_id}",

--- a/hack/e2e/lib/node-join-token.sh
+++ b/hack/e2e/lib/node-join-token.sh
@@ -53,6 +53,7 @@ node_join_token() {
     --resource-group "${resource_group}" \
     --cluster-name "${cluster_name}" \
     --subscription "${subscription_id}" \
+    --agent-pool-name "${E2E_TARGET_AGENT_POOL_NAME}" \
     --bootstrap-token \
     --output "${config_file}"
 

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -48,6 +48,7 @@
 #   E2E_KUBERNETES_VERSION  Kubernetes version (default: 1.35.0)
 #   E2E_CONTAINERD_VERSION  Containerd version (default: 2.0.4)
 #   E2E_RUNC_VERSION        Runc version (default: 1.1.12)
+#   E2E_TARGET_AGENT_POOL_NAME Target AKS agent pool name (default: aksflexnodes)
 #   AZURE_SUBSCRIPTION_ID   Azure subscription (auto-detected if not set)
 #   AZURE_TENANT_ID         Azure tenant (auto-detected if not set)
 #

--- a/pkg/aksmachine/client_armapi.go
+++ b/pkg/aksmachine/client_armapi.go
@@ -13,12 +13,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 
+	"github.com/Azure/AKSFlexNode/pkg/azclient"
 	"github.com/Azure/AKSFlexNode/pkg/config"
-)
-
-const (
-	aksFlexNodePoolName = "aksflexnodes"
-	flexNodeTagKey      = "aks-flex-node"
 )
 
 type armMachineClient struct {
@@ -33,11 +29,12 @@ func newARMClient(cfg *config.Config, logger *slog.Logger) (MachineClient, error
 	if err != nil {
 		return nil, err
 	}
-	cred, err := getCredential(cfg, logger)
+	clientOpts := azureClientOptionsFromConfig(cfg)
+	cred, err := getCredential(cfg, logger, clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("resolve ARM credential: %w", err)
 	}
-	var armOpts *arm.ClientOptions // nil = default public ARM endpoint
+	armOpts := &arm.ClientOptions{ClientOptions: clientOpts}
 	client, err := armcontainerservice.NewMachinesClient(machineID.SubscriptionID, cred, armOpts)
 	if err != nil {
 		return nil, fmt.Errorf("create machines client: %w", err)
@@ -53,12 +50,8 @@ func (c *armMachineClient) Create(ctx context.Context, desired GoalState) (*Mach
 	if err := desired.validate(); err != nil {
 		return nil, fmt.Errorf("validate goal state: %w", err)
 	}
-	flexNodeTagValue := "true"
 	params := armcontainerservice.Machine{
 		Properties: &armcontainerservice.MachineProperties{
-			Tags: map[string]*string{
-				flexNodeTagKey: &flexNodeTagValue,
-			},
 			Kubernetes: buildK8sProfile(desired),
 		},
 	}
@@ -123,11 +116,20 @@ func (c *armMachineClient) PatchStatus(context.Context, Status) error {
 }
 
 func machineResourceIDFromConfig(cfg *config.Config) (*arm.ResourceID, error) {
-	if cfg.Azure.TargetCluster.ResourceID == "" || cfg.Agent.NodeName == "" || cfg.Kubernetes.Version == "" {
-		return nil, fmt.Errorf("incomplete AKS machine config: clusterResourceId=%q machineName=%q kubernetesVersion=%q",
-			cfg.Azure.TargetCluster.ResourceID, cfg.Agent.NodeName, cfg.Kubernetes.Version)
+	var clusterResourceID, agentPoolName, machineName, k8sVersion string
+	if cfg != nil {
+		if cfg.Azure.TargetCluster != nil {
+			clusterResourceID = cfg.Azure.TargetCluster.ResourceID
+		}
+		agentPoolName = strings.TrimSpace(cfg.Azure.TargetAgentPoolName)
+		machineName = cfg.Agent.NodeName
+		k8sVersion = cfg.Kubernetes.Version
 	}
-	machineResourceID := strings.TrimRight(cfg.Azure.TargetCluster.ResourceID, "/") + "/agentPools/" + aksFlexNodePoolName + "/machines/" + cfg.Agent.NodeName
+	if clusterResourceID == "" || agentPoolName == "" || machineName == "" || k8sVersion == "" {
+		return nil, fmt.Errorf("incomplete AKS machine config: clusterResourceId=%q targetAgentPoolName=%q machineName=%q kubernetesVersion=%q",
+			clusterResourceID, agentPoolName, machineName, k8sVersion)
+	}
+	machineResourceID := strings.TrimRight(clusterResourceID, "/") + "/agentPools/" + agentPoolName + "/machines/" + machineName
 	machineID, err := arm.ParseResourceID(machineResourceID)
 	if err != nil {
 		return nil, fmt.Errorf("parse AKS machine resource ID %q: %w", machineResourceID, err)
@@ -135,7 +137,11 @@ func machineResourceIDFromConfig(cfg *config.Config) (*arm.ResourceID, error) {
 	return machineID, nil
 }
 
-func getCredential(cfg *config.Config, logger *slog.Logger) (azcore.TokenCredential, error) {
+func azureClientOptionsFromConfig(cfg *config.Config) azcore.ClientOptions {
+	return azclient.ClientOptionsFromConfig(cfg)
+}
+
+func getCredential(cfg *config.Config, logger *slog.Logger, clientOpts azcore.ClientOptions) (azcore.TokenCredential, error) {
 	switch {
 	case cfg.IsSPConfigured():
 		logger.Debug(
@@ -147,10 +153,10 @@ func getCredential(cfg *config.Config, logger *slog.Logger) (azcore.TokenCredent
 			cfg.Azure.ServicePrincipal.TenantID,
 			cfg.Azure.ServicePrincipal.ClientID,
 			cfg.Azure.ServicePrincipal.ClientSecret,
-			nil,
+			&azidentity.ClientSecretCredentialOptions{ClientOptions: clientOpts},
 		)
 	case cfg.IsMIConfigured():
-		opts := &azidentity.ManagedIdentityCredentialOptions{}
+		opts := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: clientOpts}
 		if cfg.Azure.ManagedIdentity != nil && cfg.Azure.ManagedIdentity.ClientID != "" {
 			opts.ID = azidentity.ClientID(cfg.Azure.ManagedIdentity.ClientID)
 			logger.Debug(
@@ -163,20 +169,19 @@ func getCredential(cfg *config.Config, logger *slog.Logger) (azcore.TokenCredent
 		return azidentity.NewManagedIdentityCredential(opts)
 	default:
 		logger.Debug("falling back to default credential for ARM")
-		return azidentity.NewDefaultAzureCredential(nil)
+		return azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{ClientOptions: clientOpts})
 	}
 }
 
 func buildK8sProfile(goal GoalState) *armcontainerservice.MachineKubernetesProfile {
+	// FlexNode RP accepts the registration surface below; local kubelet defaults
+	// are consumed during node bootstrap and must not be sent as Machine fields.
+	maxPods := int32(goal.MaxPods) //nolint:gosec // validated non-negative and small
 	p := &armcontainerservice.MachineKubernetesProfile{
 		OrchestratorVersion: &goal.KubernetesVersion,
-		MaxPods:             new(int32(goal.MaxPods)), //nolint:gosec // validated non-negative and small
+		MaxPods:             &maxPods,
 		NodeLabels:          stringPointerMap(goal.NodeLabels),
 		NodeTaints:          stringPointerSlice(goal.NodeTaints),
-		KubeletConfig: &armcontainerservice.KubeletConfig{
-			ImageGcHighThreshold: new(int32(goal.KubeletConfig.ImageGCHighThreshold)), //nolint:gosec // validated non-negative and small
-			ImageGcLowThreshold:  new(int32(goal.KubeletConfig.ImageGCLowThreshold)),  //nolint:gosec // validated non-negative and small
-		},
 	}
 	return p
 }

--- a/pkg/aksmachine/client_armapi_test.go
+++ b/pkg/aksmachine/client_armapi_test.go
@@ -1,6 +1,7 @@
 package aksmachine
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -202,6 +203,11 @@ func TestGoalStateValidate(t *testing.T) {
 			name:    "negative max pods",
 			goal:    GoalState{KubernetesVersion: "1.35.1", MaxPods: -1},
 			wantErr: "max pods must be non-negative",
+		},
+		{
+			name:    "max pods exceeds int32",
+			goal:    GoalState{KubernetesVersion: "1.35.1", MaxPods: math.MaxInt32 + 1},
+			wantErr: "max pods must be less than or equal to",
 		},
 		{
 			name: "negative image GC high threshold",

--- a/pkg/aksmachine/client_armapi_test.go
+++ b/pkg/aksmachine/client_armapi_test.go
@@ -4,21 +4,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8"
 
 	"github.com/Azure/AKSFlexNode/pkg/config"
 )
 
-const testClusterResourceID = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster"
+const (
+	testClusterResourceID = "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster"
+	testAgentPoolName     = "aksflexnodes"
+)
 
 func TestMachineResourceIDFromConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		cfg     *config.Config
-		want    string
-		wantErr string
+		name     string
+		cfg      *config.Config
+		want     string
+		wantPool string
+		wantErr  string
 	}{
 		{
 			name: "valid config",
@@ -27,7 +32,8 @@ func TestMachineResourceIDFromConfig(t *testing.T) {
 				"flex-node-1",
 				"1.34.0",
 			),
-			want: testClusterResourceID + "/agentPools/aksflexnodes/machines/flex-node-1",
+			want:     testClusterResourceID + "/agentPools/aksflexnodes/machines/flex-node-1",
+			wantPool: testAgentPoolName,
 		},
 		{
 			name: "trims cluster resource slash",
@@ -36,7 +42,22 @@ func TestMachineResourceIDFromConfig(t *testing.T) {
 				"flex-node-1",
 				"1.34.0",
 			),
-			want: testClusterResourceID + "/agentPools/aksflexnodes/machines/flex-node-1",
+			want:     testClusterResourceID + "/agentPools/aksflexnodes/machines/flex-node-1",
+			wantPool: testAgentPoolName,
+		},
+		{
+			name: "uses configured agent pool name",
+			cfg: func() *config.Config {
+				cfg := testARMConfig(
+					testClusterResourceID,
+					"flex-node-1",
+					"1.34.0",
+				)
+				cfg.Azure.TargetAgentPoolName = "flexnode-edge"
+				return cfg
+			}(),
+			want:     testClusterResourceID + "/agentPools/flexnode-edge/machines/flex-node-1",
+			wantPool: "flexnode-edge",
 		},
 		{
 			name: "missing cluster resource ID",
@@ -54,6 +75,19 @@ func TestMachineResourceIDFromConfig(t *testing.T) {
 				"",
 				"1.34.0",
 			),
+			wantErr: "incomplete AKS machine config",
+		},
+		{
+			name: "missing agent pool name",
+			cfg: func() *config.Config {
+				cfg := testARMConfig(
+					testClusterResourceID,
+					"flex-node-1",
+					"1.34.0",
+				)
+				cfg.Azure.TargetAgentPoolName = ""
+				return cfg
+			}(),
 			wantErr: "incomplete AKS machine config",
 		},
 		{
@@ -84,13 +118,36 @@ func TestMachineResourceIDFromConfig(t *testing.T) {
 			if got.String() != tt.want {
 				t.Fatalf("machineResourceIDFromConfig() = %q, want %q", got.String(), tt.want)
 			}
-			if got.Parent == nil || got.Parent.Name != aksFlexNodePoolName {
-				t.Fatalf("agent pool parent = %#v, want name %q", got.Parent, aksFlexNodePoolName)
+			if got.Parent == nil || got.Parent.Name != tt.wantPool {
+				t.Fatalf("agent pool parent = %#v, want name %q", got.Parent, tt.wantPool)
 			}
 			if got.Parent.Parent == nil || got.Parent.Parent.Name != "test-cluster" {
 				t.Fatalf("cluster parent = %#v, want name test-cluster", got.Parent.Parent)
 			}
 		})
+	}
+}
+
+func TestAzureClientOptionsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := testARMConfig(testClusterResourceID, "flex-node-1", "1.34.0")
+	cfg.Azure.Cloud = "InvalidCloud"
+	cfg.Azure.ResourceManagerEndpointURL = "https://management.example.test"
+
+	opts := azureClientOptionsFromConfig(cfg)
+	service, ok := opts.Cloud.Services[cloud.ResourceManager]
+	if !ok {
+		t.Fatal("ResourceManager cloud service is missing")
+	}
+	if service.Endpoint != "https://management.example.test" {
+		t.Fatalf("ResourceManager endpoint = %q, want https://management.example.test", service.Endpoint)
+	}
+	if service.Audience != "https://management.example.test" {
+		t.Fatalf("ResourceManager audience = %q, want https://management.example.test", service.Audience)
+	}
+	if opts.Cloud.ActiveDirectoryAuthorityHost != cloud.AzurePublic.ActiveDirectoryAuthorityHost {
+		t.Fatalf("authority host = %q, want public cloud", opts.Cloud.ActiveDirectoryAuthorityHost)
 	}
 }
 
@@ -119,14 +176,8 @@ func TestBuildK8sProfile(t *testing.T) {
 	if len(profile.NodeTaints) != 1 || profile.NodeTaints[0] == nil || *profile.NodeTaints[0] != "dedicated=flex:NoSchedule" {
 		t.Fatalf("NodeTaints = %#v, want dedicated=flex:NoSchedule", profile.NodeTaints)
 	}
-	if profile.KubeletConfig == nil {
-		t.Fatal("KubeletConfig is nil")
-	}
-	if profile.KubeletConfig.ImageGcHighThreshold == nil || *profile.KubeletConfig.ImageGcHighThreshold != 85 {
-		t.Fatalf("ImageGcHighThreshold = %v, want 85", profile.KubeletConfig.ImageGcHighThreshold)
-	}
-	if profile.KubeletConfig.ImageGcLowThreshold == nil || *profile.KubeletConfig.ImageGcLowThreshold != 80 {
-		t.Fatalf("ImageGcLowThreshold = %v, want 80", profile.KubeletConfig.ImageGcLowThreshold)
+	if profile.KubeletConfig != nil {
+		t.Fatalf("KubeletConfig = %#v, want nil because FlexNode RP rejects custom kubelet config on Machine PUT", profile.KubeletConfig)
 	}
 }
 
@@ -305,6 +356,7 @@ func TestMachineFromARMUsesCurrentOrchestratorVersionFallback(t *testing.T) {
 func testARMConfig(clusterResourceID, nodeName, kubernetesVersion string) *config.Config {
 	return &config.Config{
 		Azure: config.AzureConfig{
+			TargetAgentPoolName: testAgentPoolName,
 			TargetCluster: &config.TargetClusterConfig{
 				ResourceID: clusterResourceID,
 			},

--- a/pkg/aksmachine/types.go
+++ b/pkg/aksmachine/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 
 	"github.com/Azure/AKSFlexNode/pkg/config"
@@ -32,6 +33,9 @@ func (g GoalState) validate() error {
 	}
 	if g.MaxPods < 0 {
 		return fmt.Errorf("max pods must be non-negative")
+	}
+	if g.MaxPods > math.MaxInt32 {
+		return fmt.Errorf("max pods must be less than or equal to %d", math.MaxInt32)
 	}
 	if g.KubeletConfig.ImageGCHighThreshold < 0 {
 		return fmt.Errorf("image GC high threshold must be non-negative")

--- a/pkg/arc/arc_installer.go
+++ b/pkg/arc/arc_installer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute"
 	"github.com/google/uuid"
 
+	"github.com/Azure/AKSFlexNode/pkg/azclient"
 	"github.com/Azure/AKSFlexNode/pkg/config"
 	"github.com/Azure/AKSFlexNode/pkg/utils/utilaz"
 	"github.com/Azure/AKSFlexNode/pkg/utils/utilexec"
@@ -94,18 +95,15 @@ func (t *installArcTask) ensureAuthentication(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	scope, err := t.cfg.Azure.ResourceManagerTokenScope()
-	if err != nil {
-		return err
-	}
-	_, err = getAccessToken(ctx, cred, scope)
+	_, err = getAccessToken(ctx, cred, azclient.ResourceManagerTokenScopeFromConfig(t.cfg))
 	return err
 }
 
 func (t *installArcTask) getCredential() (azcore.TokenCredential, error) {
 	var sources []azcore.TokenCredential
+	clientOpts := azclient.ClientOptionsFromConfig(t.cfg)
 
-	cred, err := azidentity.NewManagedIdentityCredential(nil)
+	cred, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{ClientOptions: clientOpts})
 	if err == nil {
 		sources = append(sources, cred)
 	} else {
@@ -113,14 +111,20 @@ func (t *installArcTask) getCredential() (azcore.TokenCredential, error) {
 		sources = append(sources, &utilaz.CredentialErrorReporter{CredentialType: "Arc managed identity", Err: err})
 	}
 
-	defaultCred, err := azidentity.NewDefaultAzureCredential(nil)
+	defaultCred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+		ClientOptions: clientOpts,
+		TenantID:      t.cfg.Azure.TenantID,
+	})
 	if err == nil {
 		sources = append(sources, defaultCred)
 	} else {
 		sources = append(sources, &utilaz.CredentialErrorReporter{CredentialType: "default Azure", Err: err})
 	}
 
-	cliCred, err := azidentity.NewAzureCLICredential(nil)
+	cliCred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
+		Subscription: t.cfg.Azure.SubscriptionID,
+		TenantID:     t.cfg.Azure.TenantID,
+	})
 	if err == nil {
 		sources = append(sources, cliCred)
 	} else {
@@ -208,16 +212,17 @@ func (t *installArcTask) setUpClients(ctx context.Context) error {
 	}
 
 	subID := t.cfg.Azure.SubscriptionID
+	armOpts := azclient.ARMClientOptionsFromConfig(t.cfg)
 
-	t.hybridComputeClient, err = armhybridcompute.NewMachinesClient(subID, cred, nil)
+	t.hybridComputeClient, err = armhybridcompute.NewMachinesClient(subID, cred, armOpts)
 	if err != nil {
 		return fmt.Errorf("create hybrid compute client: %w", err)
 	}
-	t.mcClient, err = armcontainerservice.NewManagedClustersClient(subID, cred, nil)
+	t.mcClient, err = armcontainerservice.NewManagedClustersClient(subID, cred, armOpts)
 	if err != nil {
 		return fmt.Errorf("create managed clusters client: %w", err)
 	}
-	t.roleAssignmentsClient, err = armauthorization.NewRoleAssignmentsClient(subID, cred, nil)
+	t.roleAssignmentsClient, err = armauthorization.NewRoleAssignmentsClient(subID, cred, armOpts)
 	if err != nil {
 		return fmt.Errorf("create role assignments client: %w", err)
 	}
@@ -284,6 +289,9 @@ func (t *installArcTask) runArcAgentConnect(ctx context.Context) error {
 		"--subscription-id", cfg.Azure.SubscriptionID,
 		"--resource-name", arcConfig.MachineName,
 	}
+	if cloudName := azclient.AzcmagentCloudNameFromConfig(cfg); cloudName != "" {
+		args = append(args, "--cloud", cloudName)
+	}
 
 	for key, value := range arcConfig.Tags {
 		args = append(args, "--tags", fmt.Sprintf("%s=%s", key, value))
@@ -294,11 +302,7 @@ func (t *installArcTask) runArcAgentConnect(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("obtain credential for azcmagent: %w", err)
 	}
-	scope, err := t.cfg.Azure.ResourceManagerTokenScope()
-	if err != nil {
-		return err
-	}
-	accessToken, err := getAccessToken(ctx, cred, scope)
+	accessToken, err := getAccessToken(ctx, cred, azclient.ResourceManagerTokenScopeFromConfig(cfg))
 	if err != nil {
 		return fmt.Errorf("get access token: %w", err)
 	}

--- a/pkg/azclient/resource_manager.go
+++ b/pkg/azclient/resource_manager.go
@@ -1,0 +1,100 @@
+package azclient
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+const (
+	azureGovernmentResourceManagerEndpoint = "https://management.usgovcloudapi.net"
+	azureGovernmentResourceManagerAudience = "https://management.core.usgovcloudapi.net"
+	azureChinaResourceManagerEndpoint      = "https://management.chinacloudapi.cn"
+	azureChinaResourceManagerAudience      = "https://management.core.chinacloudapi.cn"
+
+	azcmagentAzureGovernmentCloud = "AzureUSGovernment"
+	azcmagentAzureChinaCloud      = "AzureChinaCloud"
+)
+
+// ResourceManagerEnvironment is the Azure SDK configuration derived from the
+// configured ARM endpoint. The public cloud defaults preserve existing behavior;
+// known sovereign endpoints switch authority host and token audience together.
+type ResourceManagerEnvironment struct {
+	Endpoint           string
+	Audience           string
+	AuthorityHost      string
+	AzcmagentCloudName string
+}
+
+func ResourceManagerEnvironmentFromConfig(cfg *config.Config) ResourceManagerEnvironment {
+	endpoint := config.DefaultResourceManagerEndpointURL
+	if cfg != nil {
+		if configured := strings.TrimSpace(cfg.Azure.ResourceManagerEndpointURL); configured != "" {
+			endpoint = strings.TrimRight(configured, "/")
+		}
+	}
+
+	env := ResourceManagerEnvironment{
+		Endpoint:      endpoint,
+		Audience:      strings.TrimRight(endpoint, "/"),
+		AuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+	}
+
+	switch resourceManagerEndpointHost(endpoint) {
+	case "management.azure.com":
+		env.Audience = config.DefaultResourceManagerAudience
+	case "management.usgovcloudapi.net":
+		env.Endpoint = azureGovernmentResourceManagerEndpoint
+		env.Audience = azureGovernmentResourceManagerAudience
+		env.AuthorityHost = cloud.AzureGovernment.ActiveDirectoryAuthorityHost
+		env.AzcmagentCloudName = azcmagentAzureGovernmentCloud
+	case "management.chinacloudapi.cn":
+		env.Endpoint = azureChinaResourceManagerEndpoint
+		env.Audience = azureChinaResourceManagerAudience
+		env.AuthorityHost = cloud.AzureChina.ActiveDirectoryAuthorityHost
+		env.AzcmagentCloudName = azcmagentAzureChinaCloud
+	}
+
+	return env
+}
+
+func ClientOptionsFromConfig(cfg *config.Config) azcore.ClientOptions {
+	env := ResourceManagerEnvironmentFromConfig(cfg)
+	return azcore.ClientOptions{
+		Cloud: cloud.Configuration{
+			ActiveDirectoryAuthorityHost: env.AuthorityHost,
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: env.Audience,
+					Endpoint: env.Endpoint,
+				},
+			},
+		},
+	}
+}
+
+func ARMClientOptionsFromConfig(cfg *config.Config) *arm.ClientOptions {
+	return &arm.ClientOptions{ClientOptions: ClientOptionsFromConfig(cfg)}
+}
+
+func ResourceManagerTokenScopeFromConfig(cfg *config.Config) string {
+	env := ResourceManagerEnvironmentFromConfig(cfg)
+	return strings.TrimRight(env.Audience, "/") + "/.default"
+}
+
+func AzcmagentCloudNameFromConfig(cfg *config.Config) string {
+	return ResourceManagerEnvironmentFromConfig(cfg).AzcmagentCloudName
+}
+
+func resourceManagerEndpointHost(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err == nil && parsed.Host != "" {
+		return strings.ToLower(parsed.Host)
+	}
+	return strings.ToLower(strings.Trim(endpoint, "/"))
+}

--- a/pkg/azclient/resource_manager_test.go
+++ b/pkg/azclient/resource_manager_test.go
@@ -1,0 +1,105 @@
+package azclient
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+func TestResourceManagerEnvironmentFromConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		endpoint      string
+		wantEndpoint  string
+		wantAudience  string
+		wantAuthority string
+		wantScope     string
+		wantAzcmagent string
+	}{
+		{
+			name:          "public default",
+			wantEndpoint:  config.DefaultResourceManagerEndpointURL,
+			wantAudience:  config.DefaultResourceManagerAudience,
+			wantAuthority: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			wantScope:     config.DefaultResourceManagerTokenScope,
+		},
+		{
+			name:          "custom endpoint",
+			endpoint:      "https://management.example.test/",
+			wantEndpoint:  "https://management.example.test",
+			wantAudience:  "https://management.example.test",
+			wantAuthority: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			wantScope:     "https://management.example.test/.default",
+		},
+		{
+			name:          "azure government endpoint",
+			endpoint:      "https://management.usgovcloudapi.net/",
+			wantEndpoint:  azureGovernmentResourceManagerEndpoint,
+			wantAudience:  azureGovernmentResourceManagerAudience,
+			wantAuthority: cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
+			wantScope:     azureGovernmentResourceManagerAudience + "/.default",
+			wantAzcmagent: azcmagentAzureGovernmentCloud,
+		},
+		{
+			name:          "azure china endpoint",
+			endpoint:      "https://management.chinacloudapi.cn/",
+			wantEndpoint:  azureChinaResourceManagerEndpoint,
+			wantAudience:  azureChinaResourceManagerAudience,
+			wantAuthority: cloud.AzureChina.ActiveDirectoryAuthorityHost,
+			wantScope:     azureChinaResourceManagerAudience + "/.default",
+			wantAzcmagent: azcmagentAzureChinaCloud,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{}
+			cfg.Azure.ResourceManagerEndpointURL = tt.endpoint
+
+			got := ResourceManagerEnvironmentFromConfig(cfg)
+			if got.Endpoint != tt.wantEndpoint {
+				t.Fatalf("Endpoint = %q, want %q", got.Endpoint, tt.wantEndpoint)
+			}
+			if got.Audience != tt.wantAudience {
+				t.Fatalf("Audience = %q, want %q", got.Audience, tt.wantAudience)
+			}
+			if got.AuthorityHost != tt.wantAuthority {
+				t.Fatalf("AuthorityHost = %q, want %q", got.AuthorityHost, tt.wantAuthority)
+			}
+			if scope := ResourceManagerTokenScopeFromConfig(cfg); scope != tt.wantScope {
+				t.Fatalf("ResourceManagerTokenScopeFromConfig() = %q, want %q", scope, tt.wantScope)
+			}
+			if cloudName := AzcmagentCloudNameFromConfig(cfg); cloudName != tt.wantAzcmagent {
+				t.Fatalf("AzcmagentCloudNameFromConfig() = %q, want %q", cloudName, tt.wantAzcmagent)
+			}
+		})
+	}
+}
+
+func TestClientOptionsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	cfg.Azure.ResourceManagerEndpointURL = "https://management.usgovcloudapi.net/"
+
+	opts := ClientOptionsFromConfig(cfg)
+	service, ok := opts.Cloud.Services[cloud.ResourceManager]
+	if !ok {
+		t.Fatal("ResourceManager cloud service is missing")
+	}
+	if service.Endpoint != azureGovernmentResourceManagerEndpoint {
+		t.Fatalf("ResourceManager endpoint = %q, want %q", service.Endpoint, azureGovernmentResourceManagerEndpoint)
+	}
+	if service.Audience != azureGovernmentResourceManagerAudience {
+		t.Fatalf("ResourceManager audience = %q, want %q", service.Audience, azureGovernmentResourceManagerAudience)
+	}
+	if opts.Cloud.ActiveDirectoryAuthorityHost != cloud.AzureGovernment.ActiveDirectoryAuthorityHost {
+		t.Fatalf("authority host = %q, want Azure Government", opts.Cloud.ActiveDirectoryAuthorityHost)
+	}
+}

--- a/pkg/config/bootstrap_data.go
+++ b/pkg/config/bootstrap_data.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// poolBootstrapData is the AKS RP-generated bootstrap config shape. The agent
+// accepts it at load time and normalizes it into the runtime Config shape.
+// this is based on v20260502preview AKS RP API version
+type poolBootstrapData struct {
+	Components *poolBootstrapComponents `json:"components,omitempty"`
+	Networking *poolBootstrapNetworking `json:"networking,omitempty"`
+	Node       *poolBootstrapNode       `json:"node,omitempty"`
+}
+
+type poolBootstrapComponents struct {
+	Kubernetes string `json:"kubernetes,omitempty"`
+	Containerd string `json:"containerd,omitempty"`
+	Runc       string `json:"runc,omitempty"`
+}
+
+type poolBootstrapNetworking struct {
+	DNSServiceIP string `json:"dnsServiceIP,omitempty"`
+	CNIVersion   string `json:"cniVersion,omitempty"`
+}
+
+type poolBootstrapNode struct {
+	MaxPods *int                  `json:"maxPods,omitempty"`
+	Labels  map[string]string     `json:"labels,omitempty"`
+	Taints  []string              `json:"taints,omitempty"`
+	Kubelet *poolBootstrapKubelet `json:"kubelet,omitempty"`
+}
+
+type poolBootstrapKubelet struct {
+	ClusterFQDN string `json:"clusterFQDN,omitempty"`
+	CACertData  string `json:"caCertData,omitempty"`
+}
+
+// adaptPoolBootstrapData copies AKS RP bootstrap fields into canonical Config
+// fields without overriding values already provided in the runtime config shape.
+func adaptPoolBootstrapData(data []byte, cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	var bootstrap poolBootstrapData
+	if err := json.Unmarshal(data, &bootstrap); err != nil {
+		return err
+	}
+
+	// The AKS RP bootstrap response is an input contract, not the runtime config
+	// shape. Normalize it here so the rest of the agent only sees Config fields.
+	if bootstrap.Components != nil {
+		if cfg.Kubernetes.Version == "" {
+			cfg.Kubernetes.Version = bootstrap.Components.Kubernetes
+		}
+		if cfg.Containerd.Version == "" {
+			cfg.Containerd.Version = bootstrap.Components.Containerd
+		}
+		if cfg.Runc.Version == "" {
+			cfg.Runc.Version = bootstrap.Components.Runc
+		}
+	}
+	if bootstrap.Networking != nil {
+		if cfg.Node.Kubelet.DNSServiceIP == "" {
+			cfg.Node.Kubelet.DNSServiceIP = bootstrap.Networking.DNSServiceIP
+		}
+		if cfg.CNI.Version == "" {
+			cfg.CNI.Version = bootstrap.Networking.CNIVersion
+		}
+	}
+	if bootstrap.Node != nil {
+		if cfg.Node.MaxPods == 0 && bootstrap.Node.MaxPods != nil {
+			cfg.Node.MaxPods = *bootstrap.Node.MaxPods
+		}
+		if cfg.Node.Labels == nil && bootstrap.Node.Labels != nil {
+			cfg.Node.Labels = bootstrap.Node.Labels
+		}
+		if cfg.Node.Taints == nil && bootstrap.Node.Taints != nil {
+			cfg.Node.Taints = bootstrap.Node.Taints
+		}
+		if bootstrap.Node.Kubelet != nil {
+			if cfg.Node.Kubelet.ServerURL == "" {
+				cfg.Node.Kubelet.ServerURL = serverURLFromClusterFQDN(bootstrap.Node.Kubelet.ClusterFQDN)
+			}
+			if cfg.Node.Kubelet.CACertData == "" {
+				cfg.Node.Kubelet.CACertData = bootstrap.Node.Kubelet.CACertData
+			}
+		}
+	}
+
+	return nil
+}
+
+func serverURLFromClusterFQDN(clusterFQDN string) string {
+	clusterFQDN = strings.TrimSpace(clusterFQDN)
+	if clusterFQDN == "" {
+		return ""
+	}
+	if strings.Contains(clusterFQDN, "://") {
+		return clusterFQDN
+	}
+	if strings.Contains(clusterFQDN, ":") {
+		return "https://" + clusterFQDN
+	}
+	return "https://" + clusterFQDN + ":443"
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,8 +23,19 @@ const (
 	DefaultLogDir                   = "/var/log/aks-flex-node"
 	defaultLogLevel                 = "info"
 	defaultMachineOperationMode     = "auto"
-	defaultAzureCloud               = "AzurePublicCloud"
 	defaultMachineReconcileInterval = 10 * time.Minute
+
+	// DefaultResourceManagerEndpointURL is the public Azure Resource Manager
+	// endpoint used when azure.resourceManagerEndpoint is omitted.
+	DefaultResourceManagerEndpointURL = "https://management.azure.com"
+
+	// DefaultResourceManagerAudience is the public Azure Resource Manager token
+	// audience used by Azure SDK for Go's ARM pipeline.
+	DefaultResourceManagerAudience = "https://management.azure.com"
+
+	// DefaultResourceManagerTokenScope is the OAuth scope for public Azure
+	// Resource Manager tokens.
+	DefaultResourceManagerTokenScope = DefaultResourceManagerAudience + "/.default"
 )
 
 // Config represents the complete agent configuration structure.
@@ -42,16 +53,17 @@ type Config struct {
 }
 
 // AzureConfig holds Azure-specific configuration required for connecting to Azure services.
-// All fields except Cloud are required for proper operation.
 type AzureConfig struct {
-	SubscriptionID   string                  `json:"subscriptionId"`             // Azure subscription ID
-	TenantID         string                  `json:"tenantId"`                   // Azure tenant ID
-	Cloud            string                  `json:"cloud"`                      // Azure cloud environment (defaults to AzurePublicCloud)
-	ServicePrincipal *ServicePrincipalConfig `json:"servicePrincipal,omitempty"` // Optional service principal authentication
-	ManagedIdentity  *ManagedIdentityConfig  `json:"managedIdentity,omitempty"`  // Optional managed identity authentication
-	BootstrapToken   *BootstrapTokenConfig   `json:"bootstrapToken,omitempty"`   // Optional bootstrap token authentication
-	Arc              *ArcConfig              `json:"arc"`                        // Azure Arc machine configuration
-	TargetCluster    *TargetClusterConfig    `json:"targetCluster"`              // Target AKS cluster configuration
+	SubscriptionID             string                  `json:"subscriptionId"`                    // Azure subscription ID; defaults from targetCluster.resourceId when omitted
+	TenantID                   string                  `json:"tenantId"`                          // Azure tenant ID
+	Cloud                      string                  `json:"cloud,omitempty"`                   // Legacy Azure cloud label; Resource Manager uses resourceManagerEndpoint
+	ResourceManagerEndpointURL string                  `json:"resourceManagerEndpoint,omitempty"` // Azure Resource Manager endpoint; defaults to https://management.azure.com
+	ServicePrincipal           *ServicePrincipalConfig `json:"servicePrincipal,omitempty"`        // Optional service principal authentication
+	ManagedIdentity            *ManagedIdentityConfig  `json:"managedIdentity,omitempty"`         // Optional managed identity authentication
+	BootstrapToken             *BootstrapTokenConfig   `json:"bootstrapToken,omitempty"`          // Optional bootstrap token authentication
+	Arc                        *ArcConfig              `json:"arc"`                               // Azure Arc machine configuration
+	TargetCluster              *TargetClusterConfig    `json:"targetCluster"`                     // Target AKS cluster configuration
+	TargetAgentPoolName        string                  `json:"targetAgentPoolName"`               // Target AKS agent pool for FlexNode machines
 }
 
 // ServicePrincipalConfig holds Azure service principal authentication configuration.
@@ -215,23 +227,6 @@ func (cfg *Config) IsBootstrapTokenConfigured() bool {
 	return cfg.Azure.BootstrapToken != nil
 }
 
-func (cfg AzureConfig) ResourceManagerEndpoint() (string, error) {
-	switch cfg.Cloud {
-	case "", "AzurePublicCloud":
-		return "https://management.azure.com", nil
-	default:
-		return "", fmt.Errorf("unsupported Azure cloud %q", cfg.Cloud)
-	}
-}
-
-func (cfg AzureConfig) ResourceManagerTokenScope() (string, error) {
-	endpoint, err := cfg.ResourceManagerEndpoint()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(endpoint, "/") + "/.default", nil
-}
-
 // resolveNodeName resolves the Kubernetes Node name once and stores it on the
 // config so bootstrap, daemon watches, and lifecycle operations use one value.
 func (cfg *Config) resolveNodeName(hostnameFunc func() (string, error)) (string, error) {
@@ -281,6 +276,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	if err := json.Unmarshal(data, config); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %w", err)
 	}
+	if err := adaptPoolBootstrapData(data, config); err != nil {
+		return nil, fmt.Errorf("adapt RP bootstrap data: %w", err)
+	}
 
 	if err := config.validate(); err != nil {
 		return nil, fmt.Errorf("config validation failed: %w", err)
@@ -304,18 +302,20 @@ func (cfg *Config) DeepCopy() *Config {
 }
 
 func (c *Config) setDefaults() {
-	c.setAzureCloudDefaults()
+	c.setAzureDefaults()
 	c.setAgentDefaults()
 	c.setNodeDefaults()
 	c.setRuncDefaults()
 	c.setNpdDefaults()
 }
 
-func (c *Config) setAzureCloudDefaults() {
-	// Set default Azure cloud if not provided
-	if c.Azure.Cloud == "" {
-		c.Azure.Cloud = defaultAzureCloud
+func (c *Config) setAzureDefaults() {
+	if endpoint := strings.TrimSpace(c.Azure.ResourceManagerEndpointURL); endpoint == "" {
+		c.Azure.ResourceManagerEndpointURL = DefaultResourceManagerEndpointURL
+	} else {
+		c.Azure.ResourceManagerEndpointURL = strings.TrimRight(endpoint, "/")
 	}
+	c.Azure.TargetAgentPoolName = strings.TrimSpace(c.Azure.TargetAgentPoolName)
 }
 
 func (c *Config) setAgentDefaults() {
@@ -421,10 +421,7 @@ func (c *Config) validateBootstrapToken() error {
 }
 
 func (c *AzureConfig) validate() error {
-	if c.SubscriptionID == "" {
-		return fmt.Errorf("azure.subscriptionId is required")
-	}
-	if c.TenantID == "" {
+	if c.requiresTenantID() && c.TenantID == "" {
 		return fmt.Errorf("azure.tenantId is required")
 	}
 	if c.TargetCluster == nil {
@@ -433,8 +430,11 @@ func (c *AzureConfig) validate() error {
 	if err := c.TargetCluster.validate(); err != nil {
 		return err
 	}
-	if !validAzureClouds[c.Cloud] {
-		return fmt.Errorf("invalid azure.cloud: %s. Valid values are: AzurePublicCloud", c.Cloud)
+	if strings.TrimSpace(c.TargetAgentPoolName) == "" {
+		return fmt.Errorf("azure.targetAgentPoolName is required")
+	}
+	if c.SubscriptionID == "" {
+		return fmt.Errorf("azure.subscriptionId is required")
 	}
 	if err := c.ServicePrincipal.validate(); err != nil {
 		return err
@@ -449,6 +449,13 @@ func (c *AzureConfig) validate() error {
 		return err
 	}
 	return nil
+}
+
+func (c *AzureConfig) requiresTenantID() bool {
+	if c == nil || c.Arc == nil {
+		return false
+	}
+	return c.Arc.Enabled
 }
 
 func (c *ServicePrincipalConfig) validate() error {
@@ -472,9 +479,6 @@ func (c *ManagedIdentityConfig) validate() error {
 }
 
 func (c *TargetClusterConfig) validate() error {
-	if c.Location == "" {
-		return fmt.Errorf("azure.targetCluster.location is required")
-	}
 	if c.ResourceID == "" {
 		return fmt.Errorf("azure.targetCluster.resourceId is required")
 	}
@@ -536,12 +540,6 @@ func (c *AgentConfig) validate() error {
 	return nil
 }
 
-// validAzureClouds defines the supported Azure cloud environments
-// Currently only Azure Public Cloud is supported
-var validAzureClouds = map[string]bool{
-	"AzurePublicCloud": true,
-}
-
 var validMachineOperationModes = map[string]bool{
 	"auto":    true,
 	"disable": true,
@@ -554,6 +552,8 @@ func (c *Config) validate() error {
 		return fmt.Errorf("resolve node name: %w", err)
 	}
 
+	populateTargetClusterInfoFromConfig(c)
+
 	if err := c.Azure.validate(); err != nil {
 		return err
 	}
@@ -561,43 +561,43 @@ func (c *Config) validate() error {
 		return err
 	}
 
-	if err := c.validateExclusiveAuthSettings(); err != nil {
+	if err := c.validateAuthSettings(); err != nil {
 		return err
 	}
 	if err := c.validateBootstrapToken(); err != nil {
 		return fmt.Errorf("invalid bootstrap token configuration: %w", err)
 	}
 
-	populateTargetClusterInfoFromConfig(c)
-
 	return nil
 }
 
-func (c *Config) validateExclusiveAuthSettings() error {
-	authMethodCount := 0
-	for _, m := range []bool{c.IsARCEnabled(), c.IsSPConfigured(), c.IsMIConfigured(), c.IsBootstrapTokenConfigured()} {
+func (c *Config) validateAuthSettings() error {
+	armAuthMethodCount := 0
+	for _, m := range []bool{c.IsARCEnabled(), c.IsSPConfigured(), c.IsMIConfigured()} {
 		if m {
-			authMethodCount++
+			armAuthMethodCount++
 		}
 	}
-	if authMethodCount == 0 {
+	if armAuthMethodCount == 0 && !c.IsBootstrapTokenConfigured() {
 		return fmt.Errorf("at least one authentication method must be configured: Arc, Service Principal, Managed Identity, or Bootstrap Token")
 	}
-	if authMethodCount > 1 {
-		return fmt.Errorf("only one authentication method can be enabled at a time: Arc, Service Principal, Managed Identity, or Bootstrap Token")
+	if armAuthMethodCount > 1 {
+		return fmt.Errorf("only one Azure authentication method can be enabled at a time: Arc, Service Principal, or Managed Identity")
 	}
 
 	return nil
 }
 
-// populateTargetClusterInfoFromConfig extracts cluster information from the resource ID
-// This function should only be called after validateAzureResourceID confirms the format is correct
+// populateTargetClusterInfoFromConfig extracts cluster information from the resource ID.
+// Invalid or absent resource IDs are ignored so validation can return the canonical error.
 // TODO: Deprecate this helper; deriving cluster fields from resourceID/location is wrong
 // for cases like custom node resource groups. Use explicit config fields or an Azure lookup instead.
 func populateTargetClusterInfoFromConfig(cfg *Config) {
+	if cfg == nil || cfg.Azure.TargetCluster == nil {
+		return
+	}
 	matches := AKSClusterResourceIDPattern.FindStringSubmatch(cfg.Azure.TargetCluster.ResourceID)
 	if len(matches) < 4 {
-		// This should not happen if validation occurred first, but handle gracefully
 		return
 	}
 
@@ -615,6 +615,9 @@ func populateTargetClusterInfoFromConfig(cfg *Config) {
 	cfg.Azure.TargetCluster.ResourceGroup = resourceGroupName
 	cfg.Azure.TargetCluster.SubscriptionID = subscriptionID
 	cfg.Azure.TargetCluster.NodeResourceGroup = mcResourceGroup
+	if cfg.Azure.SubscriptionID == "" {
+		cfg.Azure.SubscriptionID = subscriptionID
+	}
 }
 
 // HostRoutingConfig groups host-level routing tasks that run before the nspawn

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ const (
 	defaultLogLevel                 = "info"
 	defaultMachineOperationMode     = "auto"
 	defaultMachineReconcileInterval = 10 * time.Minute
+	defaultTargetAgentPoolName      = "aksflexnodes"
 
 	// DefaultResourceManagerEndpointURL is the public Azure Resource Manager
 	// endpoint used when azure.resourceManagerEndpoint is omitted.
@@ -316,6 +317,9 @@ func (c *Config) setAzureDefaults() {
 		c.Azure.ResourceManagerEndpointURL = strings.TrimRight(endpoint, "/")
 	}
 	c.Azure.TargetAgentPoolName = strings.TrimSpace(c.Azure.TargetAgentPoolName)
+	if c.Azure.TargetAgentPoolName == "" {
+		c.Azure.TargetAgentPoolName = defaultTargetAgentPoolName
+	}
 }
 
 func (c *Config) setAgentDefaults() {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,7 +31,7 @@ func TestSetDefaults(t *testing.T) {
 			want: func(c *Config) bool {
 				return c.Azure.Cloud == "" &&
 					c.Azure.ResourceManagerEndpointURL == "https://management.azure.com" &&
-					c.Azure.TargetAgentPoolName == "" &&
+					c.Azure.TargetAgentPoolName == "aksflexnodes" &&
 					c.Agent.LogLevel == "info" &&
 					c.Agent.LogDir == "/var/log/aks-flex-node" &&
 					c.Agent.MachineOperationMode == "auto" &&
@@ -478,7 +478,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateRequiresTargetAgentPoolName(t *testing.T) {
+func TestValidateDefaultsTargetAgentPoolName(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Config{
@@ -500,9 +500,11 @@ func TestValidateRequiresTargetAgentPoolName(t *testing.T) {
 		},
 	}
 
-	err := cfg.validate()
-	if err == nil || !strings.Contains(err.Error(), "azure.targetAgentPoolName is required") {
-		t.Fatalf("validate() error = %v, want azure.targetAgentPoolName required", err)
+	if err := cfg.validate(); err != nil {
+		t.Fatalf("validate() unexpected error = %v", err)
+	}
+	if cfg.Azure.TargetAgentPoolName != "aksflexnodes" {
+		t.Fatalf("TargetAgentPoolName = %q, want aksflexnodes", cfg.Azure.TargetAgentPoolName)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+const testTargetAgentPoolName = "aksflexnodes"
+
+func setTestTargetAgentPoolName(c *Config) {
+	if c != nil && strings.TrimSpace(c.Azure.TargetAgentPoolName) == "" {
+		c.Azure.TargetAgentPoolName = testTargetAgentPoolName
+	}
+}
+
 func TestSetDefaults(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -21,7 +29,9 @@ func TestSetDefaults(t *testing.T) {
 			name:   "empty config gets all defaults",
 			config: &Config{},
 			want: func(c *Config) bool {
-				return c.Azure.Cloud == "AzurePublicCloud" &&
+				return c.Azure.Cloud == "" &&
+					c.Azure.ResourceManagerEndpointURL == "https://management.azure.com" &&
+					c.Azure.TargetAgentPoolName == "" &&
 					c.Agent.LogLevel == "info" &&
 					c.Agent.LogDir == "/var/log/aks-flex-node" &&
 					c.Agent.MachineOperationMode == "auto" &&
@@ -33,7 +43,8 @@ func TestSetDefaults(t *testing.T) {
 			name: "existing values are preserved",
 			config: &Config{
 				Azure: AzureConfig{
-					Cloud: "AzurePublicCloud",
+					Cloud:               "AzurePublicCloud",
+					TargetAgentPoolName: " flexnode-edge ",
 				},
 				Agent: AgentConfig{
 					LogLevel: "debug",
@@ -42,7 +53,9 @@ func TestSetDefaults(t *testing.T) {
 			},
 			want: func(c *Config) bool {
 				return c.Agent.LogLevel == "debug" &&
-					c.Agent.LogDir == "/custom/log/dir"
+					c.Agent.LogDir == "/custom/log/dir" &&
+					c.Azure.Cloud == "AzurePublicCloud" &&
+					c.Azure.TargetAgentPoolName == "flexnode-edge"
 			},
 		},
 		{
@@ -82,6 +95,14 @@ func TestSetDefaults(t *testing.T) {
 				t.Errorf("SetDefaults() failed validation for %s", tt.name)
 			}
 		})
+	}
+}
+
+func TestDefaultResourceManagerTokenScope(t *testing.T) {
+	t.Parallel()
+
+	if DefaultResourceManagerTokenScope != "https://management.azure.com/.default" {
+		t.Fatalf("DefaultResourceManagerTokenScope = %q, want https://management.azure.com/.default", DefaultResourceManagerTokenScope)
 	}
 }
 
@@ -178,29 +199,42 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "missing subscription ID fails",
+			name: "missing subscription ID uses target cluster subscription",
 			config: &Config{
 				Azure: AzureConfig{
 					TenantID: "12345678-1234-1234-1234-123456789012",
 					Cloud:    "AzurePublicCloud",
+					BootstrapToken: &BootstrapTokenConfig{
+						Token: "abcdef.0123456789abcdef",
+					},
 					TargetCluster: &TargetClusterConfig{
 						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
 						Location:   "eastus",
 					},
 				},
+				Node: NodeConfig{
+					Kubelet: KubeletConfig{
+						ServerURL:  "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
+						CACertData: "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R",
+					},
+				},
 			},
-			wantErr: true,
-			errMsg:  "azure.subscriptionId is required",
+			wantErr: false,
 		},
 		{
-			name: "missing tenant ID fails",
+			name: "missing tenant ID fails when Arc is enabled",
 			config: &Config{
 				Azure: AzureConfig{
 					SubscriptionID: "12345678-1234-1234-1234-123456789012",
 					Cloud:          "AzurePublicCloud",
+					Arc: &ArcConfig{
+						Enabled:       true,
+						ResourceGroup: "test-rg",
+						MachineName:   "test-machine",
+						Location:      "eastus",
+					},
 					TargetCluster: &TargetClusterConfig{
 						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
-						Location:   "eastus",
 					},
 				},
 			},
@@ -208,19 +242,20 @@ func TestValidate(t *testing.T) {
 			errMsg:  "azure.tenantId is required",
 		},
 		{
-			name: "missing target cluster location fails",
+			name: "missing target cluster location passes",
 			config: &Config{
 				Azure: AzureConfig{
 					SubscriptionID: "12345678-1234-1234-1234-123456789012",
-					TenantID:       "12345678-1234-1234-1234-123456789012",
 					Cloud:          "AzurePublicCloud",
+					ManagedIdentity: &ManagedIdentityConfig{
+						ClientID: "12345678-1234-1234-1234-123456789012",
+					},
 					TargetCluster: &TargetClusterConfig{
 						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
 					},
 				},
 			},
-			wantErr: true,
-			errMsg:  "azure.targetCluster.location is required",
+			wantErr: false,
 		},
 		{
 			name: "missing target cluster resource ID fails",
@@ -254,20 +289,47 @@ func TestValidate(t *testing.T) {
 			errMsg:  "invalid azure.targetCluster.resourceId:",
 		},
 		{
-			name: "invalid azure cloud fails",
+			name: "azure cloud no longer controls resource manager endpoint",
 			config: &Config{
 				Azure: AzureConfig{
 					SubscriptionID: "12345678-1234-1234-1234-123456789012",
 					TenantID:       "12345678-1234-1234-1234-123456789012",
 					Cloud:          "InvalidCloud",
+					ManagedIdentity: &ManagedIdentityConfig{
+						ClientID: "12345678-1234-1234-1234-123456789012",
+					},
 					TargetCluster: &TargetClusterConfig{
 						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
 						Location:   "eastus",
 					},
 				},
 			},
-			wantErr: true,
-			errMsg:  "invalid azure.cloud: InvalidCloud. Valid values are: AzurePublicCloud",
+			wantErr: false,
+		},
+		{
+			name: "explicit resource manager endpoint is preserved",
+			config: &Config{
+				Azure: AzureConfig{
+					SubscriptionID:             "12345678-1234-1234-1234-123456789012",
+					TenantID:                   "12345678-1234-1234-1234-123456789012",
+					Cloud:                      "InvalidCloud",
+					ResourceManagerEndpointURL: "https://management.example.test/",
+					BootstrapToken: &BootstrapTokenConfig{
+						Token: "abcdef.0123456789abcdef",
+					},
+					TargetCluster: &TargetClusterConfig{
+						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+						Location:   "eastus",
+					},
+				},
+				Node: NodeConfig{
+					Kubelet: KubeletConfig{
+						ServerURL:  "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
+						CACertData: "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R",
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "invalid log level fails",
@@ -396,6 +458,8 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setTestTargetAgentPoolName(tt.config)
+
 			err := tt.config.validate()
 			if tt.wantErr {
 				if err == nil {
@@ -411,6 +475,34 @@ func TestValidate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateRequiresTargetAgentPoolName(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Azure: AzureConfig{
+			SubscriptionID: "12345678-1234-1234-1234-123456789012",
+			Cloud:          "AzurePublicCloud",
+			BootstrapToken: &BootstrapTokenConfig{
+				Token: "abcdef.0123456789abcdef",
+			},
+			TargetCluster: &TargetClusterConfig{
+				ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+			},
+		},
+		Node: NodeConfig{
+			Kubelet: KubeletConfig{
+				ServerURL:  "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
+				CACertData: "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R",
+			},
+		},
+	}
+
+	err := cfg.validate()
+	if err == nil || !strings.Contains(err.Error(), "azure.targetAgentPoolName is required") {
+		t.Fatalf("validate() error = %v, want azure.targetAgentPoolName required", err)
 	}
 }
 
@@ -433,28 +525,29 @@ func TestLoadConfig(t *testing.T) {
 		{
 			name: "valid config file loads successfully",
 			configJSON: `{
-				"azure": {
-					"subscriptionId": "12345678-1234-1234-1234-123456789012",
-					"tenantId": "12345678-1234-1234-1234-123456789012",
-					"cloud": "AzurePublicCloud",
-					"bootstrapToken": {
-						"token": "abcdef.0123456789abcdef"
+					"azure": {
+						"subscriptionId": "12345678-1234-1234-1234-123456789012",
+						"tenantId": "12345678-1234-1234-1234-123456789012",
+						"cloud": "AzurePublicCloud",
+						"targetAgentPoolName": "flexnode-edge",
+						"bootstrapToken": {
+							"token": "abcdef.0123456789abcdef"
+						},
+						"targetCluster": {
+							"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+							"location": "eastus"
+						}
 					},
-					"targetCluster": {
-						"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
-						"location": "eastus"
+					"agent": {
+						"logLevel": "debug"
+					},
+					"node": {
+						"kubelet": {
+							"serverURL": "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
+							"caCertData": "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R"
+						}
 					}
-				},
-				"agent": {
-					"logLevel": "debug"
-				},
-				"node": {
-					"kubelet": {
-						"serverURL": "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
-						"caCertData": "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R"
-					}
-				}
-			}`,
+				}`,
 			wantErr: false,
 		},
 		{
@@ -507,8 +600,256 @@ func TestLoadConfig(t *testing.T) {
 				} else if config.Agent.LogLevel != "info" {
 					t.Errorf("Expected default log level 'info', got %s", config.Agent.LogLevel)
 				}
+				if config.Azure.TargetAgentPoolName != "flexnode-edge" {
+					t.Errorf("Expected target agent pool name 'flexnode-edge', got %s", config.Azure.TargetAgentPoolName)
+				}
 			}
 		})
+	}
+}
+
+func TestLoadConfigPoolBootstrapData(t *testing.T) {
+	t.Parallel()
+
+	configJSON := `{
+		"azure": {
+			"resourceManagerEndpoint": "https://management.azure.com/",
+			"targetAgentPoolName": "pool1",
+			"bootstrapToken": {
+				"token": "abcdef.0123456789abcdef"
+			},
+			"targetCluster": {
+				"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster"
+			}
+		},
+		"components": {
+			"kubernetes": "1.29.0",
+			"containerd": "2.0.5",
+			"runc": "1.2.3"
+		},
+		"networking": {
+			"dnsServiceIP": "10.42.0.10",
+			"cniVersion": "1.5.1"
+		},
+		"node": {
+			"maxPods": 30,
+			"labels": {
+				"env": "test"
+			},
+			"taints": [
+				"dedicated=flexnode:NoSchedule"
+			],
+			"kubelet": {
+				"clusterFQDN": "test-cluster-dns-12345678.hcp.eastus.azmk8s.io",
+				"caCertData": "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0t"
+			}
+		}
+	}`
+
+	configFile := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configFile, []byte(configJSON), 0o600); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	if cfg.Azure.ResourceManagerEndpointURL != "https://management.azure.com" {
+		t.Fatalf("Azure.ResourceManagerEndpointURL = %q, want https://management.azure.com", cfg.Azure.ResourceManagerEndpointURL)
+	}
+	if cfg.Node.Kubelet.ServerURL != "https://test-cluster-dns-12345678.hcp.eastus.azmk8s.io:443" {
+		t.Fatalf("Node.Kubelet.ServerURL = %q", cfg.Node.Kubelet.ServerURL)
+	}
+	if cfg.Node.Kubelet.CACertData != "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0t" {
+		t.Fatalf("Node.Kubelet.CACertData = %q", cfg.Node.Kubelet.CACertData)
+	}
+	if cfg.Node.MaxPods != 30 {
+		t.Fatalf("Node.MaxPods = %d, want 30", cfg.Node.MaxPods)
+	}
+	if cfg.Node.Labels["env"] != "test" {
+		t.Fatalf("Node.Labels[env] = %q, want test", cfg.Node.Labels["env"])
+	}
+	if len(cfg.Node.Taints) != 1 || cfg.Node.Taints[0] != "dedicated=flexnode:NoSchedule" {
+		t.Fatalf("Node.Taints = %#v, want dedicated=flexnode:NoSchedule", cfg.Node.Taints)
+	}
+
+	agentCfg := ToAgentConfig(cfg, "flex-node-1")
+	if agentCfg.Cluster.Version != "1.29.0" {
+		t.Fatalf("Agent Cluster.Version = %q, want 1.29.0", agentCfg.Cluster.Version)
+	}
+	if agentCfg.Cluster.ClusterDNS != "10.42.0.10" {
+		t.Fatalf("Agent Cluster.ClusterDNS = %q, want 10.42.0.10", agentCfg.Cluster.ClusterDNS)
+	}
+	if agentCfg.CRI.Containerd.Version != "2.0.5" {
+		t.Fatalf("Agent CRI.Containerd.Version = %q, want 2.0.5", agentCfg.CRI.Containerd.Version)
+	}
+	if agentCfg.CRI.Runc.Version != "1.2.3" {
+		t.Fatalf("Agent CRI.Runc.Version = %q, want 1.2.3", agentCfg.CRI.Runc.Version)
+	}
+	if agentCfg.CNI.PluginVersion != "1.5.1" {
+		t.Fatalf("Agent CNI.PluginVersion = %q, want 1.5.1", agentCfg.CNI.PluginVersion)
+	}
+	if agentCfg.Kubelet.ApiServer != "https://test-cluster-dns-12345678.hcp.eastus.azmk8s.io:443" {
+		t.Fatalf("Agent Kubelet.ApiServer = %q", agentCfg.Kubelet.ApiServer)
+	}
+	if agentCfg.Kubelet.Auth.BootstrapToken != "abcdef.0123456789abcdef" {
+		t.Fatalf("Agent bootstrap token = %q", agentCfg.Kubelet.Auth.BootstrapToken)
+	}
+	if len(agentCfg.Kubelet.Labels) == 0 || agentCfg.Kubelet.Labels["env"] != "test" {
+		t.Fatalf("Agent Kubelet.Labels = %#v, want env=test", agentCfg.Kubelet.Labels)
+	}
+	if len(agentCfg.Kubelet.RegisterWithTaints) != 1 || agentCfg.Kubelet.RegisterWithTaints[0] != "dedicated=flexnode:NoSchedule" {
+		t.Fatalf("Agent Kubelet.RegisterWithTaints = %#v", agentCfg.Kubelet.RegisterWithTaints)
+	}
+}
+
+func TestLoadConfigPoolBootstrapDataMissingOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	configJSON := `{
+		"azure": {
+			"targetAgentPoolName": "pool1",
+			"bootstrapToken": {
+				"token": "abcdef.0123456789abcdef"
+			},
+			"targetCluster": {
+				"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster"
+			}
+		},
+		"components": {
+			"kubernetes": "1.29.0"
+		},
+		"node": {
+			"kubelet": {
+				"clusterFQDN": "test-cluster-dns-12345678.hcp.eastus.azmk8s.io",
+				"caCertData": "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0t"
+			}
+		}
+	}`
+
+	configFile := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configFile, []byte(configJSON), 0o600); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	if cfg.Azure.Cloud != "" {
+		t.Fatalf("Azure.Cloud = %q, want empty when RP omits legacy cloud", cfg.Azure.Cloud)
+	}
+	if cfg.Azure.SubscriptionID != "12345678-1234-1234-1234-123456789012" {
+		t.Fatalf("Azure.SubscriptionID = %q", cfg.Azure.SubscriptionID)
+	}
+	if cfg.Azure.TargetAgentPoolName != "pool1" {
+		t.Fatalf("Azure.TargetAgentPoolName = %q, want pool1", cfg.Azure.TargetAgentPoolName)
+	}
+	if cfg.Node.Kubelet.DNSServiceIP != "10.0.0.10" {
+		t.Fatalf("Node.Kubelet.DNSServiceIP = %q, want default 10.0.0.10", cfg.Node.Kubelet.DNSServiceIP)
+	}
+	if cfg.Node.Kubelet.ServerURL != "https://test-cluster-dns-12345678.hcp.eastus.azmk8s.io:443" {
+		t.Fatalf("Node.Kubelet.ServerURL = %q", cfg.Node.Kubelet.ServerURL)
+	}
+	if cfg.Kubernetes.Version != "1.29.0" {
+		t.Fatalf("Kubernetes.Version = %q, want 1.29.0", cfg.Kubernetes.Version)
+	}
+	if cfg.Containerd.Version != "" {
+		t.Fatalf("Containerd.Version = %q, want empty when RP omits it", cfg.Containerd.Version)
+	}
+	if cfg.Runc.Version != "1.1.12" {
+		t.Fatalf("Runc.Version = %q, want default 1.1.12", cfg.Runc.Version)
+	}
+	if cfg.CNI.Version != "" {
+		t.Fatalf("CNI.Version = %q, want empty when RP omits it", cfg.CNI.Version)
+	}
+}
+
+func TestLoadConfigPreservesExistingConfigOverPoolBootstrapAliases(t *testing.T) {
+	t.Parallel()
+
+	configJSON := `{
+		"azure": {
+			"subscriptionId": "12345678-1234-1234-1234-123456789012",
+			"tenantId": "12345678-1234-1234-1234-123456789012",
+			"cloud": "AzurePublicCloud",
+			"targetAgentPoolName": "aksflexnodes",
+			"bootstrapToken": {
+				"token": "abcdef.0123456789abcdef"
+			},
+			"targetCluster": {
+				"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+				"location": "eastus"
+			}
+		},
+		"kubernetes": {
+			"version": "1.30.1"
+		},
+		"containerd": {
+			"version": "2.1.0"
+		},
+		"runc": {
+			"version": "1.3.0"
+		},
+		"cni": {
+			"version": "1.6.0"
+		},
+		"node": {
+			"maxPods": 35,
+			"labels": {
+				"legacy": "true"
+			},
+			"taints": [
+				"legacy=true:NoSchedule"
+			],
+			"kubelet": {
+				"serverURL": "https://legacy.example.test:443",
+				"clusterFQDN": "rp.example.test",
+				"dnsServiceIP": "10.0.0.10",
+				"caCertData": "bGVnYWN5LWNh"
+			}
+		},
+		"components": {
+			"kubernetes": "9.99.0",
+			"containerd": "9.99.0",
+			"runc": "9.99.0"
+		},
+		"networking": {
+			"dnsServiceIP": "10.42.0.10",
+			"cniVersion": "9.99.0"
+		}
+	}`
+
+	configFile := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configFile, []byte(configJSON), 0o600); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	cfg, err := LoadConfig(configFile)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	if cfg.Kubernetes.Version != "1.30.1" {
+		t.Fatalf("Kubernetes.Version = %q, want legacy value", cfg.Kubernetes.Version)
+	}
+	if cfg.Containerd.Version != "2.1.0" {
+		t.Fatalf("Containerd.Version = %q, want legacy value", cfg.Containerd.Version)
+	}
+	if cfg.Runc.Version != "1.3.0" {
+		t.Fatalf("Runc.Version = %q, want legacy value", cfg.Runc.Version)
+	}
+	if cfg.CNI.Version != "1.6.0" {
+		t.Fatalf("CNI.Version = %q, want legacy value", cfg.CNI.Version)
+	}
+	if cfg.Node.Kubelet.DNSServiceIP != "10.0.0.10" {
+		t.Fatalf("Node.Kubelet.DNSServiceIP = %q, want legacy value", cfg.Node.Kubelet.DNSServiceIP)
+	}
+	if cfg.Node.Kubelet.ServerURL != "https://legacy.example.test:443" {
+		t.Fatalf("Node.Kubelet.ServerURL = %q, want legacy value", cfg.Node.Kubelet.ServerURL)
 	}
 }
 
@@ -694,6 +1035,9 @@ func TestPopulateTargetClusterInfoFromConfig(t *testing.T) {
 	if config.Azure.TargetCluster.SubscriptionID != expected.SubscriptionID {
 		t.Errorf("Expected SubscriptionID %s, got %s", expected.SubscriptionID, config.Azure.TargetCluster.SubscriptionID)
 	}
+	if config.Azure.SubscriptionID != expected.SubscriptionID {
+		t.Errorf("Expected Azure SubscriptionID %s, got %s", expected.SubscriptionID, config.Azure.SubscriptionID)
+	}
 	if config.Azure.TargetCluster.NodeResourceGroup != expected.NodeResourceGroup {
 		t.Errorf("Expected NodeResourceGroup %s, got %s", expected.NodeResourceGroup, config.Azure.TargetCluster.NodeResourceGroup)
 	}
@@ -729,6 +1073,7 @@ func TestManagedIdentityConfiguration(t *testing.T) {
 					"subscriptionId": "12345678-1234-1234-1234-123456789012",
 					"tenantId": "12345678-1234-1234-1234-123456789012",
 					"cloud": "AzurePublicCloud",
+					"targetAgentPoolName": "aksflexnodes",
 					"managedIdentity": {},
 					"targetCluster": {
 						"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
@@ -747,6 +1092,7 @@ func TestManagedIdentityConfiguration(t *testing.T) {
 					"subscriptionId": "12345678-1234-1234-1234-123456789012",
 					"tenantId": "12345678-1234-1234-1234-123456789012",
 					"cloud": "AzurePublicCloud",
+					"targetAgentPoolName": "aksflexnodes",
 					"managedIdentity": {
 						"clientId": "87654321-4321-4321-4321-210987654321"
 					},
@@ -767,6 +1113,7 @@ func TestManagedIdentityConfiguration(t *testing.T) {
 					"subscriptionId": "12345678-1234-1234-1234-123456789012",
 					"tenantId": "12345678-1234-1234-1234-123456789012",
 					"cloud": "AzurePublicCloud",
+					"targetAgentPoolName": "aksflexnodes",
 					"managedIdentity": {
 						"clientId": ""
 					},
@@ -787,6 +1134,7 @@ func TestManagedIdentityConfiguration(t *testing.T) {
 					"subscriptionId": "12345678-1234-1234-1234-123456789012",
 					"tenantId": "12345678-1234-1234-1234-123456789012",
 					"cloud": "AzurePublicCloud",
+					"targetAgentPoolName": "aksflexnodes",
 					"bootstrapToken": {
 						"token": "abcdef.0123456789abcdef"
 					},
@@ -1162,26 +1510,22 @@ func TestAuthenticationMethodValidation(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "only one authentication method can be enabled at a time",
+			errMsg:  "only one Azure authentication method can be enabled at a time",
 		},
 		{
-			name: "bootstrap token and service principal together fails",
+			name: "bootstrap token and managed identity together passes",
 			config: &Config{
 				Azure: AzureConfig{
 					SubscriptionID: "12345678-1234-1234-1234-123456789012",
-					TenantID:       "12345678-1234-1234-1234-123456789012",
 					Cloud:          "AzurePublicCloud",
 					BootstrapToken: &BootstrapTokenConfig{
 						Token: "abcdef.0123456789abcdef",
 					},
-					ServicePrincipal: &ServicePrincipalConfig{
-						TenantID:     "12345678-1234-1234-1234-123456789012",
-						ClientID:     "12345678-1234-1234-1234-123456789012",
-						ClientSecret: "test-secret",
+					ManagedIdentity: &ManagedIdentityConfig{
+						ClientID: "12345678-1234-1234-1234-123456789012",
 					},
 					TargetCluster: &TargetClusterConfig{
 						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
-						Location:   "eastus",
 					},
 				},
 				Agent: AgentConfig{
@@ -1194,8 +1538,62 @@ func TestAuthenticationMethodValidation(t *testing.T) {
 					},
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name: "bootstrap token and service principal together passes",
+			config: &Config{
+				Azure: AzureConfig{
+					SubscriptionID: "12345678-1234-1234-1234-123456789012",
+					Cloud:          "AzurePublicCloud",
+					BootstrapToken: &BootstrapTokenConfig{
+						Token: "abcdef.0123456789abcdef",
+					},
+					ServicePrincipal: &ServicePrincipalConfig{
+						TenantID:     "12345678-1234-1234-1234-123456789012",
+						ClientID:     "12345678-1234-1234-1234-123456789012",
+						ClientSecret: "test-secret",
+					},
+					TargetCluster: &TargetClusterConfig{
+						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+					},
+				},
+				Agent: AgentConfig{
+					LogLevel: "info",
+				},
+				Node: NodeConfig{
+					Kubelet: KubeletConfig{
+						ServerURL:  "https://test-cluster-abc123.hcp.eastus.azmk8s.io:443",
+						CACertData: "LS0tLS1CRUdJTi1DRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU1kbzBZa0R",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "service principal and managed identity together fails",
+			config: &Config{
+				Azure: AzureConfig{
+					SubscriptionID: "12345678-1234-1234-1234-123456789012",
+					Cloud:          "AzurePublicCloud",
+					ServicePrincipal: &ServicePrincipalConfig{
+						TenantID:     "12345678-1234-1234-1234-123456789012",
+						ClientID:     "12345678-1234-1234-1234-123456789012",
+						ClientSecret: "test-secret",
+					},
+					ManagedIdentity: &ManagedIdentityConfig{
+						ClientID: "12345678-1234-1234-1234-123456789012",
+					},
+					TargetCluster: &TargetClusterConfig{
+						ResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",
+					},
+				},
+				Agent: AgentConfig{
+					LogLevel: "info",
+				},
+			},
 			wantErr: true,
-			errMsg:  "only one authentication method can be enabled at a time",
+			errMsg:  "only one Azure authentication method can be enabled at a time",
 		},
 		{
 			name: "arc and service principal together fails",
@@ -1225,7 +1623,7 @@ func TestAuthenticationMethodValidation(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "only one authentication method can be enabled at a time",
+			errMsg:  "only one Azure authentication method can be enabled at a time",
 		},
 		{
 			name: "no authentication method configured fails",
@@ -1304,6 +1702,8 @@ func TestAuthenticationMethodValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setTestTargetAgentPoolName(tt.config)
+
 			err := tt.config.validate()
 			if tt.wantErr {
 				if err == nil {
@@ -1326,6 +1726,7 @@ const baseAzureJSON = `{
 		"subscriptionId": "12345678-1234-1234-1234-123456789012",
 		"tenantId": "12345678-1234-1234-1234-123456789012",
 		"cloud": "AzurePublicCloud",
+		"targetAgentPoolName": "aksflexnodes",
 		"bootstrapToken": { "token": "abcdef.0123456789abcdef" },
 		"targetCluster": {
 			"resourceId": "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-cluster",

--- a/scripts/aks-flex-config
+++ b/scripts/aks-flex-config
@@ -13,6 +13,9 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+RESOURCE_MANAGER_ENDPOINT = "https://management.azure.com"
+DEFAULT_AGENT_POOL_NAME = "aksflexnodes"
+
 
 def log_info(message: str) -> None:
     print(f"INFO: {message}", file=sys.stderr)
@@ -140,11 +143,16 @@ def cluster_metadata(args: argparse.Namespace) -> dict[str, str]:
     }
 
 
+def agent_pool_name(args: argparse.Namespace) -> str:
+    return (args.agent_pool_name or "").strip() or DEFAULT_AGENT_POOL_NAME
+
+
 def render_config(args: argparse.Namespace, mode: str, metadata: dict[str, str]) -> dict[str, object]:
     azure: dict[str, object] = {
         "subscriptionId": metadata["subscription_id"],
         "tenantId": metadata["tenant_id"],
-        "cloud": "AzurePublicCloud",
+        "resourceManagerEndpoint": RESOURCE_MANAGER_ENDPOINT,
+        "targetAgentPoolName": metadata["agent_pool_name"],
         "targetCluster": {
             "resourceId": metadata["resource_id"],
             "location": metadata["location"],
@@ -230,6 +238,7 @@ def generate_node_config(args: argparse.Namespace) -> None:
     require_command("kubectl") if args.bootstrap_token else None
     mode = auth_mode(args)
     metadata = cluster_metadata(args)
+    metadata["agent_pool_name"] = agent_pool_name(args)
     config = render_config(args, mode, metadata)
     write_config(config, args.output)
 
@@ -249,6 +258,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     generate = subparsers.add_parser("generate-node-config", help="Render a Flex Node config.")
     add_cluster_args(generate)
+    generate.add_argument(
+        "--agent-pool-name",
+        default=DEFAULT_AGENT_POOL_NAME,
+        help=f"AKS agent pool name written to azure.targetAgentPoolName (default: {DEFAULT_AGENT_POOL_NAME}).",
+    )
     generate.add_argument("--bootstrap-token", action="store_true")
     generate.add_argument("--identity", action="store_true")
     generate.add_argument("--service-principal", action="store_true")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -320,7 +320,8 @@ show_next_steps() {
   "azure": {
     "subscriptionId": "YOUR_SUBSCRIPTION_ID",
     "tenantId": "YOUR_TENANT_ID",
-    "cloud": "AzurePublicCloud",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "YOUR_AGENT_POOL_NAME",
     "arc": {
       "machineName": "YOUR_MACHINE_NAME",
       "tags": {


### PR DESCRIPTION
## Summary

- Accept AKS RP `listBootstrapData` shape and normalize it into the local agent config.
- Add `azure.targetAgentPoolName` support and use it for ARM Machine resource paths.
- Add `azure.resourceManagerEndpoint` support and share Resource Manager endpoint/audience/authority handling across Machine and Arc clients.
- Keep `scripts/aks-flex-config generate-node-config` backward compatible by defaulting `--agent-pool-name` to `aksflexnodes`.
- Update E2E config generation and docs to include the target agent pool name.