### PR TITLE
Integrate Unbounded v0.2.0 configuration and repave cleanup

### DIFF
--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -112,6 +112,7 @@ At least one join or Azure authentication method must be configured. `azure.boot
 | `bootstrap.ociImage` | string | Optional nspawn rootfs OCI image used during bootstrap. When omitted, the shared agent default image selection is used. | `ghcr.io/example/aks-flex-node-rootfs:ubuntu-24.04` |
 | `bootstrap.offlineArtifacts.source` | string | Optional complete offline binary artifact bundle source. Supports absolute paths, `file://`, and unauthenticated `oci://` artifact references. The value is rendered as a strict Go template with `.KubernetesVersion` and `.KubernetesVersionNoV`. Preflight treats missing host packages as fatal when this is set. | `/opt/aks-flex-node/artifacts/{{ .KubernetesVersion }}` |
 | `bootstrap.additionalHostDevices` | array of strings | Optional extra host device nodes under `/dev` to expose to the nspawn machine in addition to devices discovered automatically by the shared agent. Entries must be clean absolute `/dev/...` paths. | `["/dev/uinput"]` |
+| `bootstrap.additionalHostMounts` | array of objects | Optional non-device host paths to bind mount into the nspawn machine. `source` is required, `target` defaults to `source`, and `readOnly` defaults to `false`. Source and target must be clean absolute paths without whitespace, control characters, or `:`. Prefer read-only mounts unless write access is required. | `[{"source":"/opt/config","target":"/etc/config","readOnly":true}]` |
 
 ## Networking
 
@@ -322,3 +323,26 @@ Add this section when you need to pin the nspawn rootfs image or use a complete 
   }
 }
 ```
+
+### Additional Host Mounts
+
+Use `bootstrap.additionalHostMounts` to expose host files or directories inside the nspawn worker. This is separate from `additionalHostDevices`, which is only for device nodes under `/dev`. The source is not required to exist during configuration validation, but it must exist when systemd-nspawn starts the machine. When `target` is omitted, the source path is also used inside the worker.
+
+```json
+{
+  "bootstrap": {
+    "additionalHostMounts": [
+      {
+        "source": "/opt/config",
+        "target": "/etc/config",
+        "readOnly": true
+      },
+      {
+        "source": "/var/lib/shared-data"
+      }
+    ]
+  }
+}
+```
+
+Read-only entries render as systemd-nspawn `BindReadOnly=` directives; writable entries render as `Bind=` directives.

--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -104,6 +104,7 @@ At least one join or Azure authentication method must be configured. `azure.boot
 | `components.containerd` | string | Optional containerd version override. | `2.0.4` |
 | `components.runc` | string | Optional runc version override. | `1.1.12` |
 | `components.sandboxImage` | string | Optional CRI sandbox/pause image used by containerd. When omitted, the shared agent default is used. | `mcr.microsoft.com/oss/kubernetes/pause:3.9` |
+| `components.gantry.disabled` | boolean | Optional breakglass setting that disables the Gantry containerd registry routing managed by the shared agent. Gantry is enabled by default when this setting or the `gantry` object is omitted. | `false` |
 
 ## Bootstrap
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff
+	github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7
+	github.com/Azure/unbounded v0.1.24-rc.7
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.1.24-rc.7
+	github.com/Azure/unbounded v0.1.24-rc.9
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d
+	github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.1.24-rc.9
+	github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.1.22
+	github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.2.0-beta.4
+	github.com/Azure/unbounded v0.2.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v8 v8.3.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute v1.2.0
 	github.com/Azure/kubelogin v0.2.15
-	github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533
+	github.com/Azure/unbounded v0.2.0-beta.4
 	github.com/go-logr/logr v1.4.3
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/Azure/unbounded v0.1.22 h1:Yvp4liCyJ6qn/YCRsLBRe41MELXMUHLSz5Sog5tOh2
 github.com/Azure/unbounded v0.1.22/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
 github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7 h1:bgZGNlAZf6gGOmaHtGCTih9IToGKoNbSj6OiuXIX48w=
 github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
+github.com/Azure/unbounded v0.1.24-rc.7 h1:nUIcTgsahEm1u8J3UQrvFgXqeO7HNAsdvfOHHmTyj0U=
+github.com/Azure/unbounded v0.1.24-rc.7/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -36,14 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmys=
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
-github.com/Azure/unbounded v0.1.22 h1:Yvp4liCyJ6qn/YCRsLBRe41MELXMUHLSz5Sog5tOh2E=
-github.com/Azure/unbounded v0.1.22/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
-github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7 h1:bgZGNlAZf6gGOmaHtGCTih9IToGKoNbSj6OiuXIX48w=
-github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
-github.com/Azure/unbounded v0.1.24-rc.7 h1:nUIcTgsahEm1u8J3UQrvFgXqeO7HNAsdvfOHHmTyj0U=
-github.com/Azure/unbounded v0.1.24-rc.7/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
-github.com/Azure/unbounded v0.1.24-rc.9 h1:1xkdeMAOYcFCtEaG5Pf35UIQBvNAR5GVcRidRsHlenY=
-github.com/Azure/unbounded v0.1.24-rc.9/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff h1:cRuPLGv6deGVKkn+r8a0liJM7LWZYGbL5dbDsNmrMP8=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmy
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
 github.com/Azure/unbounded v0.1.22 h1:Yvp4liCyJ6qn/YCRsLBRe41MELXMUHLSz5Sog5tOh2E=
 github.com/Azure/unbounded v0.1.22/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
+github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7 h1:bgZGNlAZf6gGOmaHtGCTih9IToGKoNbSj6OiuXIX48w=
+github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7 h1:bgZGNlAZf6gG
 github.com/Azure/unbounded v0.1.23-0.20260716170822-1b12f5a4a9f7/go.mod h1:yjBIx3w5y0xpmJE0Eti8LdPXYZLEwQa9oZ1fcRn6H+c=
 github.com/Azure/unbounded v0.1.24-rc.7 h1:nUIcTgsahEm1u8J3UQrvFgXqeO7HNAsdvfOHHmTyj0U=
 github.com/Azure/unbounded v0.1.24-rc.7/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.1.24-rc.9 h1:1xkdeMAOYcFCtEaG5Pf35UIQBvNAR5GVcRidRsHlenY=
+github.com/Azure/unbounded v0.1.24-rc.9/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmys=
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d h1:236G4aZCTp7NR+RDGmEFzZjwCWwuqOzmJB4y1hE6td0=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533 h1:E1dD1AnGTsGInTVpOh3VWX90cu+YxYM1HWp69NapXdY=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmys=
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff h1:cRuPLGv6deGVKkn+r8a0liJM7LWZYGbL5dbDsNmrMP8=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260722190723-1113adbed1ff/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d h1:236G4aZCTp7NR+RDGmEFzZjwCWwuqOzmJB4y1hE6td0=
+github.com/Azure/unbounded v0.2.0-beta.2.0.20260722195535-f86b0ddab56d/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmys=
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
-github.com/Azure/unbounded v0.2.0-beta.4 h1:G0nbgoirUOiasVkZeShtJaStO48LExA28jBIcvgkIgI=
-github.com/Azure/unbounded v0.2.0-beta.4/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.2.0 h1:IhLCuiA0ytIsULmSVCMWDINoKqXojw2ItMq4Pp2SngE=
+github.com/Azure/unbounded v0.2.0/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/Azure/kubelogin v0.2.15 h1:oJqD8Dvput3rO/xZgMTU+hBrcgg0BfQGPCNHJ2dEmys=
 github.com/Azure/kubelogin v0.2.15/go.mod h1:RwJS8TzSHTVQhfIZA4HLS79QGfvIp0ocIVLT5oHS/ls=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533 h1:E1dD1AnGTsGInTVpOh3VWX90cu+YxYM1HWp69NapXdY=
-github.com/Azure/unbounded v0.2.0-beta.2.0.20260723041501-08c4138bc533/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
+github.com/Azure/unbounded v0.2.0-beta.4 h1:G0nbgoirUOiasVkZeShtJaStO48LExA28jBIcvgkIgI=
+github.com/Azure/unbounded v0.2.0-beta.4/go.mod h1:BPlUc8jhOt9OW1zXKcFw6FQb9X7i/kz5K9fmm96hCqE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/pkg/cmd/preflight/preflight.go
+++ b/pkg/cmd/preflight/preflight.go
@@ -68,7 +68,7 @@ func (h *handler) execute(ctx context.Context) error {
 	}
 	log := createPreflightLogger(cfg.Agent.LogLevel)
 
-	agentCfg, gs, _, err := config.ResolveMachineGoalState(log, cfg, goalstates.NSpawnMachineKube1)
+	agentCfg, gs, _, err := config.ResolveMachineGoalState(ctx, log, cfg, goalstates.NSpawnMachineKube1)
 	if err != nil {
 		return fmt.Errorf("preflight failed to resolve goal state: %w", err)
 	}

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -75,7 +75,7 @@ func runStart(ctx context.Context, cfg *config.Config, logger *slog.Logger) erro
 		return err
 	}
 
-	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(logger, cfg, machineName)
+	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(ctx, logger, cfg, machineName)
 	if err != nil {
 		return fmt.Errorf("bootstrap failed to resolve goal state: %w", err)
 	}

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -96,9 +97,9 @@ func ToAgentConfig(cfg *Config, machineName string) *agentconfig.AgentConfig {
 // ResolveMachineGoalState converts FlexNode config to the shared agent config
 // and resolves the nspawn machine goal state. Bootstrap and preflight both use
 // this helper so preflight validates the same sources that bootstrap consumes.
-func ResolveMachineGoalState(log *slog.Logger, cfg *Config, machineName string) (*agentconfig.AgentConfig, *goalstates.MachineGoalState, *goalstates.ContainerImageArchiveStaging, error) {
+func ResolveMachineGoalState(ctx context.Context, log *slog.Logger, cfg *Config, machineName string) (*agentconfig.AgentConfig, *goalstates.MachineGoalState, *goalstates.ContainerImageArchiveStaging, error) {
 	agentCfg := ToAgentConfig(cfg, machineName)
-	downloads, containerImageArchives, err := goalstates.ResolveDownloadOverridesWithOfflineArtifacts(agentCfg, nil)
+	downloads, containerImageArchives, err := goalstates.ResolveDownloadOverridesWithOfflineArtifacts(ctx, agentCfg, nil)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("resolve download overrides: %w", err)
 	}

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -30,6 +30,7 @@ func ToAgentConfig(cfg *Config, machineName string) *agentconfig.AgentConfig {
 		NodeName:              cfg.Agent.NodeName,
 		OCIImage:              cfg.Bootstrap.OCIImage,
 		AdditionalHostDevices: cfg.Bootstrap.AdditionalHostDevices,
+		AdditionalHostMounts:  cfg.Bootstrap.AdditionalHostMounts,
 		Cluster: agentconfig.AgentClusterConfig{
 			CaCertBase64: cfg.Node.Kubelet.CACertData,
 			ClusterDNS:   cfg.Networking.DNSServiceIP,

--- a/pkg/config/adapter.go
+++ b/pkg/config/adapter.go
@@ -62,6 +62,12 @@ func ToAgentConfig(cfg *Config, machineName string) *agentconfig.AgentConfig {
 		}
 	}
 
+	if cfg.Components.Gantry != nil {
+		ac.Gantry = &agentconfig.GantryConfig{
+			Disabled: cfg.Components.Gantry.Disabled,
+		}
+	}
+
 	switch {
 	case cfg.IsBootstrapTokenConfigured():
 		ac.Kubelet.Auth.BootstrapToken = cfg.Azure.BootstrapToken.Token

--- a/pkg/config/adapter_test.go
+++ b/pkg/config/adapter_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"testing"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
 
 func TestToAgentConfig_BootstrapToken(t *testing.T) {
@@ -257,6 +259,48 @@ func TestToAgentConfig_CRICNIVersions(t *testing.T) {
 	}
 	if ac.CNI.PluginVersion != "1.6.0" {
 		t.Fatalf("CNI.PluginVersion=%q, want %q", ac.CNI.PluginVersion, "1.6.0")
+	}
+}
+
+func TestToAgentConfig_Gantry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		gantry       *GantryConfig
+		wantConfig   bool
+		wantDisabled bool
+	}{
+		{
+			name: "omitted is enabled by default",
+		},
+		{
+			name:       "explicitly enabled",
+			gantry:     &GantryConfig{},
+			wantConfig: true,
+		},
+		{
+			name:         "disabled",
+			gantry:       &GantryConfig{Disabled: true},
+			wantConfig:   true,
+			wantDisabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{Components: ComponentsConfig{Gantry: tt.gantry}}
+			ac := ToAgentConfig(cfg, "kube1")
+
+			if got := ac.Gantry != nil; got != tt.wantConfig {
+				t.Fatalf("Gantry config present=%t, want %t", got, tt.wantConfig)
+			}
+			if got := goalstates.ResolveGantry(ac.Gantry).Disabled; got != tt.wantDisabled {
+				t.Fatalf("Gantry.Disabled=%t, want %t", got, tt.wantDisabled)
+			}
+		})
 	}
 }
 

--- a/pkg/config/adapter_test.go
+++ b/pkg/config/adapter_test.go
@@ -296,6 +296,30 @@ func TestToAgentConfig_AdditionalHostDevices(t *testing.T) {
 	}
 }
 
+func TestToAgentConfig_AdditionalHostMounts(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Bootstrap: BootstrapConfig{
+			AdditionalHostMounts: []AdditionalHostMount{
+				{Source: "/opt/config", Target: "/etc/config", ReadOnly: true},
+				{Source: "/var/lib/example"},
+			},
+		},
+	}
+
+	ac := ToAgentConfig(cfg, "kube1")
+	if len(ac.AdditionalHostMounts) != 2 {
+		t.Fatalf("AdditionalHostMounts=%#v, want 2 entries", ac.AdditionalHostMounts)
+	}
+	if got := ac.AdditionalHostMounts[0]; got.Source != "/opt/config" || got.Target != "/etc/config" || !got.ReadOnly {
+		t.Fatalf("AdditionalHostMounts[0]=%#v", got)
+	}
+	if got := ac.AdditionalHostMounts[1]; got.Source != "/var/lib/example" || got.Target != "" || got.ReadOnly {
+		t.Fatalf("AdditionalHostMounts[1]=%#v", got)
+	}
+}
+
 func TestToAgentConfig_CRICNIVersionsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,7 +195,15 @@ type BootstrapConfig struct {
 	// AdditionalHostDevices lists extra host device nodes under /dev to expose to
 	// the nspawn machine in addition to devices discovered by the shared agent.
 	AdditionalHostDevices []string `json:"additionalHostDevices,omitempty"`
+
+	// AdditionalHostMounts lists non-device host paths to bind mount into the
+	// nspawn machine. Read-only mounts should be preferred unless write access is
+	// required.
+	AdditionalHostMounts []AdditionalHostMount `json:"additionalHostMounts,omitempty"`
 }
+
+// AdditionalHostMount re-exports the shared agent's host bind-mount config.
+type AdditionalHostMount = agentconfig.AdditionalHostMount
 
 // OfflineArtifactsConfig mirrors Unbounded's OfflineArtifacts bootstrap
 // setting in the AKS Flex public config shape.
@@ -631,6 +639,9 @@ func (c *BootstrapTokenConfig) validate() error {
 func (c *BootstrapConfig) validate() error {
 	if err := agentconfig.ValidateAdditionalHostDevices(c.AdditionalHostDevices); err != nil {
 		return fmt.Errorf("invalid bootstrap.additionalHostDevices: %w", err)
+	}
+	if err := agentconfig.ValidateAdditionalHostMounts(c.AdditionalHostMounts); err != nil {
+		return fmt.Errorf("invalid bootstrap.additionalHostMounts: %w", err)
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,10 +174,18 @@ type MachineClientConfig struct {
 // ComponentsConfig is the AKS RP component version contract used by the agent
 // at runtime.
 type ComponentsConfig struct {
-	Kubernetes   string `json:"kubernetes,omitempty"`
-	Containerd   string `json:"containerd,omitempty"`
-	Runc         string `json:"runc,omitempty"`
-	SandboxImage string `json:"sandboxImage,omitempty"`
+	Kubernetes   string        `json:"kubernetes,omitempty"`
+	Containerd   string        `json:"containerd,omitempty"`
+	Runc         string        `json:"runc,omitempty"`
+	SandboxImage string        `json:"sandboxImage,omitempty"`
+	Gantry       *GantryConfig `json:"gantry,omitempty"`
+}
+
+// GantryConfig holds optional Gantry integration settings.
+type GantryConfig struct {
+	// Disabled opts out of the Gantry containerd registry routing that the
+	// shared agent enables by default.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // BootstrapConfig holds bootstrap settings that are not Kubernetes component

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -808,7 +808,10 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 			"kubernetes": "1.29.0",
 			"containerd": "2.0.5",
 			"runc": "1.2.3",
-			"sandboxImage": "registry.example.test/pause:3.9"
+			"sandboxImage": "registry.example.test/pause:3.9",
+			"gantry": {
+				"disabled": true
+			}
 		},
 		"bootstrap": {
 			"ociImage": "registry.example.test/flex/rootfs:ubuntu-24.04",
@@ -868,6 +871,9 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 	if len(cfg.Node.Taints) != 1 || cfg.Node.Taints[0] != "dedicated=flexnode:NoSchedule" {
 		t.Fatalf("Node.Taints = %#v, want dedicated=flexnode:NoSchedule", cfg.Node.Taints)
 	}
+	if cfg.Components.Gantry == nil || !cfg.Components.Gantry.Disabled {
+		t.Fatalf("Components.Gantry = %#v, want disabled", cfg.Components.Gantry)
+	}
 
 	agentCfg := ToAgentConfig(cfg, "flex-node-1")
 	if agentCfg.Cluster.Version != "1.29.0" {
@@ -881,6 +887,9 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 	}
 	if agentCfg.CRI.Containerd.SandboxImage != "registry.example.test/pause:3.9" {
 		t.Fatalf("Agent CRI.Containerd.SandboxImage = %q, want registry.example.test/pause:3.9", agentCfg.CRI.Containerd.SandboxImage)
+	}
+	if agentCfg.Gantry == nil || !agentCfg.Gantry.Disabled {
+		t.Fatalf("Agent Gantry = %#v, want disabled", agentCfg.Gantry)
 	}
 	if agentCfg.OCIImage != "registry.example.test/flex/rootfs:ubuntu-24.04" {
 		t.Fatalf("Agent OCIImage = %q, want registry.example.test/flex/rootfs:ubuntu-24.04", agentCfg.OCIImage)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -812,10 +812,11 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 		},
 		"bootstrap": {
 			"ociImage": "registry.example.test/flex/rootfs:ubuntu-24.04",
-			"additionalHostDevices": ["/dev/uinput", "/dev/input/event0"]
-		},
-		"bootstrap": {
-			"additionalHostDevices": ["/dev/uinput", "/dev/input/event0"]
+			"additionalHostDevices": ["/dev/uinput", "/dev/input/event0"],
+			"additionalHostMounts": [
+				{"source": "/opt/config", "target": "/etc/config", "readOnly": true},
+				{"source": "/var/lib/example"}
+			]
 		},
 		"networking": {
 			"dnsServiceIP": "10.42.0.10",
@@ -890,8 +891,14 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 	if agentCfg.CRI.Runc.Version != "1.2.3" {
 		t.Fatalf("Agent CRI.Runc.Version = %q, want 1.2.3", agentCfg.CRI.Runc.Version)
 	}
-	if len(agentCfg.AdditionalHostDevices) != 2 || agentCfg.AdditionalHostDevices[0] != "/dev/uinput" || agentCfg.AdditionalHostDevices[1] != "/dev/input/event0" {
-		t.Fatalf("Agent AdditionalHostDevices = %#v", agentCfg.AdditionalHostDevices)
+	if len(agentCfg.AdditionalHostMounts) != 2 {
+		t.Fatalf("Agent AdditionalHostMounts = %#v, want 2 entries", agentCfg.AdditionalHostMounts)
+	}
+	if got := agentCfg.AdditionalHostMounts[0]; got.Source != "/opt/config" || got.Target != "/etc/config" || !got.ReadOnly {
+		t.Fatalf("Agent AdditionalHostMounts[0] = %#v", got)
+	}
+	if got := agentCfg.AdditionalHostMounts[1]; got.Source != "/var/lib/example" || got.Target != "" || got.ReadOnly {
+		t.Fatalf("Agent AdditionalHostMounts[1] = %#v", got)
 	}
 	if agentCfg.CNI.PluginVersion != "1.5.1" {
 		t.Fatalf("Agent CNI.PluginVersion = %q, want 1.5.1", agentCfg.CNI.PluginVersion)
@@ -943,6 +950,55 @@ func TestLoadConfigRejectsInvalidAdditionalHostDevice(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bootstrap.additionalHostDevices") {
 		t.Fatalf("LoadConfig() error = %v, want bootstrap.additionalHostDevices", err)
+	}
+}
+
+func TestBootstrapConfigValidatesAdditionalHostMounts(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		mounts  []AdditionalHostMount
+		wantErr string
+	}{
+		"valid read-only mount": {
+			mounts: []AdditionalHostMount{{Source: "/opt/config", Target: "/etc/config", ReadOnly: true}},
+		},
+		"valid nonexistent source with omitted target": {
+			mounts: []AdditionalHostMount{{Source: "/path/does/not/need/to/exist"}},
+		},
+		"relative source": {
+			mounts:  []AdditionalHostMount{{Source: "opt/config"}},
+			wantErr: "bootstrap.additionalHostMounts",
+		},
+		"unclean source": {
+			mounts:  []AdditionalHostMount{{Source: "/opt/../config"}},
+			wantErr: "clean absolute path",
+		},
+		"target with whitespace": {
+			mounts:  []AdditionalHostMount{{Source: "/opt/config", Target: "/etc/my config"}},
+			wantErr: "must not contain whitespace",
+		},
+		"target with colon": {
+			mounts:  []AdditionalHostMount{{Source: "/opt/config", Target: "/etc/config:bad"}},
+			wantErr: "must not contain whitespace, control characters, or ':'",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := (&BootstrapConfig{AdditionalHostMounts: tt.mounts}).validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("BootstrapConfig.validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("BootstrapConfig.validate() error = %v, want %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/pkg/config/copy_test.go
+++ b/pkg/config/copy_test.go
@@ -13,6 +13,7 @@ func TestConfigDeepCopy_DoesNotSharePointersOrMaps(t *testing.T) {
 			TargetCluster:    &TargetClusterConfig{ResourceID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster", Location: "eastus"},
 			Arc:              &ArcConfig{Enabled: true, MachineName: "m", Location: "eastus", ResourceGroup: "rg", Tags: map[string]string{"k": "v"}},
 		},
+		Components: ComponentsConfig{Gantry: &GantryConfig{Disabled: true}},
 		Node: NodeConfig{
 			Labels: map[string]string{"l": "1"},
 			Taints: []string{"dedicated=infra:NoSchedule"},
@@ -42,6 +43,9 @@ func TestConfigDeepCopy_DoesNotSharePointersOrMaps(t *testing.T) {
 	}
 	if cfg.Azure.Arc == nil || copy.Azure.Arc == nil || cfg.Azure.Arc == copy.Azure.Arc {
 		t.Fatalf("Arc pointer shared or nil")
+	}
+	if cfg.Components.Gantry == nil || copy.Components.Gantry == nil || cfg.Components.Gantry == copy.Components.Gantry {
+		t.Fatalf("Gantry pointer shared or nil")
 	}
 
 	// Maps should not be shared (validate via independent mutation behavior).

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -104,6 +104,7 @@ func (o *nspawnNodeOperator) ApplyGoalState(ctx context.Context, log *slog.Logge
 
 	tasks := phases.Serial(log,
 		nodestop.StopNode(log, oldMachine),
+		reset.CleanupNetwork(log),
 		StartNode(cfg, log, newMachine, gs, containerImageArchives, o.state, newState),
 		reset.CleanupMachine(log, oldMachine),
 	)

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -42,7 +42,7 @@ func (o *nspawnNodeOperator) RestartNode(ctx context.Context, log *slog.Logger) 
 	if active.State.AppliedKubernetesVersion != "" {
 		cfg.Components.Kubernetes = active.State.AppliedKubernetesVersion
 	}
-	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(log, cfg, active.Name)
+	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(ctx, log, cfg, active.Name)
 	if err != nil {
 		return fmt.Errorf("resolve goal state for node restart: %w", err)
 	}
@@ -96,7 +96,7 @@ func (o *nspawnNodeOperator) ApplyGoalState(ctx context.Context, log *slog.Logge
 		"kubernetesVersion", cfg.Components.Kubernetes,
 	)
 
-	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(log, cfg, newMachine)
+	_, gs, containerImageArchives, err := config.ResolveMachineGoalState(ctx, log, cfg, newMachine)
 	if err != nil {
 		return nil, fmt.Errorf("resolve goal state for repave: %w", err)
 	}


### PR DESCRIPTION
## Summary

- upgrade `github.com/Azure/unbounded` from `v0.1.22` to `v0.2.0`, including the context-aware goal-state and offline archive resolution APIs
- clean up stale Unbounded network interfaces and routes after stopping the old nspawn machine and before starting its replacement during repave
- add `bootstrap.additionalHostMounts` support with shared validation, agent adaptation, tests, and configuration documentation
- add `components.gantry.disabled` as a break-glass option while preserving Gantry as enabled by default

## Testing

- `make check`
- `go test ./...`

## Related

- Azure/unbounded#489
- Azure/unbounded#493
