### PR TITLE
Secure E2E GitHub Actions pipeline

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,9 +1,10 @@
-name: E2E Tests - nodes join
+name: E2E Tests
 
-# End-to-end tests for both authentication modes (MSI + Bootstrap Token).
-# Deploys a single AKS cluster with two VMs via Bicep, joins one via MSI and
-# one via bootstrap token, verifies both nodes appear in the cluster, and runs
-# smoke tests scheduling pods on each flex node.
+# End-to-end tests for MSI, bootstrap-token, and kubeadm-style join flows.
+#
+# Security note: this workflow uses GitHub OIDC to obtain Azure access for the
+# protected e2e-testing environment. PR runs are allowed only when the PR branch
+# lives in this repository; fork PRs are blocked at the job level.
 
 on:
   workflow_dispatch:
@@ -15,15 +16,33 @@ on:
         type: boolean
 
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "hack/e2e/**"
+      - "scripts/aks-flex-config"
+      - "scripts/install.sh"
+      - ".github/workflows/e2e-tests.yml"
 
   pull_request:
-    branches: [main, dev]
+    branches:
+      - main
     types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "hack/e2e/**"
+      - "scripts/aks-flex-config"
+      - "scripts/install.sh"
+      - ".github/workflows/e2e-tests.yml"
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   E2E_RESOURCE_GROUP: ${{ secrets.E2E_RESOURCE_GROUP }}
@@ -35,20 +54,33 @@ env:
 
 jobs:
   e2e:
-    name: E2E Tests (MSI + Token)
-    runs-on: [self-hosted, e2e, azure]
+    name: E2E Tests
+    # Only run from the canonical repository, and never for fork PRs. Same-repo
+    # PRs still require the e2e-testing environment/OIDC policy to allow access.
+    if: >
+      github.repository == 'Azure/AKSFlexNode' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: e2e-testing
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
+
+      - name: Azure login
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Run E2E tests
         env:
@@ -62,7 +94,7 @@ jobs:
         run: ./hack/e2e/run.sh logs
 
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: e2e-logs-${{ github.run_id }}

--- a/.github/workflows/fork-e2e-notice.yml
+++ b/.github/workflows/fork-e2e-notice.yml
@@ -1,0 +1,59 @@
+name: Fork PR E2E Notice
+
+on:
+  # zizmor: ignore[dangerous-triggers] This workflow only comments on fork PRs and never checks out or executes PR code.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Comment on fork PRs
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upsert E2E fork notice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          marker="<!-- aks-flex-node-fork-e2e-notice -->"
+          body_file="${RUNNER_TEMP}/fork-e2e-notice.md"
+          cat > "${body_file}" <<'EOF'
+          <!-- aks-flex-node-fork-e2e-notice -->
+          Thanks for the contribution! This pull request comes from a fork, so the Azure E2E workflow is intentionally skipped for security reasons.
+
+          Merge will remain blocked until the E2E tests have been run from a branch in the `Azure/AKSFlexNode` repository by a maintainer/contributor with access to this repo.
+
+          Maintainer options:
+          1. Review the fork changes.
+          2. Push the trusted commit to a branch in `Azure/AKSFlexNode`.
+          3. Run the `E2E Tests` workflow from that same-repository branch, or open a same-repository PR so the workflow can run automatically.
+
+          We do not run Azure E2E directly from fork PR code because it requires Azure OIDC access.
+          EOF
+
+          existing_comment_id="$(gh api \
+            --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.user.type == \"Bot\" and (.body | contains(\"${marker}\"))) | .id" \
+            | head -n 1)"
+
+          if [[ -n "${existing_comment_id}" ]]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_comment_id}" \
+              --field "body=@${body_file}" \
+              >/dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --field "body=@${body_file}" \
+              >/dev/null
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -59,7 +59,7 @@ jobs:
         run: go tool cover -html=coverage.out -o coverage.html
 
       - name: Upload coverage to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: |
@@ -84,16 +84,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           args: --timeout=5m
@@ -104,16 +104,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: "-no-fail -fmt sarif -out results.sarif -exclude-dir=hack -exclude-generated ./..."
@@ -130,7 +130,7 @@ jobs:
           mv results-cleaned.sarif results.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         if: always()
         with:
           sarif_file: results.sarif
@@ -141,10 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true
@@ -178,7 +178,7 @@ jobs:
         run: go vet ./...
 
       - name: Check for common mistakes with staticcheck
-        uses: dominikh/staticcheck-action@v1
+        uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
           version: "latest"
           install-go: false
@@ -189,9 +189,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: moderate

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -85,6 +89,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -105,6 +111,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -142,6 +150,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -190,6 +200,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  security-events: write
 
 jobs:
   build:
@@ -108,6 +107,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Go
@@ -81,6 +82,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
+
+env:
+  RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -38,14 +41,14 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
+          cache: false
 
-      - name: Get version
-        id: version
+      - name: Validate version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ ! "${RELEASE_VERSION}" =~ ^v[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid release version: ${RELEASE_VERSION}" >&2
+            exit 1
           fi
 
       - name: Build binary
@@ -53,19 +56,19 @@ jobs:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
+          set -euo pipefail
           GIT_COMMIT=$(git rev-parse --short HEAD)
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          LDFLAGS="-X github.com/Azure/AKSFlexNode/pkg/cmd/version.Version=${VERSION} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.GitCommit=${GIT_COMMIT} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.BuildTime=${BUILD_DATE} -w -s"
+          LDFLAGS="-X github.com/Azure/AKSFlexNode/pkg/cmd/version.Version=${RELEASE_VERSION} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.GitCommit=${GIT_COMMIT} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.BuildTime=${BUILD_DATE} -w -s"
 
-          BINARY_NAME="aks-flex-node-${{ matrix.os }}-${{ matrix.arch }}"
+          BINARY_NAME="aks-flex-node-${GOOS}-${GOARCH}"
 
           go build -ldflags "${LDFLAGS}" -o "${BINARY_NAME}" ./cmd/aks-flex-node
 
           # Create tarball
           tar -czf "${BINARY_NAME}.tar.gz" "${BINARY_NAME}"
-          echo "ASSET=${BINARY_NAME}.tar.gz" >> $GITHUB_ENV
+          echo "ASSET=${BINARY_NAME}.tar.gz" >> "$GITHUB_ENV"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -85,13 +88,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get version
-        id: version
+      - name: Validate version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [[ ! "${RELEASE_VERSION}" =~ ^v[0-9A-Za-z._-]+$ ]]; then
+            echo "Invalid release version: ${RELEASE_VERSION}" >&2
+            exit 1
           fi
 
       - name: Download artifacts
@@ -113,44 +115,45 @@ jobs:
           cat checksums.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
-        with:
-          tag_name: ${{ steps.version.outputs.VERSION }}
-          name: Release ${{ steps.version.outputs.VERSION }}
-          generate_release_notes: true
-          body: |
-            ## AKS Flex Node ${{ steps.version.outputs.VERSION }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cat > release-notes.md <<EOF
+          ## AKS Flex Node ${RELEASE_VERSION}
 
-            ### Installation
+          ### Installation
 
-            **Quick install (Ubuntu 22.04/24.04):**
-            ```bash
-            curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.version.outputs.VERSION }}/scripts/install.sh | sudo bash
-            ```
+          **Quick install (Ubuntu 22.04/24.04):**
+          \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${RELEASE_VERSION}/scripts/install.sh | sudo bash
+          \`\`\`
 
-            **Manual installation:**
-            1. Download the appropriate binary for your platform
-            2. Extract the archive: `tar -xzf aks-flex-node-*.tar.gz`
-            3. Move the binary to your PATH: `sudo mv aks-flex-node-* /usr/local/bin/aks-flex-node`
-            4. Make it executable: `sudo chmod +x /usr/local/bin/aks-flex-node`
+          **Manual installation:**
+          1. Download the appropriate binary for your platform
+          2. Extract the archive: \`tar -xzf aks-flex-node-*.tar.gz\`
+          3. Move the binary to your PATH: \`sudo mv aks-flex-node-* /usr/local/bin/aks-flex-node\`
+          4. Make it executable: \`sudo chmod +x /usr/local/bin/aks-flex-node\`
 
-            ### Supported Platforms
+          ### Supported Platforms
 
-            - **Ubuntu 22.04 LTS (AMD64)**: `aks-flex-node-linux-amd64.tar.gz`
-            - **Ubuntu 22.04 LTS (ARM64)**: `aks-flex-node-linux-arm64.tar.gz`
-            - **Ubuntu 24.04 LTS**: Compatible with AMD64 and ARM64 binaries above
+          - **Ubuntu 22.04 LTS (AMD64)**: \`aks-flex-node-linux-amd64.tar.gz\`
+          - **Ubuntu 22.04 LTS (ARM64)**: \`aks-flex-node-linux-arm64.tar.gz\`
+          - **Ubuntu 24.04 LTS**: Compatible with AMD64 and ARM64 binaries above
 
-            ### Verification
+          ### Verification
 
-            Verify your download with the checksums in `checksums.txt`.
+          Verify your download with the checksums in \`checksums.txt\`.
 
-            ### What's Changed
+          ### What's Changed
 
-            <!-- Add your changelog here -->
-          files: |
-            release-assets/*.tar.gz
-            release-assets/checksums.txt
-          draft: false
-          prerelease: false
-          fail_on_unmatched_files: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          <!-- Add your changelog here -->
+          EOF
+
+          gh release create "${RELEASE_VERSION}" \
+            release-assets/*.tar.gz \
+            release-assets/checksums.txt \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Release ${RELEASE_VERSION}" \
+            --notes-file release-notes.md \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,10 +150,15 @@ jobs:
           <!-- Add your changelog here -->
           EOF
 
+          release_flags=(--verify-tag)
+          if [[ "${RELEASE_VERSION}" =~ -(alpha|beta|rc)([.-]|$) ]]; then
+            release_flags+=(--prerelease)
+          fi
+
           gh release create "${RELEASE_VERSION}" \
             release-assets/*.tar.gz \
             release-assets/checksums.txt \
             --repo "${GITHUB_REPOSITORY}" \
             --title "Release ${RELEASE_VERSION}" \
             --notes-file release-notes.md \
-            --verify-tag
+            "${release_flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -67,7 +67,7 @@ jobs:
           echo "ASSET=${BINARY_NAME}.tar.gz" >> $GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: binaries-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ env.ASSET }}
@@ -80,7 +80,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get version
         id: version
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: binaries-*
           path: ./artifacts
@@ -110,7 +110,7 @@ jobs:
           cat checksums.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
           name: Release ${{ steps.version.outputs.VERSION }}

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -13,6 +13,22 @@ The E2E suite provisions an AKS cluster and three Ubuntu VMs in Azure, joins the
 | `openssl` | Bootstrap token generation. |
 | `go` | Build the agent binary unless `--binary` is supplied. |
 
+## GitHub Actions Policy
+
+The `E2E Tests` workflow uses GitHub-hosted runners and Azure OIDC for the protected `e2e-testing` environment. Automatic runs are intentionally limited because the workflow executes repository code that can create and delete Azure resources.
+
+Automatic E2E runs are allowed for:
+
+- pushes to `main` that touch Go files, `go.mod` / `go.sum`, E2E files, or E2E helper scripts;
+- same-repository pull requests targeting `main` with those same path changes.
+
+Fork pull requests are skipped by the workflow job condition. This prevents unreviewed fork code from receiving Azure OIDC access. To run full E2E for a trusted fork contribution, a maintainer should first review the change and then either:
+
+1. push the contributor's commit to a branch in the canonical repository and open/run E2E from that same-repo branch; or
+2. manually apply the change to a same-repo branch and run `workflow_dispatch`.
+
+Do not use `pull_request_target` to check out and execute fork code with Azure credentials.
+
 ## Quick Start
 
 ```bash

--- a/hack/e2e/lib/infra.sh
+++ b/hack/e2e/lib/infra.sh
@@ -35,7 +35,7 @@ _resolve_ssh_key() {
     # Generate a temporary keypair for the test run
     key_file="${E2E_WORK_DIR}/e2e_ssh_key.pub"
     if [[ ! -f "${key_file}" ]]; then
-      log_info "No SSH key found; generating a temporary keypair..."
+      log_info "No SSH key found; generating a temporary keypair..." >&2
       ssh-keygen -t ed25519 -f "${E2E_WORK_DIR}/e2e_ssh_key" -N "" -q
     fi
   fi
@@ -72,6 +72,9 @@ infra_deploy() {
   # Resolve SSH key
   local ssh_key
   ssh_key="$(_resolve_ssh_key)"
+  if [[ -f "${E2E_WORK_DIR}/e2e_ssh_key" && "${ssh_key}" == "$(cat "${E2E_WORK_DIR}/e2e_ssh_key.pub")" ]]; then
+    export E2E_SSH_OPTS="-i ${E2E_WORK_DIR}/e2e_ssh_key -o IdentitiesOnly=yes ${E2E_SSH_OPTS}"
+  fi
 
   # Build tags
   local run_id="${GITHUB_RUN_ID:-local-$(date +%s)}"


### PR DESCRIPTION
## Summary
- move E2E to GitHub-hosted runners with Azure OIDC authentication
- allow same-repo PR E2E while blocking fork PR Azure access
- restrict automatic E2E triggers to relevant Go/E2E workflow changes
- pin workflow actions to commit SHAs and disable checkout credential persistence
- address zizmor findings in PR/release workflows and document fork E2E policy

## Validation
- zizmor --run 'zizmor .github/workflows'
- verified all workflow `uses:` references are pinned to 40-char commit SHAs