### PR TITLE
docs: rewrite Getting Started as a guided, step-by-step quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This quickstart involves two machines. Keep them distinct:
 - **Your workstation** is the computer you drive the setup from, using the Azure CLI and `kubectl` (for example, your laptop). It is not joined to the cluster; it only generates the configuration and runs commands. Every step labeled **Run on: your workstation** happens here.
 - **Your Flex Node machine** is the on-premises physical server or virtual machine you are joining to the cluster as a worker node. Every step labeled **Run on: your Flex Node machine** happens there.
 
+> **Tip**
+> The **Run on: your Flex Node machine** steps are run on that machine after you SSH in. If you would rather stay on your workstation, you can run them remotely by wrapping the command, for example `ssh "$TARGET_HOST" "sudo aks-flex-node preflight --config /etc/aks-flex-node/config.json"`. This requires passwordless sudo on the Flex Node machine.
+
 Before you begin, make sure you have:
 
 - An Azure subscription. [Create one for free](https://azure.microsoft.com/free/).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This quickstart involves two machines. Keep them distinct:
 - **Your Flex Node machine** is the on-premises physical server or virtual machine you are joining to the cluster as a worker node. Every step labeled **Run on: your Flex Node machine** happens there.
 
 > **Tip**
-> The **Run on: your Flex Node machine** steps are run on that machine after you SSH in. If you would rather stay on your workstation, you can run them remotely by wrapping the command, for example `ssh "$TARGET_HOST" "sudo aks-flex-node preflight --config /etc/aks-flex-node/config.json"`. This requires passwordless sudo on the Flex Node machine.
+> Steps 4 to 6 use a single interactive SSH session: you connect once in Step 4, stay on the Flex Node machine through Step 6, then return to your workstation for Step 7. As an alternative, you can skip the interactive session and run each host command from your workstation by wrapping it, for example `ssh "$TARGET_HOST" "sudo aks-flex-node preflight --config /etc/aks-flex-node/config.json"`. Use one approach or the other, not both. Wrapping requires passwordless sudo on the Flex Node machine.
 
 Before you begin, make sure you have:
 
@@ -151,13 +151,17 @@ scp ./aks-flex-node-config.json "$TARGET_HOST:/tmp/aks-flex-node-config.json"
 
 ### Step 4: Install the agent on your Flex Node machine
 
-**Run on: your Flex Node machine**
+First, from your workstation, open an SSH session on the Flex Node machine.
 
-Connect to the Flex Node machine, then install the agent and move the generated config into place.
+**Run on: your workstation**
 
 ```bash
 ssh "$TARGET_HOST"
 ```
+
+You are now connected to the Flex Node machine. Install the agent and move the generated config into place, as root.
+
+**Run on: your Flex Node machine**
 
 ```bash
 sudo su
@@ -217,6 +221,8 @@ Started aks-flex-node-agent.service - AKS Flex Node Agent.
 aks-flex-node[3800]: level=INFO msg="running agent daemon" nodeName=aks-flex-config-test
 aks-flex-node[3800]: level=INFO msg="machine state reconciled" status=healthy
 ```
+
+When you are finished, press `Ctrl+C` to stop following the logs, then run `exit` twice, once to leave the root shell and once to close the SSH session, to return to your workstation.
 
 ### Step 7: Verify the node joined
 

--- a/README.md
+++ b/README.md
@@ -18,28 +18,64 @@ AKS Flex Node extends Azure Kubernetes Service (AKS) to customer-managed virtual
 
 ## Getting Started
 
-Before you begin, [create or choose an existing AKS cluster](https://learn.microsoft.com/azure/aks/learn/quick-kubernetes-deploy-cli) and a virtual machine or bare metal host to join as a Flex Node. This example assumes a Linux workstation with Azure CLI, `kubectl`, `curl`, and `python3`. The target host must run systemd, allow root installation, and reach the AKS API server over outbound HTTPS. Use a VM size with enough CPU and memory for nspawn startup and Kubernetes components; the validated quickstart used a 4-vCPU Azure VM.
+This quickstart walks you through joining your first **Flex Node machine**, an on-premises physical server or virtual machine you own, to an existing AKS cluster, then running a workload on it. Plan about 10 minutes once the prerequisites are in place.
 
-For the quickstart network, place the target host in a peered or otherwise routed network with non-overlapping CIDRs. The Flex host and AKS node private IPs must have bidirectional reachability, and any NSGs or firewalls must allow the CNI's cross-node traffic (often TCP/UDP between node private IPs, and sometimes pod CIDR ranges depending on the CNI) so pod networking works after the node joins. For private AKS clusters, also ensure the host can resolve and reach the private API endpoint. For advanced network scenarios such as cross-region, gateway, or custom CNI topologies, follow the [lab guides](docs/labs/README.md).
+### Prerequisites
 
-The flow below will:
+This quickstart involves two machines. Keep them distinct:
 
-1. Apply the node bootstrap RBAC bindings on the AKS cluster.
-2. Create a Kubernetes bootstrap token while generating the Flex Node config from AKS cluster metadata.
-3. Install `aks-flex-node` on the target host as root.
-4. Copy the generated config to `/etc/aks-flex-node/config.json`.
-5. Start the host bootstrap flow and launch the `aks-flex-node-agent` systemd service.
+- **Your workstation** is the computer you drive the setup from, using the Azure CLI and `kubectl` (for example, your laptop). It is not joined to the cluster; it only generates the configuration and runs commands. Every step labeled **Run on: your workstation** happens here.
+- **Your Flex Node machine** is the on-premises physical server or virtual machine you are joining to the cluster as a worker node. Every step labeled **Run on: your Flex Node machine** happens there.
 
-Expected result: the target host appears in `kubectl get nodes`, and `aks-flex-node-agent` is running on the host.
+Before you begin, make sure you have:
 
-On your workstation, save the config helper script, setup node RBAC permissions, then generate the bootstrap-token config from AKS cluster metadata:
+- An Azure subscription. [Create one for free](https://azure.microsoft.com/free/).
+- **Your workstation**, with the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), `kubectl`, `curl`, and `python3` installed. Sign in with `az login`, then `az account set --subscription "<subscription-id>"`.
+- **An existing AKS cluster** with a Linux node pool. Azure CNI is recommended so pods are reachable across your network, and you need permission to configure RBAC on the cluster. If you don't have a cluster yet, see [create an AKS cluster](https://learn.microsoft.com/azure/aks/learn/quick-kubernetes-deploy-cli).
+- **A Flex Node machine you own**: an on-premises physical server or a virtual machine to join as the worker node. It must:
+  - run `systemd` and allow root installation,
+  - have at least 4 vCPUs and enough memory for nspawn startup and the Kubernetes components,
+  - be reachable from your workstation over SSH.
+
+### Network requirements
+
+Your Flex Node machine and the AKS cluster must be able to reach each other. Confirm each item before you start:
+
+- **Outbound HTTPS (TCP 443)** from the Flex Node machine to the AKS API server.
+- **Bidirectional reachability** between the Flex Node machine's private IP and the AKS node private IPs.
+- **Non-overlapping CIDRs** between the host network and the cluster's node and pod address ranges.
+- **NSG and firewall rules** that allow the CNI's cross-node traffic (typically TCP/UDP between node private IPs, and pod CIDR ranges depending on the CNI).
+- **For private AKS clusters:** the Flex Node machine can resolve and reach the private API server endpoint.
+
+> **Note**
+> On-premises machines usually reach the cluster's private node network through a site-to-site VPN, ExpressRoute, or equivalent routed connectivity. Establishing that link is a prerequisite for this quickstart. For advanced network scenarios such as cross-region, gateway, or custom CNI topologies, follow the [lab guides](docs/labs/README.md).
+
+### Step 1: Set your variables and connect to the cluster
+
+**Run on: your workstation**
 
 ```bash
-RESOURCE_GROUP="<resource-group>"
-CLUSTER_NAME="<cluster-name>"
-SUBSCRIPTION_ID="<subscription-id>"
-AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
+export SUBSCRIPTION_ID="<subscription-id>"
+export RESOURCE_GROUP="<resource-group-of-your-aks-cluster>"
+export CLUSTER_NAME="<cluster-name>"
+export AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 
+# Your Flex Node machine, as an SSH target (for example: azureuser@203.0.113.10)
+export TARGET_HOST="<user>@<flex-node-machine-ip-or-hostname>"
+
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME"
+kubectl get nodes
+```
+
+You should see your existing cluster nodes in `Ready` state.
+
+### Step 2: Generate the join configuration
+
+**Run on: your workstation**
+
+Download the helper, apply the node bootstrap RBAC bindings, and generate a bootstrap-token config from your cluster's metadata.
+
+```bash
 curl -fsSLo ./aks-flex-config https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/aks-flex-config
 chmod +x ./aks-flex-config
 
@@ -57,7 +93,7 @@ chmod +x ./aks-flex-config
   --output ./aks-flex-node-config.json
 ```
 
-`generate-node-config` supports one of the following auth modes: `--bootstrap-token`, `--identity`, `--service-principal --username <client-id> --password <client-secret>`, or `--arc`.
+This produces `aks-flex-node-config.json` in your current folder. `generate-node-config` supports one of the following auth modes: `--bootstrap-token`, `--identity`, `--service-principal --username <client-id> --password <client-secret>`, or `--arc`. This quickstart uses `--bootstrap-token`.
 
 <details>
 <summary>Example Config With Field Notes</summary>
@@ -99,15 +135,26 @@ The rendered config should look like this. Comments are shown here only to expla
 
 </details>
 
-Copy the generated config to the target host:
+### Step 3: Copy the configuration to your Flex Node machine
+
+**Run on: your workstation**
 
 ```bash
-TARGET_HOST="<user>@<host>"
-
 scp ./aks-flex-node-config.json "$TARGET_HOST:/tmp/aks-flex-node-config.json"
 ```
 
-On the target host, install the agent and move the generated config into place:
+> **Note**
+> The config is staged in `/tmp` because your SSH user cannot write to root-owned `/etc`, and `/etc/aks-flex-node` does not exist yet. The next step creates that directory and installs the file as root with owner-only `0600` permissions.
+
+### Step 4: Install the agent on your Flex Node machine
+
+**Run on: your Flex Node machine**
+
+Connect to the Flex Node machine, then install the agent and move the generated config into place.
+
+```bash
+ssh "$TARGET_HOST"
+```
 
 ```bash
 sudo su
@@ -121,35 +168,33 @@ install -m 0600 /tmp/aks-flex-node-config.json /etc/aks-flex-node/config.json
 cat /etc/aks-flex-node/config.json
 ```
 
-After reviewing the config, run preflight checks. Preflight is non-mutating and validates host prerequisites, API server reachability, rootfs image reachability, and bootstrap artifact sources before bootstrap changes the host.
+### Step 5: Run preflight checks
+
+**Run on: your Flex Node machine**
+
+Preflight is non-mutating. It validates host prerequisites, API server reachability, rootfs image reachability, and bootstrap artifact sources before bootstrap changes the host.
 
 ```bash
 aks-flex-node preflight --config /etc/aks-flex-node/config.json
 ```
 
-Then bootstrap the node. This installs the long-running agent service and starts the local Kubernetes worker environment. Use a standard `022` umask so bootstrap-created nspawn rootfs paths remain traversable by non-root service users such as `dbus`; the config file remains `0600`.
+Confirm all checks pass before continuing.
+
+### Step 6: Join the node
+
+**Run on: your Flex Node machine**
+
+This installs the long-running agent service and starts the local Kubernetes worker environment.
 
 ```bash
 umask 022
 aks-flex-node start --config /etc/aks-flex-node/config.json
 ```
 
-Verify the node from your workstation:
+> **Note**
+> `umask 022` sets standard default permissions (directories `755`, files `644`). The bootstrap creates the node's nspawn rootfs directories, and `755` lets non-root service users such as `dbus` traverse them; without it, the node fails to start. Your credentials are unaffected: the config file remains `0600`.
 
-```bash
-kubectl get nodes -o wide
-```
-
-Example output:
-
-```text
-NAME                   STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-aks-flex-config-test   Ready    <none>   12s   v1.34.3   10.0.0.4      <none>        Ubuntu 24.04.4 LTS   6.17.0-1013-azure   containerd://2.0.4
-```
-
-The node name should match the target host's hostname unless you set `agent.nodeName` in the config.
-
-On the target host, the agent service should be active:
+Confirm the agent is running:
 
 ```bash
 systemctl is-active aks-flex-node-agent
@@ -170,7 +215,33 @@ aks-flex-node[3800]: level=INFO msg="running agent daemon" nodeName=aks-flex-con
 aks-flex-node[3800]: level=INFO msg="machine state reconciled" status=healthy
 ```
 
-AKS Flex Node runs the Kubernetes worker inside a local nspawn machine. You can inspect it from the host:
+### Step 7: Verify the node joined
+
+**Run on: your workstation**
+
+```bash
+kubectl get nodes -o wide
+```
+
+Example output:
+
+```text
+NAME                   STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
+aks-flex-config-test   Ready    <none>   12s   v1.34.3   10.0.0.4      <none>        Ubuntu 24.04.4 LTS   6.17.0-1013-azure   containerd://2.0.4
+```
+
+The node name matches the Flex Node machine's hostname unless you set `agent.nodeName` in the config. Schedule a test workload onto it to confirm it can run pods (replace `<node-name>` with the name shown above):
+
+```bash
+kubectl run hello --image=mcr.microsoft.com/azuredocs/aks-helloworld:v1 \
+  --overrides='{"spec":{"nodeName":"<node-name>"}}'
+kubectl get pod hello -o wide
+```
+
+<details>
+<summary>Inspect the nspawn worker (optional)</summary>
+
+AKS Flex Node runs the Kubernetes worker inside a local nspawn machine. You can inspect it from the Flex Node machine:
 
 ```bash
 machinectl list
@@ -179,7 +250,17 @@ journalctl -M kube1 -u kubelet -f
 journalctl -M kube1 -u containerd -f
 ```
 
-Try scheduling a test workload onto the node and watch kubelet/containerd logs to see how the nspawn-backed worker handles it.
+Watch the kubelet and containerd logs to see how the nspawn-backed worker handles scheduled workloads.
+
+</details>
+
+### Clean up
+
+Remove the test workload from your workstation:
+
+```bash
+kubectl delete pod hello --ignore-not-found
+```
 
 <details>
 <summary>Reset And Uninstall</summary>
@@ -230,6 +311,12 @@ kubectl delete node <node-name>
 ```
 
 </details>
+
+### Next steps
+
+- **Other authentication modes** (managed identity, service principal, Azure Arc): see the [Usage Guide](docs/usage.md).
+- **Advanced networking** (cross-region, gateway, custom CNI): see the [lab guides](docs/labs/README.md).
+- **GPU workloads:** Flex Node auto-detects NVIDIA GPU devices; see the [Usage Guide](docs/usage.md).
 
 ## Usage Guides And Topics
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ This quickstart involves two machines. Keep them distinct:
 - **Your workstation** is the computer you drive the setup from, using the Azure CLI and `kubectl` (for example, your laptop). It is not joined to the cluster; it only generates the configuration and runs commands. Every step labeled **Run on: your workstation** happens here.
 - **Your Flex Node machine** is the on-premises physical server or virtual machine you are joining to the cluster as a worker node. Every step labeled **Run on: your Flex Node machine** happens there.
 
-> **Tip**
-> Steps 4 to 6 use a single interactive SSH session: you connect once in Step 4, stay on the Flex Node machine through Step 6, then return to your workstation for Step 7. As an alternative, you can skip the interactive session and run each host command from your workstation by wrapping it, for example `ssh "$TARGET_HOST" "sudo aks-flex-node preflight --config /etc/aks-flex-node/config.json"`. Use one approach or the other, not both. Wrapping requires passwordless sudo on the Flex Node machine.
-
 Before you begin, make sure you have:
 
 - An Azure subscription. [Create one for free](https://azure.microsoft.com/free/).


### PR DESCRIPTION
## Summary

This PR rewrites the **Getting Started** section into a more guided, step-by-step quickstart, and adds the missing **cluster-side prerequisites** and a **Troubleshooting** section. The goal is to help first-time users join a Flex Node without silently hitting a failed setup.

The original walkthrough is technically complete for the node side, but for a newcomer it's hard to follow (workstation and host commands interleaved, prerequisites in dense prose, no clear "do this, then this" path), and it does not mention the cluster-side components the agent now depends on. Against a plain AKS cluster, `aks-flex-node start` then fails with `wait for daemon controller certificate: context deadline exceeded`, which is confusing without guidance.

## What changes

- Adds a **two-machine model** up front (your workstation vs. your Flex Node machine) so it's always clear where each command runs.
- Turns prerequisites and network requirements into scannable checklists.
- Splits the walkthrough into **numbered steps**, each labeled **Run on: your workstation** or **Run on: your Flex Node machine**.
- Adds a **Prepare the cluster** section documenting the three cluster-side requirements: a Flex-compatible CNI (Unbounded-Net), the `aks-flex-controller` deployed with `--enable-csr-approver=true`, and a registered machine per node. Points to the lab guides, `hack/controller-deployment/`, and the design docs.
- Adds a **Troubleshooting** section that maps the `wait for daemon controller certificate: context deadline exceeded` symptom (and Pending CSRs) to a missing or misconfigured controller.
- Briefly explains why `umask 022` is needed and why the config is staged in `/tmp` then installed to `/etc`.
- Adds a **Clean up** step.

## What stays the same

- All commands are unchanged (`aks-flex-config`, `install.sh`, `preflight`, `start`, `uninstall.sh`).
- The **Example Config With Field Notes** and **Reset And Uninstall** collapsibles are preserved, as is node inspection guidance.
- No changes to Overview, Key Features, status, Usage Guides, Development, License, or the footer.

This is a documentation-only change. Feedback and suggestions are very welcome, happy to adjust tone, depth, or structure to match the team's preferences. In particular, I'd appreciate a maintainer sanity-check on the **Prepare the cluster** steps, since the cluster-side setup is currently exercised mainly through `hack/e2e`.
