### PR TITLE
Send certificate chain for SP authentication

### DIFF
--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -82,7 +82,7 @@ At least one join or Azure authentication method must be configured. `azure.boot
 | `azure.servicePrincipal.tenantId` | string | Microsoft Entra tenant ID for the service principal. | `70a036f6-8e4d-4615-bad6-149c02e7720d` |
 | `azure.servicePrincipal.clientId` | string | Application client ID. | `00000000-0000-0000-0000-000000000000` |
 | `azure.servicePrincipal.clientSecret` | string | Application client secret. Mutually exclusive with `clientSecretFile`. | `<client-secret>` |
-| `azure.servicePrincipal.clientSecretFile` | string | Path to a protected regular file (no group/other access; e.g., 0600) containing either the application client secret or a PEM/unencrypted PFX certificate and private key. PFX certificate files must use a `.pfx` suffix. | `/run/credentials/aks-flex-node-sp` |
+| `azure.servicePrincipal.clientSecretFile` | string | Path to a protected regular file (no group/other access; e.g., 0600) containing either the application client secret or a PEM/unencrypted PFX certificate and private key. PFX certificate files must use a `.pfx` suffix. Certificate auth sends the public chain in `x5c` (and the leaf thumbprint in `x5t`) for Subject Name/Issuer compatibility. | `/run/credentials/aks-flex-node-sp` |
 
 ## Agent
 

--- a/docs/usages/joining-nodes.md
+++ b/docs/usages/joining-nodes.md
@@ -107,7 +107,7 @@ Minimal config shape:
 }
 ```
 
-The credential file contains either the client secret or a PEM/unencrypted PFX application certificate and private key; the agent detects the credential type from its contents. PFX certificate files must use a `.pfx` suffix. The file must be a non-empty regular file with no group/world access (for example, mode 0600). Only one of `clientSecret` or `clientSecretFile` can be configured.
+The credential file contains either the client secret or a PEM/unencrypted PFX application certificate and private key; the agent detects the credential type from its contents. PFX certificate files must use a `.pfx` suffix. The file must be a non-empty regular file with no group/world access (for example, mode 0600). Only one of `clientSecret` or `clientSecretFile` can be configured. Certificate authentication sends both the leaf thumbprint (`x5t`) and public certificate chain (`x5c`), allowing directly registered certificates and Subject Name/Issuer trust policies.
 
 ## Authentication Mode Selection
 

--- a/pkg/aksmachine/client_armapi.go
+++ b/pkg/aksmachine/client_armapi.go
@@ -175,7 +175,7 @@ func getCredential(cfg *config.Config, logger *slog.Logger, clientOpts azcore.Cl
 				cfg.Azure.ServicePrincipal.ClientID,
 				certificates,
 				privateKey,
-				&azidentity.ClientCertificateCredentialOptions{ClientOptions: clientOpts},
+				clientCertificateCredentialOptions(clientOpts),
 			)
 		}
 		return azidentity.NewClientSecretCredential(
@@ -199,6 +199,13 @@ func getCredential(cfg *config.Config, logger *slog.Logger, clientOpts azcore.Cl
 	default:
 		logger.Debug("falling back to default credential for ARM")
 		return azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{ClientOptions: clientOpts})
+	}
+}
+
+func clientCertificateCredentialOptions(clientOpts azcore.ClientOptions) *azidentity.ClientCertificateCredentialOptions {
+	return &azidentity.ClientCertificateCredentialOptions{
+		ClientOptions:        clientOpts,
+		SendCertificateChain: true,
 	}
 }
 

--- a/pkg/aksmachine/client_armapi_test.go
+++ b/pkg/aksmachine/client_armapi_test.go
@@ -165,6 +165,19 @@ func TestAzureClientOptionsFromConfig(t *testing.T) {
 	}
 }
 
+func TestClientCertificateCredentialOptionsSendCertificateChain(t *testing.T) {
+	t.Parallel()
+
+	clientOptions := azureClientOptionsFromConfig(testARMConfig(testClusterResourceID, "flex-node-1", "1.34.0"))
+	options := clientCertificateCredentialOptions(clientOptions)
+	if !options.SendCertificateChain {
+		t.Fatal("SendCertificateChain = false, want true for Subject Name/Issuer authentication")
+	}
+	if options.Cloud.ActiveDirectoryAuthorityHost != clientOptions.Cloud.ActiveDirectoryAuthorityHost {
+		t.Fatal("ClientOptions were not preserved")
+	}
+}
+
 func TestGetCredentialClientCertificateLoadError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- send the public certificate chain (`x5c`) for long-running ARM service-principal certificate authentication
- preserve the standard leaf certificate thumbprint (`x5t`)
- align ARM reconciliation with kubelogin, which already sends the certificate chain
- document Subject Name/Issuer compatibility

## Motivation

Directly registered certificate credentials work with thumbprint authentication, but Microsoft Entra Subject Name/Issuer trust requires the public certificate chain in the client assertion. Azure Identity exposes this through `ClientCertificateCredentialOptions.SendCertificateChain`.

## Change

```go
&azidentity.ClientCertificateCredentialOptions{
    ClientOptions:        clientOpts,
    SendCertificateChain: true,
}
```

This applies only when `azure.servicePrincipal.clientSecretFile` contains a certificate/private key. Secret-based SP auth is unchanged.

## Coverage

- focused unit test asserts `SendCertificateChain` is enabled and client/cloud options are preserved
- `go test ./pkg/aksmachine ./pkg/bootstrap ./pkg/cmd/bootstrap`
- `make lint`
- `go vet ./...`
- `git diff --check`

## Dependency

This is a stacked draft PR based on `hbc/bootstrap-command` / PR #257. That branch already uses Azure Identity certificate auth for `listBootstrapData`; this PR completes x5c support for the long-running ARM Machine reconciliation path. Kubelogin already sets `SendCertificateChain: true` for Kubernetes exec authentication.

A live Subject Name/Issuer policy test still requires an Entra application configured with the appropriate trusted certificate authority and subject policy. The direct-certificate E2E in PR #257 validates the underlying certificate-file lifecycle but not SNI trust configuration.
