### PR TITLE
docs: add cluster prerequisites and troubleshooting for node join

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ Your Flex Node machine and the AKS cluster must be able to reach each other. Con
 > **Note**
 > On-premises machines usually reach the cluster's private node network through a site-to-site VPN, ExpressRoute, or equivalent routed connectivity. Establishing that link is a prerequisite for this quickstart. For advanced network scenarios such as cross-region, gateway, or custom CNI topologies, follow the [lab guides](docs/labs/README.md).
 
+### Prepare the cluster
+
+Before you join any nodes, the target AKS cluster must be set up with the Flex Node cluster-side components. A plain AKS cluster does **not** have them, and `aks-flex-node start` (Step 6) will hang, then fail with `wait for daemon controller certificate: context deadline exceeded` (see [Troubleshooting](#troubleshooting)).
+
+> **Note**
+> AKS Flex Node is alpha. Automatic cluster preparation through the AKS resource provider is not yet available, so today you prepare the cluster yourself. The [lab guides](docs/labs/README.md) provide a fully validated end-to-end setup and are the recommended path.
+
+The cluster needs three things:
+
+1. **A Flex-compatible CNI.** A default AKS CNI does not route pod traffic to Flex nodes. The validated CNI is [Unbounded-Net](https://github.com/Azure/unbounded); the [lab guides](docs/labs/README.md) create the cluster with `--network-plugin none` and install it.
+2. **The AKS Flex Controller** in `kube-system`, with the CSR approver enabled. It approves each node's daemon certificate and serves machine goal state. Deploy it from [`hack/controller-deployment/`](hack/controller-deployment/), ensuring the deployment runs with `--enable-csr-approver=true` (the checked-in manifest defaults to `false`):
+
+   ```bash
+   kubectl apply -k hack/controller-deployment/
+   kubectl -n kube-system rollout status deployment/aks-flex-controller
+   ```
+3. **A registered machine for each node.** The controller only approves a node whose machine is pre-registered in the `kube-system/aks-flex-machines` ConfigMap, keyed by node name. See [`docs/design/in-cluster-machine.md`](docs/design/in-cluster-machine.md) for the machine JSON shape and `hack/e2e/` for a working reference.
+
+For the fully scripted version of all of the above, run `hack/e2e/run.sh infra`.
+
 ### Step 1: Set your variables and connect to the cluster
 
 **Run on: your workstation**
@@ -317,6 +337,25 @@ kubectl delete node <node-name>
 ```
 
 </details>
+
+### Troubleshooting
+
+**`aks-flex-node start` hangs, then fails with `wait for daemon controller certificate: context deadline exceeded`.**
+
+The node's daemon requested a certificate that nothing approved. This almost always means the cluster side is not fully prepared (see [Prepare the cluster](#prepare-the-cluster)). Check, from your workstation:
+
+```bash
+# Is the controller running?
+kubectl -n kube-system get deployment aks-flex-controller
+
+# Are daemon CSRs stuck Pending? (signer: kubernetes.io/kube-apiserver-client)
+kubectl get csr
+
+# Is this node registered as a machine?
+kubectl -n kube-system get configmap aks-flex-machines -o json | jq -r '.data | keys[]?'
+```
+
+If the controller is missing, the CSR approver is disabled (`--enable-csr-approver=false`), or the node has no machine entry, the daemon certificate is never issued and the agent times out.
 
 ### Next steps
 

--- a/README.md
+++ b/README.md
@@ -52,23 +52,10 @@ Your Flex Node machine and the AKS cluster must be able to reach each other. Con
 
 ### Prepare the cluster
 
-Before you join any nodes, the target AKS cluster must be set up with the Flex Node cluster-side components. A plain AKS cluster does **not** have them, and `aks-flex-node start` (Step 6) will hang, then fail with `wait for daemon controller certificate: context deadline exceeded` (see [Troubleshooting](#troubleshooting)).
+Before joining a node, prepare the target AKS cluster by following the [operator guide](docs/usages/operator-first-boot.md). It covers the FlexNodes pool, Unbounded networking, identity, RBAC, and node registration requirements that are not present on a standard AKS cluster.
 
 > **Note**
-> AKS Flex Node is alpha. Automatic cluster preparation through the AKS resource provider is not yet available, so today you prepare the cluster yourself. The [lab guides](docs/labs/README.md) provide a fully validated end-to-end setup and are the recommended path.
-
-The cluster needs three things:
-
-1. **A Flex-compatible CNI.** A default AKS CNI does not route pod traffic to Flex nodes. The validated CNI is [Unbounded-Net](https://github.com/Azure/unbounded); the [lab guides](docs/labs/README.md) create the cluster with `--network-plugin none` and install it.
-2. **The AKS Flex Controller** in `kube-system`, with the CSR approver enabled. It approves each node's daemon certificate and serves machine goal state. Deploy it from [`hack/controller-deployment/`](hack/controller-deployment/), ensuring the deployment runs with `--enable-csr-approver=true` (the checked-in manifest defaults to `false`):
-
-   ```bash
-   kubectl apply -k hack/controller-deployment/
-   kubectl -n kube-system rollout status deployment/aks-flex-controller
-   ```
-3. **A registered machine for each node.** The controller only approves a node whose machine is pre-registered in the `kube-system/aks-flex-machines` ConfigMap, keyed by node name. See [`docs/design/in-cluster-machine.md`](docs/design/in-cluster-machine.md) for the machine JSON shape and `hack/e2e/` for a working reference.
-
-For the fully scripted version of all of the above, run `hack/e2e/run.sh infra`.
+> The controller under `hack/controller-deployment/` is for E2E and development environments. Do not deploy it as part of the user quickstart.
 
 ### Step 1: Set your variables and connect to the cluster
 
@@ -340,22 +327,26 @@ kubectl delete node <node-name>
 
 ### Troubleshooting
 
-**`aks-flex-node start` hangs, then fails with `wait for daemon controller certificate: context deadline exceeded`.**
+**The node joins, but `aks-flex-node-agent` is restarting.**
 
-The node's daemon requested a certificate that nothing approved. This almost always means the cluster side is not fully prepared (see [Prepare the cluster](#prepare-the-cluster)). Check, from your workstation:
+Kubelet bootstrap and daemon authentication are separate. The Kubernetes node can become `Ready` while the long-running agent waits for approval of its daemon CSR.
+
+On the Flex Node machine:
 
 ```bash
-# Is the controller running?
-kubectl -n kube-system get deployment aks-flex-controller
-
-# Are daemon CSRs stuck Pending? (signer: kubernetes.io/kube-apiserver-client)
-kubectl get csr
-
-# Is this node registered as a machine?
-kubectl -n kube-system get configmap aks-flex-machines -o json | jq -r '.data | keys[]?'
+systemctl status aks-flex-node-agent
+journalctl -u aks-flex-node-agent --no-pager -n 200
 ```
 
-If the controller is missing, the CSR approver is disabled (`--enable-csr-approver=false`), or the node has no machine entry, the daemon certificate is never issued and the agent times out.
+From your workstation:
+
+```bash
+kubectl get csr
+```
+
+When the AKS Flex CSR approver is not available, inspect and manually approve the daemon CSR using the procedure in [Approve the daemon CSR when required](docs/usages/operator-first-boot.md#7-approve-the-daemon-csr-when-required).
+
+Manual approval is a temporary preview fallback. Verify that the CSR belongs to the expected node before approving it.
 
 ### Next steps
 


### PR DESCRIPTION
## Summary

Follow-up to #244. That PR rewrote **Getting Started** into a guided quickstart for the node side. This PR adds the **cluster-side** setup that the node steps depend on, plus a **Troubleshooting** section.

Today the docs walk a user through `generate-node-config` → `install` → `start`, but they don't mention the cluster-side components the agent needs. Against a plain AKS cluster, `aks-flex-node start` hangs and then fails with:

```
Error: create daemon credential provider: wait for daemon controller certificate: context deadline exceeded
```

The cause is that nothing approves the node's daemon certificate: the in-cluster `aks-flex-controller` (CSR approver) isn't deployed, or the machine isn't registered. The daemon CSRs (`kubernetes.io/kube-apiserver-client`) sit `Pending` and the agent times out.

## What this PR adds

- **Prepare the cluster** section, placed before the node steps, covering the three cluster-side requirements:
  1. a Flex-compatible CNI (Unbounded-Net), with a pointer to the lab guides;
  2. the `aks-flex-controller` deployed in `kube-system` with `--enable-csr-approver=true` (the checked-in manifest defaults to `false`), including the `kubectl apply -k hack/controller-deployment/` command;
  3. a registered machine per node in the `kube-system/aks-flex-machines` ConfigMap, pointing to `docs/design/in-cluster-machine.md` and `hack/e2e/`.
- **Troubleshooting** section that maps the certificate-timeout symptom and Pending CSRs to a missing or misconfigured controller, with the exact `kubectl` checks.

Documentation only; no code or command changes. Since the cluster-side setup is currently exercised mainly through `hack/e2e`, I'd welcome a maintainer sanity-check on the **Prepare the cluster** steps, and any preference on whether this belongs in the README quickstart or the lab guides.
