### PR TITLE
Make E2E VM SKUs configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ E2E_RESOURCE_GROUP=rg-aksflexnode-e2e-tests
 # Azure region for E2E test resources
 E2E_LOCATION=westus2
 
+# AKS node pool VM size for the test cluster
+E2E_AKS_NODE_VM_SIZE=Standard_B2s
+
+# VM size for Flex Node test VMs
+E2E_VM_SIZE=Standard_B2as_v2
+
 # Target AKS agent pool name written to E2E node configs
 E2E_TARGET_AGENT_POOL_NAME=aksflexnodes
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,6 +47,8 @@ permissions:
 env:
   E2E_RESOURCE_GROUP: ${{ secrets.E2E_RESOURCE_GROUP }}
   E2E_LOCATION: ${{ secrets.E2E_LOCATION }}
+  E2E_AKS_NODE_VM_SIZE: ${{ secrets.E2E_AKS_NODE_VM_SIZE }}
+  E2E_VM_SIZE: ${{ secrets.E2E_VM_SIZE }}
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   GITHUB_RUN_ID: ${{ github.run_id }}

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -98,6 +98,8 @@ Additional environment variables:
 | `E2E_CONTAINERD_VERSION` | `2.0.4` | Containerd version used in generated node configs. |
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
 | `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Target AKS agent pool name written to generated node configs. |
+| `E2E_AKS_NODE_VM_SIZE` | `Standard_B2s` | VM size for the AKS cluster system node pool. |
+| `E2E_VM_SIZE` | `Standard_B2as_v2` | VM size for Flex Node test VMs. |
 | `E2E_SSH_WAIT_TIMEOUT` | `300` | Timeout in seconds while waiting for SSH. |
 | `E2E_NODE_JOIN_TIMEOUT` | `300` | Timeout in seconds while waiting for node bootstrap. |
 | `E2E_POD_READY_TIMEOUT` | `120` | Timeout in seconds while waiting for smoke pods. |

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -190,6 +190,10 @@ load_config() {
   E2E_RUNC_VERSION="${E2E_RUNC_VERSION:-1.1.12}"
   E2E_TARGET_AGENT_POOL_NAME="${E2E_TARGET_AGENT_POOL_NAME:-aksflexnodes}"
 
+  # Azure infrastructure sizing. Defaults match the Bicep template defaults.
+  E2E_AKS_NODE_VM_SIZE="${E2E_AKS_NODE_VM_SIZE:-Standard_B2s}"
+  E2E_VM_SIZE="${E2E_VM_SIZE:-Standard_B2as_v2}"
+
   # Timeouts (seconds)
   E2E_SSH_WAIT_TIMEOUT="${E2E_SSH_WAIT_TIMEOUT:-300}"
   E2E_NODE_JOIN_TIMEOUT="${E2E_NODE_JOIN_TIMEOUT:-300}"
@@ -202,6 +206,8 @@ load_config() {
   log_info "  Subscription:     ${AZURE_SUBSCRIPTION_ID}"
   log_info "  Name Suffix:      ${E2E_NAME_SUFFIX}"
   log_info "  Agent Pool:       ${E2E_TARGET_AGENT_POOL_NAME}"
+  log_info "  AKS Node VM Size: ${E2E_AKS_NODE_VM_SIZE}"
+  log_info "  Flex VM Size:     ${E2E_VM_SIZE}"
   log_info "  Kubeconfig:       ${KUBECONFIG}"
   log_info "  Skip Cleanup:     ${E2E_SKIP_CLEANUP}"
 }

--- a/hack/e2e/lib/infra.sh
+++ b/hack/e2e/lib/infra.sh
@@ -92,6 +92,8 @@ infra_deploy() {
     --parameters \
       location="${E2E_LOCATION}" \
       nameSuffix="${E2E_NAME_SUFFIX}" \
+      aksNodeVmSize="${E2E_AKS_NODE_VM_SIZE}" \
+      vmSize="${E2E_VM_SIZE}" \
       sshPublicKey="${ssh_key}" \
       tags="${tags_json}" \
     --output none


### PR DESCRIPTION
## Summary

Make E2E infrastructure VM SKUs configurable.

The new TME E2E subscription does not allow the previously hardcoded B-series SKUs in the tested regions. This change lets the E2E workflow choose compatible SKUs through environment secrets while preserving the existing defaults for local/dev usage.

## Changes

- Add `E2E_AKS_NODE_VM_SIZE` for the AKS system node pool VM size.
- Add `E2E_VM_SIZE` for the Flex Node test VM size.
- Pass both values into the existing Bicep template parameters.
- Document the new variables in `.env.example` and `hack/e2e/README.md`.
- Keep existing defaults unchanged:
  - `E2E_AKS_NODE_VM_SIZE=Standard_B2s`
  - `E2E_VM_SIZE=Standard_B2as_v2`

