### PR TITLE
Add E2E runner workspace cleanup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -74,3 +74,7 @@ jobs:
         env:
           E2E_SKIP_CLEANUP: ${{ inputs.skip_cleanup && '1' || '0' }}
         run: ./hack/e2e/run.sh cleanup
+
+      - name: Cleanup runner workspace
+        if: always()
+        run: ./hack/e2e/run.sh runner-cleanup

--- a/hack/e2e/lib/runner.sh
+++ b/hack/e2e/lib/runner.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hack/e2e/lib/runner.sh - Self-hosted runner maintenance helpers
+#
+# Provides local runner hygiene for the GitHub Actions host.
+# =============================================================================
+set -euo pipefail
+
+[[ -n "${_E2E_RUNNER_LOADED:-}" ]] && return 0
+readonly _E2E_RUNNER_LOADED=1
+
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+# ---------------------------------------------------------------------------
+# cleanup_runner_workspace - Reclaim local disk on the self-hosted runner
+# ---------------------------------------------------------------------------
+cleanup_runner_workspace() {
+  log_section "Cleaning Up Runner Workspace"
+
+  if [[ "${E2E_SKIP_RUNNER_CLEANUP:-0}" == "1" ]]; then
+    log_warn "Runner workspace cleanup skipped (E2E_SKIP_RUNNER_CLEANUP=1)"
+    return 0
+  fi
+
+  local can_sudo=0
+  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+    can_sudo=1
+  fi
+
+  log_info "Disk usage before runner cleanup:"
+  df -h / 2>/dev/null || true
+
+  local removed=0
+  local dir
+  while IFS= read -r dir; do
+    [[ -n "${dir}" && -d "${dir}" ]] || continue
+    log_info "Removing ${dir}"
+    if [[ "${can_sudo}" == "1" ]]; then
+      sudo rm -rf -- "${dir}" || { log_warn "Failed to remove ${dir}"; continue; }
+    else
+      rm -rf -- "${dir}" || { log_warn "Failed to remove ${dir}"; continue; }
+    fi
+    removed=$((removed + 1))
+  done < <(find /tmp -maxdepth 1 -type d \( \
+    -name 'aks-flex-node-e2e' -o \
+    -name 'aks-flex-node-e2e-*' \
+  \) 2>/dev/null || true)
+
+  log_info "Removed ${removed} temporary directories"
+
+  if command -v go >/dev/null 2>&1; then
+    log_info "Cleaning Go build cache"
+    go clean -cache 2>/dev/null || true
+  fi
+
+  if [[ "${can_sudo}" == "1" ]]; then
+    log_info "Cleaning apt cache"
+    sudo apt-get clean 2>/dev/null || true
+    sudo rm -rf /var/cache/apt/archives/* 2>/dev/null || true
+
+    log_info "Trimming systemd journal"
+    sudo journalctl --vacuum-size="${E2E_JOURNAL_MAX_SIZE:-200M}" >/dev/null 2>&1 || true
+  else
+    log_warn "Passwordless sudo is unavailable; skipping system cache cleanup"
+  fi
+
+  local runner_work_root=""
+  if [[ -n "${RUNNER_WORKSPACE:-}" ]]; then
+    runner_work_root="$(dirname "${RUNNER_WORKSPACE}")"
+  fi
+  if [[ "${runner_work_root}" == */_work && -d "${runner_work_root}/_update" ]]; then
+    log_info "Cleaning old runner update payloads"
+    if [[ "${can_sudo}" == "1" ]]; then
+      sudo find "${runner_work_root}/_update" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + 2>/dev/null || true
+    else
+      find "${runner_work_root}/_update" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + 2>/dev/null || true
+    fi
+  fi
+
+  log_info "Disk usage after runner cleanup:"
+  df -h / 2>/dev/null || true
+  log_success "Runner workspace cleanup complete"
+}

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -23,6 +23,7 @@
 #   upgrade-drift Run MSI-node Kubernetes version drift repave test
 #   logs          Collect logs from VMs
 #   cleanup       Tear down Azure resources
+#   runner-cleanup Reclaim local disk on the self-hosted runner
 #   status        Show current state (deployment outputs)
 #
 # Options:
@@ -41,6 +42,7 @@
 #   E2E_BINARY              Path to pre-built aks-flex-node binary
 #   E2E_NAME_SUFFIX         Unique suffix for resource names
 #   E2E_SKIP_CLEANUP        Set to 1 to keep resources after tests
+#   E2E_SKIP_RUNNER_CLEANUP Set to 1 to keep local runner artifacts after tests
 #   E2E_SKIP_BUILD          Set to 1 to skip building the binary
 #   E2E_DEBUG               Set to 1 for verbose logging
 #   E2E_SSH_KEY_FILE        SSH public key file for VM access
@@ -94,6 +96,8 @@ source "${SCRIPT_DIR}/lib/validate.sh"
 source "${SCRIPT_DIR}/lib/upgrade-drift.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/cleanup.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/runner.sh"
 
 # ---------------------------------------------------------------------------
 # Defaults
@@ -115,7 +119,7 @@ usage() {
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      all|infra|join|join-msi|join-token|join-kubeadm|unjoin|unjoin-msi|unjoin-token|unjoin-kubeadm|validate|validate-absent|smoke|upgrade-drift|logs|cleanup|status)
+      all|infra|join|join-msi|join-token|join-kubeadm|unjoin|unjoin-msi|unjoin-token|unjoin-kubeadm|validate|validate-absent|smoke|upgrade-drift|logs|cleanup|runner-cleanup|status)
         COMMAND="$1"; shift ;;
       -g|--resource-group) export E2E_RESOURCE_GROUP="$2"; shift 2 ;;
       -l|--location)       export E2E_LOCATION="$2"; shift 2 ;;
@@ -215,6 +219,12 @@ cmd_status() {
 # ---------------------------------------------------------------------------
 main() {
   parse_args "$@"
+
+  if [[ "${COMMAND}" == "runner-cleanup" ]]; then
+    trap 'gha_end_group' EXIT
+    cleanup_runner_workspace
+    return
+  fi
 
   # Common initialization
   check_prerequisites


### PR DESCRIPTION
Add automatic local workspace cleanup for the self-hosted E2E GitHub Actions runner.

## Changes

- Add `hack/e2e/lib/runner.sh` with runner-local disk cleanup helpers.
- Add `runner-cleanup` command to `hack/e2e/run.sh`.
- Run `./hack/e2e/run.sh runner-cleanup` as a final `always()` workflow step after Azure resource cleanup.
- Keep runner cleanup independent from `skip_cleanup`, which only controls Azure resource cleanup.
- Add `E2E_SKIP_RUNNER_CLEANUP=1` as a separate opt-out for preserving local runner artifacts.

## Why

The self-hosted E2E runner accumulated stale `/tmp/aks-flex-node-e2e-*` directories across runs, eventually filling the runner OS disk and blocking E2E jobs. Azure resource cleanup did not clean these local runner artifacts.

