### PR TITLE
Add Go first-boot orchestration command

### DIFF
--- a/cmd/aks-flex-node/main.go
+++ b/cmd/aks-flex-node/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/AKSFlexNode/pkg/cmd/bootstrap"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/daemon"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/preflight"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/reset"
@@ -25,6 +26,7 @@ func main() {
 		Long:  "Azure Kubernetes Service Flex Node Agent for edge computing scenarios",
 	}
 
+	rootCmd.AddCommand(bootstrap.NewCommand())
 	rootCmd.AddCommand(start.NewCommand())
 	rootCmd.AddCommand(preflight.NewCommand())
 	rootCmd.AddCommand(daemon.NewCommand())

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,7 @@ This section collects scenario-focused guides for installing, joining, operating
 ## Guides
 
 - [Joining Nodes](usages/joining-nodes.md) - Join a host to AKS using bootstrap token, managed identity, Azure Arc, or service principal authentication.
+- [`aks-flex-node boot`](usages/boot-command.md) - End-to-end first-boot orchestration, including fresh AKS join data, certificate authentication, and offline agent sources.
 - [AKS Flex Config Helper](usages/aks-flex-config.md) - Generate node configs from AKS cluster metadata and prepare bootstrap-token RBAC.
 - [Operations](usages/operations.md) - Start, inspect, reset, uninstall, and troubleshoot a Flex Node host.
 - [Configuration](usages/configuration.md) - Configuration file structure, required fields, defaults, and authentication mode selection.

--- a/docs/usages/boot-command.md
+++ b/docs/usages/boot-command.md
@@ -1,0 +1,163 @@
+# `aks-flex-node boot`
+
+`aks-flex-node boot` is the first-boot orchestration command. It prepares the
+active agent binary, optionally fetches fresh join data from AKS RP, renders and
+validates the node config, runs preflight, and starts the node.
+
+The existing command remains unchanged:
+
+```console
+aks-flex-node bootstrap --config /etc/aks-flex-node/config.json
+```
+
+`bootstrap` is still an alias for `start`. Use `boot` for end-to-end first-boot
+orchestration.
+
+## Example: service-principal certificate
+
+```console
+aks-flex-node boot \
+  --fetch-bootstrap-data \
+  --cluster-resource-id "$AKS_CLUSTER_RESOURCE_ID" \
+  --agent-pool-name aksflexnodes \
+  --auth service-principal \
+  --sp-tenant-id "$TENANT_ID" \
+  --sp-client-id "$CLIENT_ID" \
+  --sp-client-certificate-file /run/credentials/aks-flex-node-certificate \
+  --agent-version v0.1.6.alpha-2 \
+  --agent-sha256 "$AGENT_SHA256" \
+  --bootstrap-oci-image "$ROOTFS_SOURCE" \
+  --bootstrap-offline-artifacts-source "$OFFLINE_ARTIFACT_TEMPLATE"
+```
+
+The certificate file can be a combined PEM certificate chain and RSA private
+key with any filename, or an unencrypted PKCS#12 file with a `.pfx` suffix. It
+must be an absolute path to a protected regular file.
+
+The command uses Azure Identity for certificate authentication and sends the
+certificate chain in `x5c`, supporting Subject Name/Issuer configurations as
+well as directly registered certificates.
+
+## Example: managed identity
+
+```console
+aks-flex-node boot \
+  --fetch-bootstrap-data \
+  --cluster-resource-id "$AKS_CLUSTER_RESOURCE_ID" \
+  --agent-pool-name aksflexnodes \
+  --auth msi \
+  --agent-url 'file:///opt/aks-flex-node/aks-flex-node-linux-amd64.tar.gz' \
+  --agent-sha256 "$AGENT_SHA256" \
+  --bootstrap-oci-image "$ROOTFS_SOURCE" \
+  --bootstrap-offline-artifacts-source "$OFFLINE_ARTIFACT_TEMPLATE"
+```
+
+Use `--msi-client-id` for a user-assigned identity.
+
+## Agent source
+
+The active agent can come from:
+
+- `--agent-url` with HTTP, HTTPS, `file://`, or a local path;
+- `--agent-version`, which resolves the normal GitHub release URL; or
+- the currently running binary when neither is supplied.
+
+URL templates support:
+
+```text
+{{OS}}
+{{ARCH}}
+{{VERSION}}
+{{ARCHIVE_NAME}}
+```
+
+The archive is optionally verified with `--agent-sha256`, installed atomically
+at `<install-dir>/aks-flex-node`, and re-executed before bootstrap continues.
+This allows a baseline binary baked into a VHD to hand off to a pinned binary
+from an offline filesystem or dedicated mirror.
+
+## Config processing order
+
+```text
+optional base --config
+→ cluster/pool/ARM endpoint overrides
+→ optional listBootstrapData response
+→ generic JSON config overrides
+→ reapply cluster/pool/ARM endpoint overrides
+→ rootfs/offline artifact source overrides
+→ offline manifest version normalization
+→ host node-name default
+→ MSI/SP auth override
+→ typed config validation
+→ atomic mode-0600 config write
+→ preflight
+→ start
+```
+
+When offline artifacts are configured, their manifest is authoritative for
+containerd, runc, and CNI versions. Kubernetes version remains explicit because
+it selects the versioned bundle.
+
+## Environment equivalents
+
+CLI values override these environment variables:
+
+```text
+AKS_FLEX_NODE_AUTH
+AKS_FLEX_NODE_MSI_CLIENT_ID
+AKS_FLEX_NODE_SP_TENANT_ID
+AKS_FLEX_NODE_SP_CLIENT_ID
+AKS_FLEX_NODE_SP_CLIENT_SECRET
+AKS_FLEX_NODE_SP_CLIENT_SECRET_FILE
+AKS_FLEX_NODE_SP_CLIENT_CERTIFICATE_FILE
+AKS_FLEX_NODE_FETCH_BOOTSTRAP_DATA
+AKS_FLEX_NODE_BOOTSTRAP_DATA_API_VERSION
+AKS_FLEX_NODE_CLUSTER_RESOURCE_ID
+AKS_FLEX_NODE_AGENT_POOL_NAME
+AKS_FLEX_NODE_RESOURCE_MANAGER_ENDPOINT
+AKS_FLEX_NODE_BOOTSTRAP_OCI_IMAGE
+AKS_FLEX_NODE_BOOTSTRAP_OFFLINE_ARTIFACTS_SOURCE
+AKS_FLEX_NODE_CONFIG_OVERRIDES
+AKS_FLEX_NODE_BASE_CONFIG_FILE
+AKS_FLEX_NODE_CONFIG_PATH
+AKS_FLEX_NODE_AGENT_URL
+AKS_FLEX_NODE_AGENT_VERSION
+AKS_FLEX_NODE_AGENT_SHA256
+AKS_FLEX_NODE_INSTALL_DIR
+AKS_FLEX_NODE_AUTHORITY_HOST
+```
+
+Prefer file-based credentials. Signed URLs supplied through environment
+variables are removed before preflight and start subprocesses.
+
+## Offline first boot
+
+A fully disconnected invocation can use local inputs:
+
+```console
+aks-flex-node boot \
+  --config /opt/aks-flex-node/base-config.json \
+  --auth service-principal \
+  --sp-tenant-id "$TENANT_ID" \
+  --sp-client-id "$CLIENT_ID" \
+  --sp-client-certificate-file /run/credentials/aks-flex-node-certificate \
+  --agent-url file:///opt/aks-flex-node/aks-flex-node-linux-amd64.tar.gz \
+  --agent-sha256 "$AGENT_SHA256" \
+  --bootstrap-oci-image oci-layout:///opt/aks-flex-node/rootfs:v20260619 \
+  --bootstrap-offline-artifacts-source 'file:///opt/aks-flex-node/artifacts/{{ .KubernetesVersion }}'
+```
+
+Omit `--fetch-bootstrap-data` when the base config already contains valid
+cluster-issued bootstrap data.
+
+## Security and lifecycle
+
+- Config and binary writes are atomic.
+- Final config is mode `0600`.
+- Download and archive sizes are bounded.
+- HTTPS downgrade redirects are rejected.
+- Certificate and secret files are validated by the typed config loader.
+- SP certificate auth uses Azure SDK assertions instead of shell-built JWTs.
+- The command fails before `start` when config validation or preflight fails.
+- This is a first-boot workflow; do not repeatedly run it after successful node
+  enrollment.

--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -82,7 +82,7 @@ At least one join or Azure authentication method must be configured. `azure.boot
 | `azure.servicePrincipal.tenantId` | string | Microsoft Entra tenant ID for the service principal. | `70a036f6-8e4d-4615-bad6-149c02e7720d` |
 | `azure.servicePrincipal.clientId` | string | Application client ID. | `00000000-0000-0000-0000-000000000000` |
 | `azure.servicePrincipal.clientSecret` | string | Application client secret. Mutually exclusive with `clientSecretFile`. | `<client-secret>` |
-| `azure.servicePrincipal.clientSecretFile` | string | Path to a protected regular file (no group/other access; e.g., 0600) containing either the application client secret or a PEM/unencrypted PFX certificate and private key. PFX certificate files must use a `.pfx` suffix. | `/run/credentials/aks-flex-node-sp` |
+| `azure.servicePrincipal.clientSecretFile` | string | Path to a protected regular file (no group/other access; e.g., 0600) containing either the application client secret or a PEM/unencrypted PFX certificate and private key. PFX certificate files must use a `.pfx` suffix. Certificate auth sends the public chain in `x5c` (and the leaf thumbprint in `x5t`) for Subject Name/Issuer compatibility. | `/run/credentials/aks-flex-node-sp` |
 
 ## Agent
 

--- a/docs/usages/joining-nodes.md
+++ b/docs/usages/joining-nodes.md
@@ -107,7 +107,7 @@ Minimal config shape:
 }
 ```
 
-The credential file contains either the client secret or a PEM/unencrypted PFX application certificate and private key; the agent detects the credential type from its contents. PFX certificate files must use a `.pfx` suffix. The file must be a non-empty regular file with no group/world access (for example, mode 0600). Only one of `clientSecret` or `clientSecretFile` can be configured.
+The credential file contains either the client secret or a PEM/unencrypted PFX application certificate and private key; the agent detects the credential type from its contents. PFX certificate files must use a `.pfx` suffix. The file must be a non-empty regular file with no group/world access (for example, mode 0600). Only one of `clientSecret` or `clientSecretFile` can be configured. Certificate authentication sends both the leaf thumbprint (`x5t`) and public certificate chain (`x5c`), allowing directly registered certificates and Subject Name/Issuer trust policies.
 
 ## Authentication Mode Selection
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
+	golang.org/x/sys v0.47.0
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -82,7 +84,6 @@ require (
 	github.com/rootless-containers/proto/go-proto v0.0.0-20230421021042-4cd87ebadd67 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/urfave/cli v1.22.16 // indirect
 	github.com/vbatts/go-mtree v0.6.1-0.20250911112631-8307d76bc1b9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -92,7 +93,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/aksmachine/client_armapi.go
+++ b/pkg/aksmachine/client_armapi.go
@@ -175,7 +175,7 @@ func getCredential(cfg *config.Config, logger *slog.Logger, clientOpts azcore.Cl
 				cfg.Azure.ServicePrincipal.ClientID,
 				certificates,
 				privateKey,
-				&azidentity.ClientCertificateCredentialOptions{ClientOptions: clientOpts},
+				clientCertificateCredentialOptions(clientOpts),
 			)
 		}
 		return azidentity.NewClientSecretCredential(
@@ -199,6 +199,13 @@ func getCredential(cfg *config.Config, logger *slog.Logger, clientOpts azcore.Cl
 	default:
 		logger.Debug("falling back to default credential for ARM")
 		return azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{ClientOptions: clientOpts})
+	}
+}
+
+func clientCertificateCredentialOptions(clientOpts azcore.ClientOptions) *azidentity.ClientCertificateCredentialOptions {
+	return &azidentity.ClientCertificateCredentialOptions{
+		ClientOptions:        clientOpts,
+		SendCertificateChain: true,
 	}
 }
 

--- a/pkg/aksmachine/client_armapi_test.go
+++ b/pkg/aksmachine/client_armapi_test.go
@@ -165,6 +165,19 @@ func TestAzureClientOptionsFromConfig(t *testing.T) {
 	}
 }
 
+func TestClientCertificateCredentialOptionsSendCertificateChain(t *testing.T) {
+	t.Parallel()
+
+	clientOptions := azureClientOptionsFromConfig(testARMConfig(testClusterResourceID, "flex-node-1", "1.34.0"))
+	options := clientCertificateCredentialOptions(clientOptions)
+	if !options.SendCertificateChain {
+		t.Fatal("SendCertificateChain = false, want true for Subject Name/Issuer authentication")
+	}
+	if options.Cloud.ActiveDirectoryAuthorityHost != clientOptions.Cloud.ActiveDirectoryAuthorityHost {
+		t.Fatal("ClientOptions were not preserved")
+	}
+}
+
 func TestGetCredentialClientCertificateLoadError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/bootstrap/config.go
+++ b/pkg/bootstrap/config.go
@@ -1,0 +1,500 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/google/renameio/v2"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+const maxBootstrapDataBytes = int64(16 << 20)
+
+var (
+	poolNamePattern   = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+	apiVersionPattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}(-preview)?$`)
+)
+
+type object = map[string]any
+
+type dependencies struct {
+	credential func(object, Options) (azcore.TokenCredential, error)
+	httpClient *http.Client
+}
+
+func defaultDependencies() dependencies {
+	return dependencies{
+		credential: bootstrapCredential,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Minute,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return fmt.Errorf("bootstrap-data redirects are not allowed")
+			},
+		},
+	}
+}
+
+func BuildConfig(ctx context.Context, options Options) ([]byte, error) {
+	return buildConfig(ctx, options, defaultDependencies())
+}
+
+func buildConfig(ctx context.Context, options Options, deps dependencies) ([]byte, error) {
+	if err := validateOptions(options); err != nil {
+		return nil, err
+	}
+	base, err := loadBaseObject(options.BaseConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	applyTargetOverrides(base, options)
+	if options.FetchBootstrapData {
+		data, err := fetchBootstrapData(ctx, base, options, deps)
+		if err != nil {
+			return nil, err
+		}
+		deepMerge(base, data)
+	}
+	for index, raw := range options.ConfigOverrides {
+		override, err := decodeObject([]byte(raw))
+		if err != nil {
+			return nil, fmt.Errorf("parse config override %d: %w", index+1, err)
+		}
+		deepMerge(base, override)
+	}
+	applyTargetOverrides(base, options)
+	applyBootstrapSourceOverrides(base, options)
+	normalizeOfflineVersions(base)
+	if err := applyNodeName(base); err != nil {
+		return nil, err
+	}
+	if err := applyAuth(base, options); err != nil {
+		return nil, err
+	}
+	data, err := json.MarshalIndent(base, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal rendered config: %w", err)
+	}
+	data = append(data, '\n')
+	if err := validateConfigData(data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func WriteConfig(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	if err := renameio.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("atomically write config: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("set config permissions: %w", err)
+	}
+	return nil
+}
+
+func loadBaseObject(path string) (object, error) {
+	if strings.TrimSpace(path) == "" {
+		return object{}, nil
+	}
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("read base config: %w", err)
+	}
+	base, err := decodeObject(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse base config: %w", err)
+	}
+	return base, nil
+}
+
+func decodeObject(data []byte) (object, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple JSON values are not allowed")
+		}
+		return nil, err
+	}
+	result, ok := value.(object)
+	if !ok {
+		return nil, fmt.Errorf("JSON value must be an object")
+	}
+	return result, nil
+}
+
+func deepMerge(destination, source object) {
+	for key, value := range source {
+		if sourceObject, ok := value.(object); ok {
+			if destinationObject, ok := destination[key].(object); ok {
+				deepMerge(destinationObject, sourceObject)
+				continue
+			}
+		}
+		destination[key] = value
+	}
+}
+
+func ensureObject(parent object, key string) object {
+	if value, ok := parent[key].(object); ok {
+		return value
+	}
+	value := object{}
+	parent[key] = value
+	return value
+}
+
+func applyTargetOverrides(root object, options Options) {
+	azure := ensureObject(root, "azure")
+	if options.ClusterResourceID != "" {
+		ensureObject(azure, "targetCluster")["resourceId"] = options.ClusterResourceID
+	}
+	if options.AgentPoolName != "" {
+		azure["targetAgentPoolName"] = options.AgentPoolName
+	}
+	if options.ResourceManagerEndpoint != "" {
+		azure["resourceManagerEndpoint"] = options.ResourceManagerEndpoint
+	}
+}
+
+func applyBootstrapSourceOverrides(root object, options Options) {
+	bootstrap := ensureObject(root, "bootstrap")
+	if options.BootstrapOCIImage != "" {
+		bootstrap["ociImage"] = options.BootstrapOCIImage
+	}
+	if options.BootstrapOfflineArtifactsSource != "" {
+		ensureObject(bootstrap, "offlineArtifacts")["source"] = options.BootstrapOfflineArtifactsSource
+	}
+}
+
+func normalizeOfflineVersions(root object) {
+	bootstrap, _ := root["bootstrap"].(object)
+	offline, _ := bootstrap["offlineArtifacts"].(object)
+	source, _ := offline["source"].(string)
+	if strings.TrimSpace(source) == "" {
+		return
+	}
+	components := ensureObject(root, "components")
+	delete(components, "containerd")
+	delete(components, "runc")
+	delete(ensureObject(root, "networking"), "cniVersion")
+}
+
+func applyNodeName(root object) error {
+	agent := ensureObject(root, "agent")
+	if name, _ := agent["nodeName"].(string); strings.TrimSpace(name) != "" {
+		return nil
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("get host name: %w", err)
+	}
+	agent["nodeName"] = strings.ToLower(strings.TrimSpace(hostname))
+	return nil
+}
+
+func validateOptions(options Options) error {
+	mode := strings.ToLower(strings.TrimSpace(options.AuthMode))
+	if mode != "sp" && mode != "service-principal" {
+		return nil
+	}
+	credentialCount := 0
+	if options.SPClientSecret != "" {
+		credentialCount++
+	}
+	if options.SPClientSecretFile != "" {
+		credentialCount++
+	}
+	if options.SPClientCertificateFile != "" {
+		credentialCount++
+	}
+	if credentialCount != 1 {
+		return fmt.Errorf("service-principal auth requires exactly one secret, secret file, or certificate file")
+	}
+	for label, path := range map[string]string{
+		"service-principal secret file":      options.SPClientSecretFile,
+		"service-principal certificate file": options.SPClientCertificateFile,
+	} {
+		if path != "" && !filepath.IsAbs(path) {
+			return fmt.Errorf("%s path must be absolute", label)
+		}
+	}
+	return nil
+}
+
+func applyAuth(root object, options Options) error {
+	mode := strings.ToLower(strings.TrimSpace(options.AuthMode))
+	if mode == "" {
+		return nil
+	}
+	azure := ensureObject(root, "azure")
+	ensureObject(azure, "arc")["enabled"] = false
+	switch mode {
+	case "msi", "managed-identity":
+		delete(azure, "servicePrincipal")
+		identity := object{}
+		if options.MSIClientID != "" {
+			identity["clientId"] = options.MSIClientID
+		}
+		azure["managedIdentity"] = identity
+	case "sp", "service-principal":
+		if options.SPClientID == "" {
+			return fmt.Errorf("service-principal auth requires client ID")
+		}
+		delete(azure, "managedIdentity")
+		tenantID := options.SPTenantID
+		if tenantID == "" {
+			tenantID, _ = azure["tenantId"].(string)
+		}
+		servicePrincipal := object{"tenantId": tenantID, "clientId": options.SPClientID}
+		switch {
+		case options.SPClientCertificateFile != "":
+			servicePrincipal["clientSecretFile"] = options.SPClientCertificateFile
+		case options.SPClientSecretFile != "":
+			servicePrincipal["clientSecretFile"] = options.SPClientSecretFile
+		default:
+			servicePrincipal["clientSecret"] = options.SPClientSecret
+		}
+		azure["servicePrincipal"] = servicePrincipal
+	default:
+		return fmt.Errorf("unsupported auth mode %q", options.AuthMode)
+	}
+	return nil
+}
+
+func fetchBootstrapData(ctx context.Context, root object, options Options, deps dependencies) (object, error) {
+	azure := ensureObject(root, "azure")
+	endpoint := options.ResourceManagerEndpoint
+	if endpoint == "" {
+		endpoint, _ = azure["resourceManagerEndpoint"].(string)
+	}
+	if endpoint == "" {
+		endpoint = defaultResourceManagerEndpoint
+	}
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil || parsedEndpoint.Scheme != "https" || parsedEndpoint.Host == "" {
+		return nil, fmt.Errorf("resource manager endpoint must be an absolute HTTPS URL")
+	}
+	resourceID := options.ClusterResourceID
+	if resourceID == "" {
+		target, _ := azure["targetCluster"].(object)
+		resourceID, _ = target["resourceId"].(string)
+	}
+	poolName := options.AgentPoolName
+	if poolName == "" {
+		poolName, _ = azure["targetAgentPoolName"].(string)
+	}
+	if !poolNamePattern.MatchString(poolName) {
+		return nil, fmt.Errorf("invalid agent pool name %q", poolName)
+	}
+	if !apiVersionPattern.MatchString(options.BootstrapDataAPIVersion) {
+		return nil, fmt.Errorf("invalid bootstrap-data API version %q", options.BootstrapDataAPIVersion)
+	}
+	clusterID, err := arm.ParseResourceID(resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("parse cluster resource ID: %w", err)
+	}
+	if !strings.EqualFold(clusterID.ResourceType.String(), "Microsoft.ContainerService/managedClusters") {
+		return nil, fmt.Errorf("resource ID is not an AKS managed cluster")
+	}
+	credential, err := deps.credential(root, options)
+	if err != nil {
+		return nil, err
+	}
+	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{strings.TrimRight(endpoint, "/") + "/.default"}})
+	if err != nil {
+		return nil, fmt.Errorf("acquire ARM token: %w", err)
+	}
+	requestURL := strings.TrimRight(endpoint, "/") + resourceID + "/agentPools/" + poolName +
+		"/listBootstrapData?api-version=" + options.BootstrapDataAPIVersion
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create bootstrap-data request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := deps.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch bootstrap data: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(response.Body, maxBootstrapDataBytes+1))
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read bootstrap data: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close bootstrap-data response: %w", closeErr)
+	}
+	if int64(len(data)) > maxBootstrapDataBytes {
+		return nil, fmt.Errorf("bootstrap data exceeds %d bytes", maxBootstrapDataBytes)
+	}
+	result, err := decodeObject(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse bootstrap data: %w", err)
+	}
+	responseAzure, _ := result["azure"].(object)
+	tokenConfig, _ := responseAzure["bootstrapToken"].(object)
+	bootstrapToken, _ := tokenConfig["token"].(string)
+	if bootstrapToken == "" {
+		return nil, fmt.Errorf("bootstrap-data response did not contain a bootstrap token")
+	}
+	return result, nil
+}
+
+func bootstrapCredential(root object, options Options) (azcore.TokenCredential, error) {
+	mode := strings.ToLower(strings.TrimSpace(options.AuthMode))
+	azure := ensureObject(root, "azure")
+	if mode == "" {
+		switch {
+		case azure["managedIdentity"] != nil:
+			mode = "msi"
+		case azure["servicePrincipal"] != nil:
+			mode = "service-principal"
+		}
+	}
+	switch mode {
+	case "msi", "managed-identity":
+		clientID := options.MSIClientID
+		if clientID == "" {
+			identity, _ := azure["managedIdentity"].(object)
+			clientID, _ = identity["clientId"].(string)
+		}
+		credentialOptions := &azidentity.ManagedIdentityCredentialOptions{}
+		if clientID != "" {
+			credentialOptions.ID = azidentity.ClientID(clientID)
+		}
+		credential, err := azidentity.NewManagedIdentityCredential(credentialOptions)
+		if err != nil {
+			return nil, fmt.Errorf("create managed identity credential: %w", err)
+		}
+		return credential, nil
+	case "sp", "service-principal":
+		servicePrincipal, _ := azure["servicePrincipal"].(object)
+		tenantID := options.SPTenantID
+		if tenantID == "" {
+			tenantID, _ = servicePrincipal["tenantId"].(string)
+		}
+		if tenantID == "" {
+			tenantID, _ = azure["tenantId"].(string)
+		}
+		clientID := options.SPClientID
+		if clientID == "" {
+			clientID, _ = servicePrincipal["clientId"].(string)
+		}
+		if tenantID == "" || clientID == "" {
+			return nil, fmt.Errorf("service-principal bootstrap-data fetch requires tenant ID and client ID")
+		}
+		clientOptions := azcore.ClientOptions{}
+		authorityHost := options.AuthorityHost
+		if authorityHost == "" {
+			authorityHost = defaultAuthorityHost
+		}
+		clientOptions.Cloud = cloud.Configuration{ActiveDirectoryAuthorityHost: authorityHost}
+		certificateFile := options.SPClientCertificateFile
+		baseCredentialFile, _ := servicePrincipal["clientSecretFile"].(string)
+		if certificateFile == "" && options.SPClientSecretFile == "" && options.SPClientSecret == "" && baseCredentialFile != "" {
+			looksLikeCertificate, err := credentialFileLooksLikeCertificate(baseCredentialFile)
+			if err != nil {
+				return nil, err
+			}
+			if looksLikeCertificate {
+				certificateFile = baseCredentialFile
+			}
+		}
+		if certificateFile != "" {
+			if err := config.ValidateServicePrincipalCertificateFile(certificateFile); err != nil {
+				return nil, fmt.Errorf("validate service-principal certificate: %w", err)
+			}
+			sp := config.ServicePrincipalConfig{ClientSecretFile: certificateFile}
+			certificates, privateKey, err := sp.LoadClientCertificate()
+			if err != nil {
+				return nil, fmt.Errorf("load service-principal certificate: %w", err)
+			}
+			credential, err := azidentity.NewClientCertificateCredential(tenantID, clientID, certificates, privateKey,
+				&azidentity.ClientCertificateCredentialOptions{ClientOptions: clientOptions, SendCertificateChain: true})
+			if err != nil {
+				return nil, fmt.Errorf("create certificate credential: %w", err)
+			}
+			return credential, nil
+		}
+		secret := options.SPClientSecret
+		secretFile := options.SPClientSecretFile
+		if secret == "" && secretFile == "" {
+			secret, _ = servicePrincipal["clientSecret"].(string)
+			secretFile, _ = servicePrincipal["clientSecretFile"].(string)
+		}
+		if secret == "" && secretFile != "" {
+			data, err := config.LoadServicePrincipalCredentialFile(secretFile)
+			if err != nil {
+				return nil, fmt.Errorf("load service-principal secret: %w", err)
+			}
+			secret = strings.TrimRight(string(data), "\r\n")
+		}
+		if secret == "" {
+			return nil, fmt.Errorf("service-principal bootstrap-data fetch requires a secret or certificate")
+		}
+		credential, err := azidentity.NewClientSecretCredential(tenantID, clientID, secret,
+			&azidentity.ClientSecretCredentialOptions{ClientOptions: clientOptions})
+		if err != nil {
+			return nil, fmt.Errorf("create client-secret credential: %w", err)
+		}
+		return credential, nil
+	default:
+		return nil, fmt.Errorf("bootstrap-data fetch requires MSI or service-principal authentication")
+	}
+}
+
+func credentialFileLooksLikeCertificate(path string) (bool, error) {
+	data, err := config.LoadServicePrincipalCredentialFile(path)
+	if err != nil {
+		return false, fmt.Errorf("load service-principal credential file: %w", err)
+	}
+	return bytes.Contains(data, []byte("-----BEGIN CERTIFICATE-----")) ||
+		bytes.Contains(data, []byte("-----BEGIN PRIVATE KEY-----")) ||
+		bytes.Contains(data, []byte("-----BEGIN RSA PRIVATE KEY-----")) ||
+		!utf8.Valid(data), nil
+}
+
+func validateConfigData(data []byte) error {
+	dir, err := os.MkdirTemp("", "aks-flex-node-bootstrap-config-")
+	if err != nil {
+		return fmt.Errorf("create config validation directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("stage config validation: %w", err)
+	}
+	if _, err := config.LoadConfig(path); err != nil {
+		return fmt.Errorf("validate rendered config: %w", err)
+	}
+	return nil
+}

--- a/pkg/bootstrap/config_test.go
+++ b/pkg/bootstrap/config_test.go
@@ -1,0 +1,163 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type staticCredential struct{}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func (staticCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "arm-token", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestBuildConfigFetchAndOverrides(t *testing.T) {
+	t.Parallel()
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost || !strings.Contains(request.URL.Path, "/agentPools/aksflexnodes/listBootstrapData") {
+			t.Errorf("request = %s %s", request.Method, request.URL.Path)
+		}
+		if request.Header.Get("Authorization") != "Bearer arm-token" {
+			t.Error("missing bearer token")
+		}
+		body := `{
+			"azure":{"bootstrapToken":{"token":"abcdef.0123456789abcdef"}},
+			"components":{"kubernetes":"1.36.2","containerd":"stale","runc":"stale"},
+			"networking":{"dnsServiceIP":"10.0.0.10","cniVersion":"stale"},
+			"node":{"kubelet":{"clusterFQDN":"api.example.test:443","caCertData":"Y2E="}}
+		}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}
+
+	resourceID := "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster"
+	data, err := buildConfig(context.Background(), Options{
+		AuthMode:                        "msi",
+		FetchBootstrapData:              true,
+		BootstrapDataAPIVersion:         defaultBootstrapDataAPIVersion,
+		ClusterResourceID:               resourceID,
+		AgentPoolName:                   "aksflexnodes",
+		ResourceManagerEndpoint:         defaultResourceManagerEndpoint,
+		BootstrapOCIImage:               "https://mirror.example/rootfs.tar.gz",
+		BootstrapOfflineArtifactsSource: "https://mirror.example/bundle-{{ .KubernetesVersion }}.tar.gz",
+		ConfigOverrides:                 []string{`{"azure":{"targetAgentPoolName":"wrong"},"node":{"labels":{"test":"true"}}}`},
+	}, dependencies{
+		credential: func(object, Options) (azcore.TokenCredential, error) { return staticCredential{}, nil },
+		httpClient: client,
+	})
+	if err != nil {
+		t.Fatalf("buildConfig() error = %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	azure := result["azure"].(map[string]any)
+	if azure["targetAgentPoolName"] != "aksflexnodes" {
+		t.Fatalf("pool = %v", azure["targetAgentPoolName"])
+	}
+	if _, ok := azure["managedIdentity"]; !ok {
+		t.Fatal("managedIdentity is missing")
+	}
+	components := result["components"].(map[string]any)
+	if _, ok := components["containerd"]; ok {
+		t.Fatal("containerd pin was not removed")
+	}
+	if _, ok := components["runc"]; ok {
+		t.Fatal("runc pin was not removed")
+	}
+	networking := result["networking"].(map[string]any)
+	if _, ok := networking["cniVersion"]; ok {
+		t.Fatal("CNI pin was not removed")
+	}
+	bootstrap := result["bootstrap"].(map[string]any)
+	if bootstrap["ociImage"] != "https://mirror.example/rootfs.tar.gz" {
+		t.Fatal("OCI override is missing")
+	}
+}
+
+func TestBuildConfigCertificateFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	certificatePath := filepath.Join(dir, "credential-without-extension")
+	writeCertificate(t, certificatePath)
+	basePath := filepath.Join(dir, "base.json")
+	base := `{
+		"azure":{"targetAgentPoolName":"aksflexnodes","targetCluster":{"resourceId":"/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster"},"bootstrapToken":{"token":"abcdef.0123456789abcdef"}},
+		"components":{"kubernetes":"1.36.2"},
+		"node":{"kubelet":{"clusterFQDN":"api.example.test:443","caCertData":"Y2E="}}
+	}`
+	if err := os.WriteFile(basePath, []byte(base), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data, err := BuildConfig(context.Background(), Options{
+		AuthMode:                "service-principal",
+		SPTenantID:              "tenant",
+		SPClientID:              "client",
+		SPClientCertificateFile: certificatePath,
+		BaseConfigPath:          basePath,
+	})
+	if err != nil {
+		t.Fatalf("BuildConfig() error = %v", err)
+	}
+	var result struct {
+		Azure struct {
+			ServicePrincipal map[string]any `json:"servicePrincipal"`
+		} `json:"azure"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Azure.ServicePrincipal["clientSecretFile"] != certificatePath {
+		t.Fatalf("service principal = %#v", result.Azure.ServicePrincipal)
+	}
+	if _, ok := result.Azure.ServicePrincipal["clientSecret"]; ok {
+		t.Fatal("inline secret is present")
+	}
+}
+
+func writeCertificate(t *testing.T, path string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "bootstrap-test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyData, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := append(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyData})...)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/bootstrap/options.go
+++ b/pkg/bootstrap/options.go
@@ -1,0 +1,115 @@
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	defaultConfigPath              = "/etc/aks-flex-node/config.json"
+	defaultInstallDir              = "/usr/local/bin"
+	defaultRepository              = "Azure/AKSFlexNode"
+	defaultResourceManagerEndpoint = "https://management.azure.com"
+	defaultAuthorityHost           = "https://login.microsoftonline.com"
+	defaultBootstrapDataAPIVersion = "2026-05-02-preview"
+	updateGuardEnvironment         = "AKS_FLEX_NODE_AGENT_UPDATE_APPLIED"
+)
+
+type Options struct {
+	AuthMode                string
+	MSIClientID             string
+	SPTenantID              string
+	SPClientID              string
+	SPClientSecret          string
+	SPClientSecretFile      string
+	SPClientCertificateFile string
+
+	FetchBootstrapData      bool
+	BootstrapDataAPIVersion string
+	ClusterResourceID       string
+	AgentPoolName           string
+	ResourceManagerEndpoint string
+	AuthorityHost           string
+
+	BootstrapOCIImage               string
+	BootstrapOfflineArtifactsSource string
+	ConfigOverrides                 []string
+	BaseConfigPath                  string
+	ConfigPath                      string
+
+	AgentURL     string
+	AgentVersion string
+	AgentSHA256  string
+	InstallDir   string
+}
+
+func DefaultOptions() Options {
+	return Options{
+		BootstrapDataAPIVersion: defaultBootstrapDataAPIVersion,
+		AuthorityHost:           defaultAuthorityHost,
+		ConfigPath:              defaultConfigPath,
+		InstallDir:              defaultInstallDir,
+	}
+}
+
+func (o *Options) ApplyEnvironment(flags *pflag.FlagSet) error {
+	stringDefaults := map[string]struct {
+		target *string
+		env    string
+	}{
+		"auth":                               {&o.AuthMode, "AKS_FLEX_NODE_AUTH"},
+		"msi-client-id":                      {&o.MSIClientID, "AKS_FLEX_NODE_MSI_CLIENT_ID"},
+		"sp-tenant-id":                       {&o.SPTenantID, "AKS_FLEX_NODE_SP_TENANT_ID"},
+		"sp-client-id":                       {&o.SPClientID, "AKS_FLEX_NODE_SP_CLIENT_ID"},
+		"sp-client-secret-file":              {&o.SPClientSecretFile, "AKS_FLEX_NODE_SP_CLIENT_SECRET_FILE"},
+		"sp-client-certificate-file":         {&o.SPClientCertificateFile, "AKS_FLEX_NODE_SP_CLIENT_CERTIFICATE_FILE"},
+		"bootstrap-data-api-version":         {&o.BootstrapDataAPIVersion, "AKS_FLEX_NODE_BOOTSTRAP_DATA_API_VERSION"},
+		"cluster-resource-id":                {&o.ClusterResourceID, "AKS_FLEX_NODE_CLUSTER_RESOURCE_ID"},
+		"agent-pool-name":                    {&o.AgentPoolName, "AKS_FLEX_NODE_AGENT_POOL_NAME"},
+		"resource-manager-endpoint":          {&o.ResourceManagerEndpoint, "AKS_FLEX_NODE_RESOURCE_MANAGER_ENDPOINT"},
+		"bootstrap-oci-image":                {&o.BootstrapOCIImage, "AKS_FLEX_NODE_BOOTSTRAP_OCI_IMAGE"},
+		"bootstrap-offline-artifacts-source": {&o.BootstrapOfflineArtifactsSource, "AKS_FLEX_NODE_BOOTSTRAP_OFFLINE_ARTIFACTS_SOURCE"},
+		"config":                             {&o.BaseConfigPath, "AKS_FLEX_NODE_BASE_CONFIG_FILE"},
+		"config-path":                        {&o.ConfigPath, "AKS_FLEX_NODE_CONFIG_PATH"},
+		"agent-url":                          {&o.AgentURL, "AKS_FLEX_NODE_AGENT_URL"},
+		"agent-version":                      {&o.AgentVersion, "AKS_FLEX_NODE_AGENT_VERSION"},
+		"agent-sha256":                       {&o.AgentSHA256, "AKS_FLEX_NODE_AGENT_SHA256"},
+		"install-dir":                        {&o.InstallDir, "AKS_FLEX_NODE_INSTALL_DIR"},
+	}
+	for name, value := range stringDefaults {
+		if !flags.Changed(name) {
+			if envValue := os.Getenv(value.env); envValue != "" {
+				*value.target = envValue
+			}
+		}
+	}
+	if !flags.Changed("fetch-bootstrap-data") {
+		value := strings.TrimSpace(os.Getenv("AKS_FLEX_NODE_FETCH_BOOTSTRAP_DATA"))
+		if value != "" {
+			switch strings.ToLower(value) {
+			case "1", "true", "yes", "y":
+				o.FetchBootstrapData = true
+			case "0", "false", "no", "n":
+				o.FetchBootstrapData = false
+			default:
+				return fmt.Errorf("parse AKS_FLEX_NODE_FETCH_BOOTSTRAP_DATA: expected boolean, got %q", value)
+			}
+		}
+	}
+	if envOverride := os.Getenv("AKS_FLEX_NODE_CONFIG_OVERRIDES"); envOverride != "" {
+		o.ConfigOverrides = append([]string{envOverride}, o.ConfigOverrides...)
+	}
+	o.SPClientSecret = os.Getenv("AKS_FLEX_NODE_SP_CLIENT_SECRET")
+	_ = os.Unsetenv("AKS_FLEX_NODE_SP_CLIENT_SECRET")
+	return nil
+}
+
+func (o Options) HasOnboardingInputs() bool {
+	return o.FetchBootstrapData || o.AuthMode != "" || o.ClusterResourceID != "" ||
+		o.AgentPoolName != "" || o.ResourceManagerEndpoint != "" ||
+		o.BootstrapOCIImage != "" || o.BootstrapOfflineArtifactsSource != "" ||
+		len(o.ConfigOverrides) != 0
+}

--- a/pkg/bootstrap/update.go
+++ b/pkg/bootstrap/update.go
@@ -1,0 +1,239 @@
+package bootstrap
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/renameio/v2"
+)
+
+const maxAgentArtifactBytes = int64(1 << 30)
+
+type UpdateResult struct {
+	Path      string
+	Reexecute bool
+}
+
+func InstallAgent(ctx context.Context, options Options) (UpdateResult, error) {
+	destination := filepath.Join(options.InstallDir, "aks-flex-node")
+	result := UpdateResult{Path: destination}
+	if os.Getenv(updateGuardEnvironment) == "1" {
+		return result, nil
+	}
+	if options.AgentURL == "" && options.AgentVersion == "" {
+		executable, err := os.Executable()
+		if err != nil {
+			return result, fmt.Errorf("resolve current executable: %w", err)
+		}
+		executable, err = filepath.Abs(executable)
+		if err != nil {
+			return result, fmt.Errorf("resolve absolute executable path: %w", err)
+		}
+		absoluteDestination, err := filepath.Abs(destination)
+		if err != nil {
+			return result, fmt.Errorf("resolve absolute agent destination: %w", err)
+		}
+		if executable == absoluteDestination {
+			return result, nil
+		}
+		binary, err := os.ReadFile(filepath.Clean(executable))
+		if err != nil {
+			return result, fmt.Errorf("read current executable: %w", err)
+		}
+		if err := installAgentBinary(options.InstallDir, destination, binary); err != nil {
+			return result, err
+		}
+		result.Reexecute = true
+		return result, nil
+	}
+	archiveName := fmt.Sprintf("aks-flex-node-linux-%s.tar.gz", runtime.GOARCH)
+	source := options.AgentURL
+	if source == "" {
+		source = fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", defaultRepository, options.AgentVersion, archiveName)
+	}
+	source = strings.NewReplacer(
+		"{{OS}}", runtime.GOOS,
+		"{{ARCH}}", runtime.GOARCH,
+		"{{VERSION}}", options.AgentVersion,
+		"{{ARCHIVE_NAME}}", archiveName,
+	).Replace(source)
+	artifact, err := downloadArtifact(ctx, source, maxAgentArtifactBytes)
+	if err != nil {
+		return result, fmt.Errorf("download agent: %w", err)
+	}
+	if err := verifySHA256(artifact, options.AgentSHA256); err != nil {
+		return result, err
+	}
+	binary, err := extractAgent(artifact, strings.TrimSuffix(archiveName, ".tar.gz"))
+	if err != nil {
+		return result, err
+	}
+	if err := installAgentBinary(options.InstallDir, destination, binary); err != nil {
+		return result, err
+	}
+	result.Reexecute = true
+	return result, nil
+}
+
+func installAgentBinary(installDir, destination string, binary []byte) error {
+	if err := os.MkdirAll(installDir, 0o755); err != nil { //nolint:gosec // executable directory
+		return fmt.Errorf("create agent install directory: %w", err)
+	}
+	if sameContent(destination, binary) {
+		return nil
+	}
+	if err := renameio.WriteFile(destination, binary, 0o755); err != nil { //nolint:gosec // executable
+		return fmt.Errorf("atomically install agent: %w", err)
+	}
+	if err := os.Chmod(destination, 0o755); err != nil { //nolint:gosec // executable
+		return fmt.Errorf("set agent permissions: %w", err)
+	}
+	return nil
+}
+
+func downloadArtifact(ctx context.Context, source string, maxBytes int64) ([]byte, error) {
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return nil, fmt.Errorf("parse source URL")
+	}
+	if parsed.Scheme == "" || parsed.Scheme == "file" {
+		path := source
+		if parsed.Scheme == "file" {
+			if parsed.Host != "" && parsed.Host != "localhost" {
+				return nil, fmt.Errorf("file URL must not have a remote host")
+			}
+			path, err = url.PathUnescape(parsed.Path)
+			if err != nil {
+				return nil, fmt.Errorf("decode file URL: %w", err)
+			}
+		}
+		file, err := os.Open(filepath.Clean(path))
+		if err != nil {
+			return nil, fmt.Errorf("open local source: %w", err)
+		}
+		data, readErr := readLimited(file, maxBytes)
+		closeErr := file.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close local source: %w", closeErr)
+		}
+		return data, nil
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return nil, fmt.Errorf("unsupported source scheme %q", parsed.Scheme)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, source, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create download request")
+	}
+	client := &http.Client{
+		Timeout: 10 * time.Minute,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) > 0 && via[0].URL.Scheme == "https" && req.URL.Scheme != "https" {
+				return fmt.Errorf("refusing HTTPS downgrade redirect")
+			}
+			return nil
+		},
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("request failed")
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("source returned HTTP status %d", response.StatusCode)
+	}
+	data, readErr := readLimited(response.Body, maxBytes)
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close response: %w", closeErr)
+	}
+	return data, nil
+}
+
+func readLimited(reader io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read source: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("source exceeds %d bytes", maxBytes)
+	}
+	return data, nil
+}
+
+func verifySHA256(data []byte, expected string) error {
+	expected = strings.ToLower(strings.TrimSpace(expected))
+	if expected == "" {
+		return nil
+	}
+	if len(expected) != sha256.Size*2 {
+		return fmt.Errorf("agent SHA-256 must have 64 hexadecimal characters")
+	}
+	if _, err := hex.DecodeString(expected); err != nil {
+		return fmt.Errorf("parse agent SHA-256: %w", err)
+	}
+	actual := sha256.Sum256(data)
+	if hex.EncodeToString(actual[:]) != expected {
+		return fmt.Errorf("agent SHA-256 mismatch")
+	}
+	return nil
+}
+
+func extractAgent(artifact []byte, expectedName string) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(artifact))
+	if err != nil {
+		return nil, fmt.Errorf("open agent archive: %w", err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read agent archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != 0 {
+			continue
+		}
+		name := filepath.Base(header.Name)
+		if name != expectedName && name != "aks-flex-node" {
+			continue
+		}
+		if header.Size <= 0 || header.Size > maxAgentArtifactBytes {
+			return nil, fmt.Errorf("agent binary has invalid size")
+		}
+		return io.ReadAll(io.LimitReader(tarReader, maxAgentArtifactBytes+1))
+	}
+	return nil, fmt.Errorf("agent archive does not contain %s or aks-flex-node", expectedName)
+}
+
+func sameContent(path string, expected []byte) bool {
+	current, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	currentDigest := sha256.Sum256(current)
+	expectedDigest := sha256.Sum256(expected)
+	return currentDigest == expectedDigest
+}

--- a/pkg/bootstrap/update_test.go
+++ b/pkg/bootstrap/update_test.go
@@ -1,0 +1,84 @@
+package bootstrap
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInstallAgentFromLocalArchive(t *testing.T) {
+	t.Parallel()
+	binary := []byte("test agent binary")
+	archive := makeAgentArchive(t, "aks-flex-node-linux-"+runtime.GOARCH, binary)
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "agent.tar.gz")
+	if err := os.WriteFile(archivePath, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(archive)
+	result, err := InstallAgent(context.Background(), Options{
+		AgentURL:    "file://" + archivePath,
+		AgentSHA256: hex.EncodeToString(digest[:]),
+		InstallDir:  filepath.Join(dir, "bin"),
+	})
+	if err != nil {
+		t.Fatalf("InstallAgent() error = %v", err)
+	}
+	if !result.Reexecute {
+		t.Fatal("Reexecute = false, want true")
+	}
+	got, err := os.ReadFile(result.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, binary) {
+		t.Fatalf("binary = %q, want %q", got, binary)
+	}
+	info, err := os.Stat(result.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("mode = %o, want 755", info.Mode().Perm())
+	}
+}
+
+func TestInstallAgentChecksumMismatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.tar.gz")
+	if err := os.WriteFile(path, makeAgentArchive(t, "aks-flex-node-linux-"+runtime.GOARCH, []byte("agent")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := InstallAgent(context.Background(), Options{AgentURL: path, AgentSHA256: string(bytes.Repeat([]byte{'0'}, 64)), InstallDir: filepath.Join(dir, "bin")})
+	if err == nil {
+		t.Fatal("InstallAgent() error = nil, want checksum error")
+	}
+}
+
+func makeAgentArchive(t *testing.T, name string, binary []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(binary))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}

--- a/pkg/cmd/bootstrap/bootstrap.go
+++ b/pkg/cmd/bootstrap/bootstrap.go
@@ -1,0 +1,149 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	bootstrapflow "github.com/Azure/AKSFlexNode/pkg/bootstrap"
+)
+
+func NewCommand() *cobra.Command {
+	options := bootstrapflow.DefaultOptions()
+	cmd := &cobra.Command{
+		Use:   "boot",
+		Short: "Fetch join data, prepare the agent, and start a Flex Node",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := options.ApplyEnvironment(cmd.Flags()); err != nil {
+				return err
+			}
+			return execute(cmd.Context(), options)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&options.AuthMode, "auth", "", "Authentication mode: msi or service-principal")
+	flags.StringVar(&options.MSIClientID, "msi-client-id", "", "Optional user-assigned managed identity client ID")
+	flags.StringVar(&options.SPTenantID, "sp-tenant-id", "", "Service-principal tenant ID")
+	flags.StringVar(&options.SPClientID, "sp-client-id", "", "Service-principal client ID")
+	flags.StringVar(&options.SPClientSecretFile, "sp-client-secret-file", "", "Protected service-principal secret file")
+	flags.StringVar(&options.SPClientCertificateFile, "sp-client-certificate-file", "", "Protected PEM or unencrypted PFX certificate file")
+	flags.BoolVar(&options.FetchBootstrapData, "fetch-bootstrap-data", false, "Fetch and merge fresh AKS RP bootstrap data")
+	flags.StringVar(&options.BootstrapDataAPIVersion, "bootstrap-data-api-version", options.BootstrapDataAPIVersion, "AKS listBootstrapData API version")
+	flags.StringVar(&options.ClusterResourceID, "cluster-resource-id", "", "Target AKS managed-cluster resource ID")
+	flags.StringVar(&options.AgentPoolName, "agent-pool-name", "", "Target FlexNodes agent pool name")
+	flags.StringVar(&options.ResourceManagerEndpoint, "resource-manager-endpoint", "", "Azure Resource Manager endpoint (defaults to public Azure)")
+	flags.StringVar(&options.BootstrapOCIImage, "bootstrap-oci-image", "", "Override bootstrap.ociImage")
+	flags.StringVar(&options.BootstrapOfflineArtifactsSource, "bootstrap-offline-artifacts-source", "", "Override bootstrap.offlineArtifacts.source")
+	flags.StringArrayVar(&options.ConfigOverrides, "config-overrides", nil, "Deep-merge a JSON object; repeatable")
+	flags.StringVar(&options.BaseConfigPath, "config", "", "Optional existing/base config path")
+	flags.StringVar(&options.ConfigPath, "config-path", options.ConfigPath, "Rendered config destination")
+	flags.StringVar(&options.AgentURL, "agent-url", "", "Agent tar.gz URL, file URL, or local path")
+	flags.StringVar(&options.AgentVersion, "agent-version", "", "Agent release version used when --agent-url is omitted")
+	flags.StringVar(&options.AgentSHA256, "agent-sha256", "", "Expected SHA-256 of the agent archive")
+	flags.StringVar(&options.InstallDir, "install-dir", options.InstallDir, "Agent binary installation directory")
+	return cmd
+}
+
+func execute(ctx context.Context, options bootstrapflow.Options) error {
+	if options.BaseConfigPath != "" && !options.HasOnboardingInputs() && options.AgentURL == "" && options.AgentVersion == "" {
+		return runSelf(ctx, "start", "--config", options.BaseConfigPath)
+	}
+	update, err := bootstrapflow.InstallAgent(ctx, options)
+	if err != nil {
+		return err
+	}
+	if update.Reexecute {
+		return reexecute(update.Path, options)
+	}
+	data, err := bootstrapflow.BuildConfig(ctx, options)
+	if err != nil {
+		return err
+	}
+	if err := bootstrapflow.WriteConfig(options.ConfigPath, data); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(os.Stderr, "Rendered node config at %s\n", options.ConfigPath)
+	if err := runSelf(ctx, "preflight", "--config", options.ConfigPath, "--output", "text"); err != nil {
+		return fmt.Errorf("bootstrap preflight: %w", err)
+	}
+	if err := runSelf(ctx, "start", "--config", options.ConfigPath); err != nil {
+		return fmt.Errorf("start node: %w", err)
+	}
+	return nil
+}
+
+func reexecute(path string, options bootstrapflow.Options) error {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve updated agent path: %w", err)
+	}
+	environment := reexecuteEnvironment(os.Environ(), options)
+	arguments := append([]string{absolutePath}, os.Args[1:]...)
+	if err := unix.Exec(absolutePath, arguments, environment); err != nil {
+		return fmt.Errorf("execute updated agent: %w", err)
+	}
+	return nil
+}
+
+func reexecuteEnvironment(environment []string, options bootstrapflow.Options) []string {
+	result := withoutEnvironment(environment, updateGuardEnvironment()+"=", "AKS_FLEX_NODE_SP_CLIENT_SECRET=")
+	result = append(result, updateGuardEnvironment()+"=1")
+	if options.SPClientSecret != "" {
+		result = append(result, "AKS_FLEX_NODE_SP_CLIENT_SECRET="+options.SPClientSecret)
+	}
+	return result
+}
+
+func runSelf(ctx context.Context, arguments ...string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve current executable: %w", err)
+	}
+	command := exec.CommandContext(ctx, executable, arguments...) // #nosec G204 -- current executable and controlled arguments
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Stdin = os.Stdin
+	command.Env = filteredEnvironment()
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("run %s: %w", arguments[0], err)
+	}
+	return nil
+}
+
+func withoutEnvironment(environment []string, prefixes ...string) []string {
+	result := make([]string, 0, len(environment))
+	for _, value := range environment {
+		keep := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(value, prefix) {
+				keep = false
+				break
+			}
+		}
+		if keep {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func filteredEnvironment() []string {
+	blocked := []string{
+		"AKS_FLEX_NODE_SP_CLIENT_SECRET=",
+		"AKS_FLEX_NODE_AGENT_URL=",
+		"AKS_FLEX_NODE_CONFIG_OVERRIDES=",
+		"AKS_FLEX_NODE_BOOTSTRAP_OCI_IMAGE=",
+		"AKS_FLEX_NODE_BOOTSTRAP_OFFLINE_ARTIFACTS_SOURCE=",
+		updateGuardEnvironment() + "=",
+	}
+	return withoutEnvironment(os.Environ(), blocked...)
+}
+
+func updateGuardEnvironment() string { return "AKS_FLEX_NODE_AGENT_UPDATE_APPLIED" }

--- a/pkg/cmd/bootstrap/bootstrap_test.go
+++ b/pkg/cmd/bootstrap/bootstrap_test.go
@@ -1,0 +1,58 @@
+package bootstrap
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	bootstrapflow "github.com/Azure/AKSFlexNode/pkg/bootstrap"
+)
+
+func TestNewCommand(t *testing.T) {
+	t.Parallel()
+	command := NewCommand()
+	if command.Use != "boot" {
+		t.Fatalf("Use = %q, want boot", command.Use)
+	}
+	for _, name := range []string{
+		"auth", "msi-client-id", "sp-tenant-id", "sp-client-id",
+		"sp-client-secret-file", "sp-client-certificate-file",
+		"fetch-bootstrap-data", "cluster-resource-id", "agent-pool-name",
+		"resource-manager-endpoint", "bootstrap-oci-image",
+		"bootstrap-offline-artifacts-source", "config-overrides", "config",
+		"config-path", "agent-url", "agent-version", "agent-sha256", "install-dir",
+	} {
+		if command.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s is missing", name)
+		}
+	}
+}
+
+func TestReexecuteEnvironmentPreservesDirectSecret(t *testing.T) {
+	t.Parallel()
+	got := reexecuteEnvironment([]string{
+		"KEEP=value",
+		"AKS_FLEX_NODE_AGENT_UPDATE_APPLIED=old",
+		"AKS_FLEX_NODE_SP_CLIENT_SECRET=old",
+	}, bootstrapflow.Options{SPClientSecret: "new-secret"})
+	for _, want := range []string{
+		"KEEP=value",
+		"AKS_FLEX_NODE_AGENT_UPDATE_APPLIED=1",
+		"AKS_FLEX_NODE_SP_CLIENT_SECRET=new-secret",
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("environment %v does not contain %q", got, want)
+		}
+	}
+	if slices.Contains(got, "AKS_FLEX_NODE_SP_CLIENT_SECRET=old") {
+		t.Fatal("old secret was preserved")
+	}
+}
+
+func TestWithoutEnvironment(t *testing.T) {
+	t.Parallel()
+	got := withoutEnvironment([]string{"KEEP=value", "SECRET=value", "URL=value"}, "SECRET=", "URL=")
+	if strings.Join(got, ",") != "KEEP=value" {
+		t.Fatalf("withoutEnvironment() = %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add `aks-flex-node boot` as an end-to-end first-boot orchestration command
- keep `bootstrap` unchanged as the existing alias for `start`
- fetch fresh `listBootstrapData` with MSI, SP secret, SP secret-file, or SP certificate auth
- accept runtime cluster/pool coordinates and mirrored rootfs/offline artifact sources
- download an agent tarball from HTTP(S), `file://`, or a local path, verify SHA-256, atomically install, and re-exec
- support a baked baseline binary when no agent URL/version is supplied
- render, type-validate, and atomically write config before running preflight and start

## Example

```console
aks-flex-node boot \
  --fetch-bootstrap-data \
  --cluster-resource-id "$AKS_CLUSTER_RESOURCE_ID" \
  --agent-pool-name aksflexnodes \
  --auth service-principal \
  --sp-tenant-id "$TENANT_ID" \
  --sp-client-id "$CLIENT_ID" \
  --sp-client-certificate-file /run/credentials/aks-flex-node-certificate \
  --agent-url file:///opt/aks-flex-node/aks-flex-node-linux-amd64.tar.gz \
  --agent-sha256 "$AGENT_SHA256" \
  --bootstrap-oci-image "$ROOTFS_SOURCE" \
  --bootstrap-offline-artifacts-source "$OFFLINE_ARTIFACT_TEMPLATE"
```

## Compatibility

`aks-flex-node bootstrap --config ...` continues to resolve to the existing `start` command alias. The new workflow is named `boot` to avoid changing existing behavior.

## Authentication

- managed identity, including user-assigned client ID
- service-principal inline secret environment input
- protected secret file
- combined PEM certificate/key with any filename
- unencrypted PKCS#12 with `.pfx` suffix

Certificate bootstrap-data auth uses Azure Identity and sends the public certificate chain. The durable config uses `azure.servicePrincipal.clientSecretFile`.

## Offline and mirrored use

- exact agent URL, release version, `file://`, or local archive
- URL placeholders for OS, architecture, version, and archive name
- optional archive SHA-256
- version-templated HTTPS/file/OCI bootstrap artifact sources
- current binary is copied to the install path and re-executed when no agent source is supplied

## Validation

- `go test ./...`
- `make lint`
- `go vet ./...`
- `git diff --check`
- unit coverage for config merge precedence, fresh bootstrap data, certificate-file rendering, offline version normalization, local archive installation, checksum rejection, flags, environment scrubbing, and re-exec secret preservation

Live certificate/SP validation will be performed against a disposable AKS no-CNI cluster and Azure VM. All resources and isolated auth caches will be deleted after validation; non-secret diagnostics will be retained locally.


## Live validation

Validated against disposable Azure resources in subscription `06e2642b-73f7-4e4e-8b9d-020525d95828` using the provided service-principal combined PEM credential:

- certificate-authenticated creation of an AKS 1.36.2 no-CNI cluster
- Unbounded v0.2.0 cluster/flex sites and node-mesh peering
- FlexNodes pool at 1.36.2
- Ubuntu 24.04 VM with certificate credential mode 0600
- baked `boot-baseline` binary copied to `/usr/local/bin`
- candidate archive from `file:///opt/aks-flex-node/...tar.gz`
- SHA-256 verification, atomic replacement, and re-exec to `boot-candidate`
- certificate-authenticated `listBootstrapData`
- generated config containing `clientSecretFile` and no inline secret
- ARM Machine `Succeeded` at 1.36.2
- Node Ready in `flex-site`
- cross-site ClusterIP traffic from the managed AKS node to a Flex-node pod
- debug evidence: `using service principal credential for ARM`

The daemon CSR required manual approval, matching the current preview environment requirement. Agent reset completed before cleanup. The VM, AKS cluster, VNet, IP, NSG, disks, node resource group, isolated auth cache, and test workloads were deleted. The pre-existing `flex-test` resource group remains empty.

Non-secret logs are retained locally under `/home/bahe/workshop/msft/flex/api-test/go-boot-cert-e2e/logs/`.
