### PR TITLE
Delegate bootstrap data retrieval to agent

### DIFF
--- a/cmd/aks-flex-node/main.go
+++ b/cmd/aks-flex-node/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/AKSFlexNode/pkg/cmd/bootstrapdata"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/daemon"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/preflight"
 	"github.com/Azure/AKSFlexNode/pkg/cmd/reset"
@@ -26,6 +27,7 @@ func main() {
 	}
 
 	rootCmd.AddCommand(start.NewCommand())
+	rootCmd.AddCommand(bootstrapdata.NewCommand())
 	rootCmd.AddCommand(preflight.NewCommand())
 	rootCmd.AddCommand(daemon.NewCommand())
 	rootCmd.AddCommand(reset.NewCommand())

--- a/docs/design/storage-backed-bootstrap.md
+++ b/docs/design/storage-backed-bootstrap.md
@@ -553,15 +553,13 @@ disables Arc authentication. The credential file must remain available for
 config loads on preflight, start, and future service restarts, or be recreated
 by the credential manager before service startup.
 
-When certificate auth is also used to call `listBootstrapData`, the script uses
-OpenSSL to construct a short-lived RS256 client assertion with the leaf
-certificate SHA-1 thumbprint (`x5t`) and the leaf-first public certificate chain
-(`x5c`), then exchanges it at the configured Microsoft Entra token endpoint.
-`x5t` uses unpadded base64url while each `x5c` element uses standard base64 DER.
-Assertion material and any PFX-extracted key are confined to the mode `0700`
-temporary workspace and removed on exit. Long-running ARM auth enables Azure
-Identity's certificate-chain sending, and kubelogin already does the same for
-Kubernetes exec authentication.
+When certificate auth is also used to call `listBootstrapData`, the script
+invokes `aks-flex-node fetch-bootstrap-data` and passes only protected credential
+paths and non-secret identity metadata. The Go command uses Azure Identity to
+construct the client assertion, including the leaf thumbprint (`x5t`) and public
+certificate chain (`x5c`). The shell no longer parses certificates, extracts
+PFX keys, or constructs JWTs. Long-running ARM auth and kubelogin use the same
+Azure Identity certificate-chain behavior.
 
 ## Agent download and installation
 

--- a/docs/usages/operator-first-boot.md
+++ b/docs/usages/operator-first-boot.md
@@ -413,7 +413,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   curl \
   jq \
   nftables \
-  openssl \
   systemd-container \
   tar \
   util-linux
@@ -518,10 +517,11 @@ For certificate-based service-principal authentication, install a protected PEM
 file containing the leaf-first certificate chain and RSA private key, or an
 unencrypted PKCS#12 file with a `.pfx` suffix. PEM detection is content-based, so
 its filename does not require a `.pem` suffix. Keep the file available for agent
-service restarts. Certificate-based `--fetch-bootstrap-data` also requires the
-`openssl` command on the host. Client assertions include the leaf thumbprint in
-`x5t` and the public chain in `x5c`, supporting both directly registered
-certificates and Microsoft Entra Subject Name/Issuer trust policies.
+service restarts. The script delegates certificate authentication to the
+installed `aks-flex-node fetch-bootstrap-data` command; OpenSSL is not required
+on the host for assertion construction. Azure Identity sends the leaf
+thumbprint in `x5t` and the public chain in `x5c`, supporting both directly
+registered certificates and Microsoft Entra Subject Name/Issuer trust policies.
 
 ```bash
 install -o root -g root -m 0600 \

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -1,0 +1,279 @@
+package bootstrapdata
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/google/renameio/v2"
+
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+const (
+	DefaultAPIVersion              = "2026-05-02-preview"
+	DefaultResourceManagerEndpoint = "https://management.azure.com"
+	DefaultAuthorityHost           = "https://login.microsoftonline.com"
+	maxResponseBytes               = int64(16 << 20)
+)
+
+var (
+	apiVersionPattern = regexp.MustCompile(`^[0-9]{4}-[0-9]{2}-[0-9]{2}(-preview)?$`)
+	poolNamePattern   = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+)
+
+type Options struct {
+	ClusterResourceID       string
+	AgentPoolName           string
+	AuthMode                string
+	MSIClientID             string
+	SPTenantID              string
+	SPClientID              string
+	SPClientSecret          string
+	SPClientSecretFile      string
+	SPClientCertificateFile string
+	SPClientCredentialFile  string
+	ResourceManagerEndpoint string
+	AuthorityHost           string
+	APIVersion              string
+	OutputPath              string
+}
+
+type dependencies struct {
+	credential func(Options, azcore.ClientOptions) (azcore.TokenCredential, error)
+	httpClient *http.Client
+}
+
+func defaultDependencies() dependencies {
+	return dependencies{
+		credential: newCredential,
+		httpClient: &http.Client{
+			Timeout: 2 * time.Minute,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return fmt.Errorf("bootstrap-data redirects are not allowed")
+			},
+		},
+	}
+}
+
+func FetchAndWrite(ctx context.Context, options Options) error {
+	return fetchAndWrite(ctx, options, defaultDependencies())
+}
+
+func fetchAndWrite(ctx context.Context, options Options, deps dependencies) error {
+	if err := validateOptions(options); err != nil {
+		return err
+	}
+	endpoint := strings.TrimRight(options.ResourceManagerEndpoint, "/")
+	clientOptions := azcore.ClientOptions{Cloud: cloud.Configuration{
+		ActiveDirectoryAuthorityHost: options.AuthorityHost,
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: endpoint, Audience: endpoint},
+		},
+	}}
+	credential, err := deps.credential(options, clientOptions)
+	if err != nil {
+		return err
+	}
+	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{endpoint + "/.default"}})
+	if err != nil {
+		return fmt.Errorf("acquire ARM token: %w", err)
+	}
+	requestURL := endpoint + options.ClusterResourceID + "/agentPools/" + options.AgentPoolName +
+		"/listBootstrapData?api-version=" + options.APIVersion
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("create bootstrap-data request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := deps.httpClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("fetch bootstrap data: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		return fmt.Errorf("read bootstrap data: %w", readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close bootstrap-data response: %w", closeErr)
+	}
+	if int64(len(data)) > maxResponseBytes {
+		return fmt.Errorf("bootstrap data exceeds %d bytes", maxResponseBytes)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return fmt.Errorf("parse bootstrap data: %w", err)
+	}
+	azure, _ := result["azure"].(map[string]any)
+	bootstrapToken, _ := azure["bootstrapToken"].(map[string]any)
+	value, _ := bootstrapToken["token"].(string)
+	if value == "" {
+		return fmt.Errorf("bootstrap-data response did not contain a bootstrap token")
+	}
+	formatted, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal bootstrap data: %w", err)
+	}
+	formatted = append(formatted, '\n')
+	if err := os.MkdirAll(filepath.Dir(options.OutputPath), 0o750); err != nil {
+		return fmt.Errorf("create bootstrap-data output directory: %w", err)
+	}
+	if err := renameio.WriteFile(options.OutputPath, formatted, 0o600); err != nil {
+		return fmt.Errorf("atomically write bootstrap data: %w", err)
+	}
+	return os.Chmod(options.OutputPath, 0o600)
+}
+
+func validateOptions(options Options) error {
+	endpoint, err := url.Parse(options.ResourceManagerEndpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil {
+		return fmt.Errorf("resource manager endpoint must be an absolute HTTPS URL")
+	}
+	authority, err := url.Parse(options.AuthorityHost)
+	if err != nil || authority.Scheme != "https" || authority.Host == "" || authority.User != nil {
+		return fmt.Errorf("authority host must be an absolute HTTPS URL")
+	}
+	clusterID, err := arm.ParseResourceID(options.ClusterResourceID)
+	if err != nil {
+		return fmt.Errorf("parse cluster resource ID: %w", err)
+	}
+	if !strings.EqualFold(clusterID.ResourceType.String(), "Microsoft.ContainerService/managedClusters") {
+		return fmt.Errorf("resource ID is not an AKS managed cluster")
+	}
+	if !poolNamePattern.MatchString(options.AgentPoolName) {
+		return fmt.Errorf("invalid agent pool name %q", options.AgentPoolName)
+	}
+	if !apiVersionPattern.MatchString(options.APIVersion) {
+		return fmt.Errorf("invalid API version %q", options.APIVersion)
+	}
+	if strings.TrimSpace(options.OutputPath) == "" {
+		return fmt.Errorf("output path is required")
+	}
+	return nil
+}
+
+func newCredential(options Options, clientOptions azcore.ClientOptions) (azcore.TokenCredential, error) {
+	switch strings.ToLower(strings.TrimSpace(options.AuthMode)) {
+	case "msi", "managed-identity":
+		credentialOptions := &azidentity.ManagedIdentityCredentialOptions{ClientOptions: clientOptions}
+		if options.MSIClientID != "" {
+			credentialOptions.ID = azidentity.ClientID(options.MSIClientID)
+		}
+		credential, err := azidentity.NewManagedIdentityCredential(credentialOptions)
+		if err != nil {
+			return nil, fmt.Errorf("create managed identity credential: %w", err)
+		}
+		return credential, nil
+	case "sp", "service-principal":
+		if options.SPTenantID == "" || options.SPClientID == "" {
+			return nil, fmt.Errorf("service-principal auth requires tenant ID and client ID")
+		}
+		return newServicePrincipalCredential(options, clientOptions)
+	default:
+		return nil, fmt.Errorf("unsupported auth mode %q", options.AuthMode)
+	}
+}
+
+func newServicePrincipalCredential(options Options, clientOptions azcore.ClientOptions) (azcore.TokenCredential, error) {
+	credentialCount := 0
+	if options.SPClientSecret != "" {
+		credentialCount++
+	}
+	if options.SPClientSecretFile != "" {
+		credentialCount++
+	}
+	if options.SPClientCertificateFile != "" {
+		credentialCount++
+	}
+	if options.SPClientCredentialFile != "" {
+		credentialCount++
+	}
+	if credentialCount != 1 {
+		return nil, fmt.Errorf("service-principal auth requires exactly one secret, secret file, certificate file, or auto-detected credential file")
+	}
+	if options.SPClientCertificateFile != "" {
+		return newCertificateCredential(options.SPTenantID, options.SPClientID, options.SPClientCertificateFile, clientOptions)
+	}
+	if options.SPClientCredentialFile != "" {
+		certificate, err := credentialFileLooksLikeCertificate(options.SPClientCredentialFile)
+		if err != nil {
+			return nil, err
+		}
+		if certificate {
+			return newCertificateCredential(options.SPTenantID, options.SPClientID, options.SPClientCredentialFile, clientOptions)
+		}
+		options.SPClientSecretFile = options.SPClientCredentialFile
+	}
+	secret := options.SPClientSecret
+	if secret == "" {
+		data, err := config.LoadServicePrincipalCredentialFile(options.SPClientSecretFile)
+		if err != nil {
+			return nil, fmt.Errorf("load service-principal secret: %w", err)
+		}
+		secret = strings.TrimRight(string(data), "\r\n")
+	}
+	if secret == "" {
+		return nil, fmt.Errorf("service-principal client secret is empty")
+	}
+	credential, err := azidentity.NewClientSecretCredential(options.SPTenantID, options.SPClientID, secret,
+		&azidentity.ClientSecretCredentialOptions{ClientOptions: clientOptions})
+	if err != nil {
+		return nil, fmt.Errorf("create client-secret credential: %w", err)
+	}
+	return credential, nil
+}
+
+func newCertificateCredential(tenantID, clientID, path string, clientOptions azcore.ClientOptions) (azcore.TokenCredential, error) {
+	if err := config.ValidateServicePrincipalCertificateFile(path); err != nil {
+		return nil, fmt.Errorf("validate service-principal certificate: %w", err)
+	}
+	servicePrincipal := config.ServicePrincipalConfig{ClientSecretFile: path}
+	certificates, privateKey, err := servicePrincipal.LoadClientCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("load service-principal certificate: %w", err)
+	}
+	credential, err := azidentity.NewClientCertificateCredential(tenantID, clientID, certificates, privateKey,
+		clientCertificateCredentialOptions(clientOptions))
+	if err != nil {
+		return nil, fmt.Errorf("create client-certificate credential: %w", err)
+	}
+	return credential, nil
+}
+
+func clientCertificateCredentialOptions(clientOptions azcore.ClientOptions) *azidentity.ClientCertificateCredentialOptions {
+	return &azidentity.ClientCertificateCredentialOptions{
+		ClientOptions:        clientOptions,
+		SendCertificateChain: true,
+	}
+}
+
+func credentialFileLooksLikeCertificate(path string) (bool, error) {
+	data, err := config.LoadServicePrincipalCredentialFile(path)
+	if err != nil {
+		return false, fmt.Errorf("load service-principal credential file: %w", err)
+	}
+	return bytes.Contains(data, []byte("-----BEGIN CERTIFICATE-----")) ||
+		bytes.Contains(data, []byte("-----BEGIN PRIVATE KEY-----")) ||
+		bytes.Contains(data, []byte("-----BEGIN RSA PRIVATE KEY-----")) || !utf8.Valid(data), nil
+}

--- a/pkg/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/bootstrapdata/bootstrap_data_test.go
@@ -1,0 +1,69 @@
+package bootstrapdata
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type staticCredential struct{}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (staticCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "arm-token", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func TestFetchAndWrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	output := filepath.Join(dir, "bootstrap-data.json")
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost {
+			t.Errorf("method = %s", request.Method)
+		}
+		if request.Header.Get("Authorization") != "Bearer arm-token" {
+			t.Error("missing token")
+		}
+		body := `{"azure":{"bootstrapToken":{"token":"abcdef.0123456789abcdef"}}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}
+	options := Options{
+		ClusterResourceID: "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		AgentPoolName:     "aksflexnodes", AuthMode: "msi",
+		ResourceManagerEndpoint: DefaultResourceManagerEndpoint,
+		AuthorityHost:           DefaultAuthorityHost, APIVersion: DefaultAPIVersion, OutputPath: output,
+	}
+	err := fetchAndWrite(context.Background(), options, dependencies{
+		credential: func(Options, azcore.ClientOptions) (azcore.TokenCredential, error) { return staticCredential{}, nil },
+		httpClient: client,
+	})
+	if err != nil {
+		t.Fatalf("fetchAndWrite() error = %v", err)
+	}
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o", info.Mode().Perm())
+	}
+}
+
+func TestClientCertificateCredentialOptions(t *testing.T) {
+	t.Parallel()
+	options := clientCertificateCredentialOptions(azcore.ClientOptions{})
+	if !options.SendCertificateChain {
+		t.Fatal("SendCertificateChain = false")
+	}
+}

--- a/pkg/cmd/bootstrapdata/bootstrap_data.go
+++ b/pkg/cmd/bootstrapdata/bootstrap_data.go
@@ -1,0 +1,46 @@
+package bootstrapdata
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/AKSFlexNode/pkg/bootstrapdata"
+)
+
+func NewCommand() *cobra.Command {
+	options := bootstrapdata.Options{
+		ResourceManagerEndpoint: bootstrapdata.DefaultResourceManagerEndpoint,
+		AuthorityHost:           bootstrapdata.DefaultAuthorityHost,
+		APIVersion:              bootstrapdata.DefaultAPIVersion,
+	}
+	cmd := &cobra.Command{
+		Use:   "fetch-bootstrap-data",
+		Short: "Fetch current FlexNodes join data from AKS RP",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			options.SPClientSecret = os.Getenv("AKS_FLEX_NODE_SP_CLIENT_SECRET")
+			_ = os.Unsetenv("AKS_FLEX_NODE_SP_CLIENT_SECRET")
+			return bootstrapdata.FetchAndWrite(cmd.Context(), options)
+		},
+	}
+	flags := cmd.Flags()
+	flags.StringVar(&options.ClusterResourceID, "cluster-resource-id", "", "Target AKS managed-cluster resource ID")
+	flags.StringVar(&options.AgentPoolName, "agent-pool-name", "", "Target FlexNodes agent pool name")
+	flags.StringVar(&options.AuthMode, "auth", "", "Authentication mode: msi or service-principal")
+	flags.StringVar(&options.MSIClientID, "msi-client-id", "", "Optional user-assigned managed identity client ID")
+	flags.StringVar(&options.SPTenantID, "sp-tenant-id", "", "Service-principal tenant ID")
+	flags.StringVar(&options.SPClientID, "sp-client-id", "", "Service-principal client ID")
+	flags.StringVar(&options.SPClientSecretFile, "sp-client-secret-file", "", "Protected service-principal client-secret file")
+	flags.StringVar(&options.SPClientCertificateFile, "sp-client-certificate-file", "", "Protected PEM or unencrypted PFX certificate file")
+	flags.StringVar(&options.SPClientCredentialFile, "sp-client-credential-file", "", "Protected secret or certificate file, detected by content")
+	flags.StringVar(&options.ResourceManagerEndpoint, "resource-manager-endpoint", options.ResourceManagerEndpoint, "Azure Resource Manager endpoint")
+	flags.StringVar(&options.AuthorityHost, "authority-host", options.AuthorityHost, "Microsoft Entra authority host")
+	flags.StringVar(&options.APIVersion, "api-version", options.APIVersion, "AKS listBootstrapData API version")
+	flags.StringVarP(&options.OutputPath, "output", "o", "", "Protected JSON output path (required)")
+	_ = cmd.MarkFlagRequired("cluster-resource-id")
+	_ = cmd.MarkFlagRequired("agent-pool-name")
+	_ = cmd.MarkFlagRequired("auth")
+	_ = cmd.MarkFlagRequired("output")
+	return cmd
+}

--- a/pkg/cmd/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/cmd/bootstrapdata/bootstrap_data_test.go
@@ -1,0 +1,21 @@
+package bootstrapdata
+
+import "testing"
+
+func TestNewCommand(t *testing.T) {
+	t.Parallel()
+	command := NewCommand()
+	if command.Use != "fetch-bootstrap-data" {
+		t.Fatalf("Use = %q", command.Use)
+	}
+	for _, name := range []string{
+		"cluster-resource-id", "agent-pool-name", "auth", "msi-client-id",
+		"sp-tenant-id", "sp-client-id", "sp-client-secret-file",
+		"sp-client-certificate-file", "sp-client-credential-file",
+		"resource-manager-endpoint", "authority-host", "api-version", "output",
+	} {
+		if command.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s is missing", name)
+		}
+	}
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,8 +2,9 @@
 # AKS Flex Node first-boot script.
 #
 # Requirements: bash, curl, tar, and jq. sha256sum is required only when an
-# artifact checksum is configured. openssl is required when a service-principal
-# certificate is used to fetch bootstrap data. This script does not install dependencies.
+# artifact checksum is configured. Authentication and bootstrap-data retrieval
+# are delegated to the downloaded aks-flex-node binary. This script does not
+# install dependencies.
 #
 # A publisher can replace the marker in write_embedded_base_config with a
 # cluster/pool-specific partial config. When --fetch-bootstrap-data is used with
@@ -132,8 +133,8 @@ Environment overrides:
 
 A CLI credential-file flag overrides credential values inherited from the
 environment. When invoking through sudo, explicitly preserve the required
-environment variables. The script requires preinstalled bash, curl, tar, and
-jq; certificate-based bootstrap-data fetch also requires openssl.
+environment variables. The script requires preinstalled bash, curl, tar, and jq. The
+aks-flex-node binary owns MSI, secret, and certificate authentication.
 EOF
 }
 
@@ -214,9 +215,6 @@ check_prerequisites() {
     if [[ -n "$AGENT_SHA256" ]]; then
         require_command sha256sum
     fi
-    if [[ -n "$SP_CLIENT_CERTIFICATE_FILE" ]]; then
-        require_command openssl
-    fi
 }
 
 write_base_config() {
@@ -292,257 +290,6 @@ is_true() {
     esac
 }
 
-resolve_fetch_auth_mode() {
-    local current="$1"
-    local mode="${AUTH_MODE,,}"
-    if [[ -z "$mode" ]]; then
-        if jq -e '.azure.managedIdentity != null' "$current" >/dev/null; then
-            mode=msi
-        elif jq -e '.azure.servicePrincipal != null' "$current" >/dev/null; then
-            mode=service-principal
-        else
-            fatal "fetching bootstrap data requires MSI or service-principal authentication"
-        fi
-    fi
-    case "$mode" in
-        msi|managed-identity) printf 'msi' ;;
-        sp|service-principal) printf 'service-principal' ;;
-        *) fatal "fetching bootstrap data does not support auth mode: $mode" ;;
-    esac
-}
-
-require_https_endpoint() {
-    local endpoint="$1"
-    local label="$2"
-    case "$endpoint" in
-        https://*) return 0 ;;
-        http://127.0.0.1:*|http://localhost:*)
-            is_true "$ALLOW_INSECURE_TEST_ENDPOINTS" && return 0
-            ;;
-    esac
-    fatal "$label must use HTTPS"
-}
-
-credential_file_looks_like_certificate() {
-    local path="$1"
-    case "$path" in
-        *.pfx|*.PFX) return 0 ;;
-    esac
-    grep -aq -- '-----BEGIN CERTIFICATE-----' "$path" ||
-        grep -aq -- '-----BEGIN PRIVATE KEY-----' "$path" ||
-        grep -aq -- '-----BEGIN RSA PRIVATE KEY-----' "$path"
-}
-
-resolve_sp_credential_kind() {
-    local current="$1"
-    if [[ -n "$SP_CLIENT_CERTIFICATE_FILE" ]]; then
-        printf 'certificate'
-    elif [[ -n "$SP_CLIENT_SECRET_FILE" || -n "$SP_CLIENT_SECRET" ]]; then
-        printf 'secret'
-    else
-        local credential_file
-        credential_file=$(jq -r '.azure.servicePrincipal.clientSecretFile // ""' "$current")
-        if [[ -n "$credential_file" ]]; then
-            check_credential_file_permissions "$credential_file"
-        fi
-        if [[ -n "$credential_file" ]] && credential_file_looks_like_certificate "$credential_file"; then
-            printf 'certificate'
-        else
-            printf 'secret'
-        fi
-    fi
-}
-
-resolve_sp_secret_file() {
-    local current="$1"
-    local secret_file="$SP_CLIENT_SECRET_FILE"
-    if [[ -n "$secret_file" ]]; then
-        check_secret_file_permissions "$secret_file"
-    elif [[ -n "$SP_CLIENT_SECRET" ]]; then
-        secret_file="$TEMP_DIR/fetch-sp-client-secret"
-        printf '%s' "$SP_CLIENT_SECRET" > "$secret_file"
-        chmod 0600 "$secret_file"
-    else
-        secret_file=$(jq -r '.azure.servicePrincipal.clientSecretFile // ""' "$current")
-        if [[ -n "$secret_file" ]]; then
-            check_secret_file_permissions "$secret_file"
-            credential_file_looks_like_certificate "$secret_file" && \
-                fatal "service-principal bootstrap-data fetch requires a secret file, not a certificate file"
-        else
-            secret_file="$TEMP_DIR/fetch-sp-client-secret"
-            jq -er '.azure.servicePrincipal.clientSecret' "$current" > "$secret_file" || \
-                fatal "service-principal bootstrap-data fetch requires a client secret or clientSecretFile"
-            chmod 0600 "$secret_file"
-        fi
-    fi
-    printf '%s' "$secret_file"
-}
-
-resolve_sp_certificate_file() {
-    local current="$1"
-    local certificate_file="$SP_CLIENT_CERTIFICATE_FILE"
-    if [[ -z "$certificate_file" ]]; then
-        certificate_file=$(jq -r '.azure.servicePrincipal.clientSecretFile // ""' "$current")
-    fi
-    [[ -n "$certificate_file" ]] || fatal "service-principal certificate authentication requires a certificate file"
-    check_certificate_file_permissions "$certificate_file"
-    printf '%s' "$certificate_file"
-}
-
-base64url() {
-    openssl base64 -A | tr '+/' '-_' | tr -d '='
-}
-
-split_pem_certificate_chain() {
-    local input="$1"
-    local output_dir="$2"
-    local start_index="${3:-0}"
-    awk -v outputDir="$output_dir" -v startIndex="$start_index" '
-        /-----BEGIN CERTIFICATE-----/ {
-            inCertificate = 1
-            certificateIndex++
-            output = sprintf("%s/%06d.pem", outputDir, startIndex + certificateIndex)
-        }
-        inCertificate { print > output }
-        /-----END CERTIFICATE-----/ {
-            close(output)
-            inCertificate = 0
-        }
-    ' "$input"
-}
-
-create_client_certificate_assertion() {
-    local certificate_file="$1"
-    local client_id="$2"
-    local audience="$3"
-    local output="$4"
-    local certificate_chain_dir="$TEMP_DIR/sp-client-certificate-chain"
-    local certificate_pem private_key_pem="$TEMP_DIR/sp-client-private-key.pem"
-    local now expires jwt_id thumbprint x5c header payload signing_input signature
-
-    require_command openssl
-    mkdir -p "$certificate_chain_dir"
-    chmod 0700 "$certificate_chain_dir"
-    if grep -aq -- '-----BEGIN CERTIFICATE-----' "$certificate_file"; then
-        split_pem_certificate_chain "$certificate_file" "$certificate_chain_dir"
-        openssl pkey -in "$certificate_file" -out "$private_key_pem" >/dev/null 2>&1 || \
-            fatal "failed to parse PEM client certificate private key"
-    else
-        local leaf_bundle="$TEMP_DIR/sp-client-leaf-bundle.pem"
-        local ca_bundle="$TEMP_DIR/sp-client-ca-bundle.pem"
-        [[ "$certificate_file" == *.pfx || "$certificate_file" == *.PFX ]] || \
-            fatal "binary PFX client-certificate file must use a .pfx suffix"
-        openssl pkcs12 -in "$certificate_file" -clcerts -nokeys -passin pass: -out "$leaf_bundle" >/dev/null 2>&1 || \
-            fatal "failed to extract certificate from unencrypted PFX file"
-        split_pem_certificate_chain "$leaf_bundle" "$certificate_chain_dir"
-        local leaf_count
-        leaf_count=$(find "$certificate_chain_dir" -type f -name '*.pem' | wc -l)
-        if openssl pkcs12 -in "$certificate_file" -cacerts -nokeys -passin pass: -out "$ca_bundle" >/dev/null 2>&1; then
-            split_pem_certificate_chain "$ca_bundle" "$certificate_chain_dir" "$leaf_count"
-        fi
-        openssl pkcs12 -in "$certificate_file" -nocerts -nodes -passin pass: -out "$private_key_pem" >/dev/null 2>&1 || \
-            fatal "failed to extract private key from unencrypted PFX file"
-    fi
-    certificate_pem=$(find "$certificate_chain_dir" -type f -name '*.pem' | sort | head -1)
-    [[ -n "$certificate_pem" ]] || fatal "client-certificate file does not contain a certificate"
-    chmod 0600 "$certificate_chain_dir"/*.pem "$private_key_pem"
-    openssl rsa -in "$private_key_pem" -check -noout >/dev/null 2>&1 || \
-        fatal "service-principal client certificate private key must be RSA"
-
-    thumbprint=$(openssl x509 -in "$certificate_pem" -outform DER | openssl dgst -sha1 -binary | base64url)
-    x5c='[]'
-    local chain_certificate encoded_certificate
-    while IFS= read -r chain_certificate; do
-        encoded_certificate=$(openssl x509 -in "$chain_certificate" -outform DER | openssl base64 -A)
-        x5c=$(jq -cn --argjson chain "$x5c" --arg certificate "$encoded_certificate" '$chain + [$certificate]')
-    done < <(find "$certificate_chain_dir" -type f -name '*.pem' | sort)
-    now=$(date +%s)
-    expires=$((now + 600))
-    if [[ -r /proc/sys/kernel/random/uuid ]]; then
-        jwt_id=$(</proc/sys/kernel/random/uuid)
-    else
-        jwt_id=$(openssl rand -hex 16)
-    fi
-    header=$(jq -cn --arg x5t "$thumbprint" --argjson x5c "$x5c" '{alg:"RS256",typ:"JWT",x5t:$x5t,x5c:$x5c}' | base64url)
-    payload=$(jq -cn --arg aud "$audience" --arg iss "$client_id" --arg sub "$client_id" --arg jti "$jwt_id" \
-        --argjson nbf "$((now - 60))" --argjson exp "$expires" \
-        '{aud:$aud,iss:$iss,sub:$sub,jti:$jti,nbf:$nbf,exp:$exp}' | base64url)
-    signing_input="${header}.${payload}"
-    signature=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$private_key_pem" -binary | base64url)
-    printf '%s.%s' "$signing_input" "$signature" > "$output"
-    chmod 0600 "$output"
-}
-
-acquire_arm_token() {
-    local current="$1"
-    local arm_endpoint="$2"
-    local output="$3"
-    local mode token_response
-    mode=$(resolve_fetch_auth_mode "$current")
-    token_response="$TEMP_DIR/arm-token-response.json"
-
-    case "$mode" in
-        msi)
-            local client_id="$MSI_CLIENT_ID"
-            if [[ -z "$client_id" ]]; then
-                client_id=$(jq -r '.azure.managedIdentity.clientId // ""' "$current")
-            fi
-            local curl_args=(
-                -fsS --get
-                --connect-timeout 10 --max-time 60
-                --retry 3 --retry-delay 2 --retry-all-errors
-                -H 'Metadata: true'
-                --data-urlencode 'api-version=2018-02-01'
-                --data-urlencode "resource=${arm_endpoint%/}/"
-                -o "$token_response"
-            )
-            if [[ -n "$client_id" ]]; then
-                curl_args+=(--data-urlencode "client_id=$client_id")
-            fi
-            curl "${curl_args[@]}" "$IMDS_ENDPOINT" || fatal "failed to acquire managed identity ARM token"
-            ;;
-        service-principal)
-            local tenant_id="$SP_TENANT_ID"
-            local client_id="$SP_CLIENT_ID"
-            local credential_kind request_body token_url
-            [[ -n "$tenant_id" ]] || tenant_id=$(jq -er '.azure.servicePrincipal.tenantId // .azure.tenantId' "$current")
-            [[ -n "$client_id" ]] || client_id=$(jq -er '.azure.servicePrincipal.clientId' "$current")
-            require_https_endpoint "$AUTHORITY_HOST" "service-principal authority host"
-            token_url="${AUTHORITY_HOST%/}/${tenant_id}/oauth2/v2.0/token"
-            credential_kind=$(resolve_sp_credential_kind "$current")
-            request_body="$TEMP_DIR/sp-token-request"
-            case "$credential_kind" in
-                secret)
-                    local secret_file
-                    secret_file=$(resolve_sp_secret_file "$current")
-                    jq -nr --arg clientID "$client_id" --arg scope "${arm_endpoint%/}/.default" --rawfile clientSecret "$secret_file" '
-                        ($clientSecret | rtrimstr("\n") | rtrimstr("\r")) as $secret |
-                        "client_id=\($clientID | @uri)&client_secret=\($secret | @uri)&scope=\($scope | @uri)&grant_type=client_credentials"
-                    ' > "$request_body"
-                    ;;
-                certificate)
-                    local certificate_file assertion_file
-                    certificate_file=$(resolve_sp_certificate_file "$current")
-                    assertion_file="$TEMP_DIR/sp-client-assertion"
-                    create_client_certificate_assertion "$certificate_file" "$client_id" "$token_url" "$assertion_file"
-                    jq -nr --arg clientID "$client_id" --arg scope "${arm_endpoint%/}/.default" --rawfile assertion "$assertion_file" '
-                        "client_id=\($clientID | @uri)&client_assertion=\($assertion | @uri)&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&scope=\($scope | @uri)&grant_type=client_credentials"
-                    ' > "$request_body"
-                    ;;
-            esac
-            chmod 0600 "$request_body"
-            curl -fsS --connect-timeout 10 --max-time 60 \
-                --retry 3 --retry-delay 2 --retry-all-errors \
-                -H 'Content-Type: application/x-www-form-urlencoded' \
-                --data-binary "@$request_body" -o "$token_response" "$token_url" || \
-                fatal "failed to acquire service-principal ARM token"
-            ;;
-    esac
-
-    jq -erj '.access_token' "$token_response" > "$output" || fatal "ARM token response did not contain an access token"
-    chmod 0600 "$output"
-}
-
 apply_target_overrides() {
     local current="$1"
     local rendered="$TEMP_DIR/config-target.json"
@@ -562,41 +309,71 @@ apply_target_overrides() {
 
 fetch_latest_bootstrap_data() {
     local current="$1"
-    local arm_endpoint resource_id pool_name token_file header_file response merged url
+    local response="$TEMP_DIR/bootstrap-data.json"
+    local merged="$TEMP_DIR/config-with-bootstrap-data.json"
+    local mode="${AUTH_MODE,,}"
+    local arm_endpoint resource_id pool_name tenant_id client_id
+    local args
+
     arm_endpoint=$(jq -r '.azure.resourceManagerEndpoint // "https://management.azure.com"' "$current")
     resource_id=$(jq -er '.azure.targetCluster.resourceId' "$current")
     pool_name=$(jq -er '.azure.targetAgentPoolName' "$current")
-    require_https_endpoint "$arm_endpoint" "resource manager endpoint"
-    shopt -s nocasematch
-    if [[ ! "$resource_id" =~ ^/subscriptions/[^/?#[:space:]]+/resourceGroups/[^/?#[:space:]]+/providers/Microsoft\.ContainerService/managedClusters/[^/?#[:space:]]+$ ]]; then
-        shopt -u nocasematch
-        fatal "embedded config contains an invalid target cluster resource ID"
-    fi
-    shopt -u nocasematch
-    [[ "$pool_name" =~ ^[A-Za-z0-9-]+$ ]] || fatal "embedded config contains an invalid target agent pool name"
-    [[ "$BOOTSTRAP_DATA_API_VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(-preview)?$ ]] || \
-        fatal "bootstrap-data API version has an invalid format"
+    [[ -n "$mode" ]] || {
+        if jq -e '.azure.managedIdentity != null' "$current" >/dev/null; then
+            mode=msi
+        elif jq -e '.azure.servicePrincipal != null' "$current" >/dev/null; then
+            mode=service-principal
+        else
+            fatal "fetching bootstrap data requires MSI or service-principal authentication"
+        fi
+    }
 
-    token_file="$TEMP_DIR/arm-access-token"
-    header_file="$TEMP_DIR/arm-headers"
-    response="$TEMP_DIR/bootstrap-data.json"
-    merged="$TEMP_DIR/config-with-bootstrap-data.json"
-    acquire_arm_token "$current" "$arm_endpoint" "$token_file"
-    {
-        printf 'Authorization: Bearer '
-        cat "$token_file"
-        printf '\nContent-Type: application/json\n'
-    } > "$header_file"
-    chmod 0600 "$header_file"
+    args=(
+        fetch-bootstrap-data
+        --cluster-resource-id "$resource_id"
+        --agent-pool-name "$pool_name"
+        --auth "$mode"
+        --resource-manager-endpoint "$arm_endpoint"
+        --authority-host "$AUTHORITY_HOST"
+        --api-version "$BOOTSTRAP_DATA_API_VERSION"
+        --output "$response"
+    )
+    case "$mode" in
+        msi|managed-identity)
+            client_id="$MSI_CLIENT_ID"
+            [[ -n "$client_id" ]] || client_id=$(jq -r '.azure.managedIdentity.clientId // ""' "$current")
+            [[ -z "$client_id" ]] || args+=(--msi-client-id "$client_id")
+            ;;
+        sp|service-principal)
+            tenant_id="$SP_TENANT_ID"
+            client_id="$SP_CLIENT_ID"
+            [[ -n "$tenant_id" ]] || tenant_id=$(jq -er '.azure.servicePrincipal.tenantId // .azure.tenantId' "$current")
+            [[ -n "$client_id" ]] || client_id=$(jq -er '.azure.servicePrincipal.clientId' "$current")
+            args+=(--sp-tenant-id "$tenant_id" --sp-client-id "$client_id")
+            if [[ -n "$SP_CLIENT_CERTIFICATE_FILE" ]]; then
+                args+=(--sp-client-certificate-file "$SP_CLIENT_CERTIFICATE_FILE")
+            elif [[ -n "$SP_CLIENT_SECRET_FILE" ]]; then
+                args+=(--sp-client-secret-file "$SP_CLIENT_SECRET_FILE")
+            elif [[ -n "$SP_CLIENT_SECRET" ]]; then
+                local secret_file="$TEMP_DIR/fetch-sp-client-secret"
+                printf '%s' "$SP_CLIENT_SECRET" > "$secret_file"
+                chmod 0600 "$secret_file"
+                args+=(--sp-client-secret-file "$secret_file")
+            else
+                local credential_file
+                credential_file=$(jq -r '.azure.servicePrincipal.clientSecretFile // ""' "$current")
+                if [[ -n "$credential_file" ]]; then
+                    args+=(--sp-client-credential-file "$credential_file")
+                else
+                    fatal "service-principal bootstrap-data fetch requires a credential file"
+                fi
+            fi
+            ;;
+        *) fatal "fetching bootstrap data does not support auth mode: $mode" ;;
+    esac
 
-    url="${arm_endpoint%/}${resource_id}/agentPools/${pool_name}/listBootstrapData?api-version=${BOOTSTRAP_DATA_API_VERSION}"
     log "fetching fresh bootstrap data from AKS RP"
-    curl -fsS --connect-timeout 10 --max-time 120 \
-        -X POST -H "@$header_file" --data '' -o "$response" "$url" || \
-        fatal "failed to fetch AKS bootstrap data"
-    chmod 0600 "$response"
-    jq -e 'type == "object" and (.azure.bootstrapToken.token | type == "string" and length > 0)' "$response" >/dev/null || \
-        fatal "AKS bootstrap-data response did not contain a bootstrap token"
+    "$INSTALL_DIR/aks-flex-node" "${args[@]}" || fatal "failed to fetch AKS bootstrap data"
     jq -s '.[0] * .[1]' "$current" "$response" > "$merged"
     mv -f "$merged" "$current"
 }
@@ -853,8 +630,8 @@ main() {
     local arch rendered_config
     arch=$(detect_architecture)
     rendered_config="$TEMP_DIR/config.json"
-    render_config "$rendered_config"
     download_and_install_agent "$arch"
+    render_config "$rendered_config"
     install_config "$rendered_config"
     clear_bootstrap_environment
 

--- a/scripts/bootstrap_test.sh
+++ b/scripts/bootstrap_test.sh
@@ -37,10 +37,23 @@ make_agent_archive() {
     mkdir -p "$dir"
     cat > "$dir/aks-flex-node-linux-$ARCH" <<'AGENT'
 #!/bin/bash
+printf '%s\n' "$*" >> "${BOOTSTRAP_TEST_CALLS:?}"
+if [[ "${1:-}" == fetch-bootstrap-data ]]; then
+    output=""
+    while (($# > 0)); do
+        if [[ "$1" == --output ]]; then output="$2"; break; fi
+        shift
+    done
+    [[ -n "$output" ]] || exit 24
+    cat > "$output" <<'JSON'
+{"azure":{"bootstrapToken":{"token":"fresh1.0123456789abcdef"}},"components":{"kubernetes":"1.35.6"},"networking":{"dnsServiceIP":"10.0.0.10","cniVersion":"stale-cni"}}
+JSON
+    chmod 0600 "$output"
+    exit 0
+fi
 for variable in AKS_FLEX_NODE_AGENT_URL AKS_FLEX_NODE_SP_CLIENT_SECRET AKS_FLEX_NODE_CONFIG_OVERRIDES AKS_FLEX_NODE_FETCH_BOOTSTRAP_DATA AKS_FLEX_NODE_AUTHORITY_HOST AKS_FLEX_NODE_IMDS_ENDPOINT AKS_FLEX_NODE_ALLOW_INSECURE_TEST_ENDPOINTS AKS_FLEX_NODE_CLUSTER_RESOURCE_ID AKS_FLEX_NODE_AGENT_POOL_NAME AKS_FLEX_NODE_RESOURCE_MANAGER_ENDPOINT AKS_FLEX_NODE_BOOTSTRAP_OCI_IMAGE AKS_FLEX_NODE_BOOTSTRAP_OFFLINE_ARTIFACTS_SOURCE AKS_FLEX_NODE_SP_CLIENT_CERTIFICATE_FILE; do
     [[ -z "${!variable+x}" ]] || exit 23
 done
-printf '%s\n' "$*" >> "${BOOTSTRAP_TEST_CALLS:?}"
 AGENT
     chmod 0755 "$dir/aks-flex-node-linux-$ARCH"
     tar -C "$dir" -czf "$dir/agent.tar.gz" "aks-flex-node-linux-$ARCH"
@@ -307,22 +320,6 @@ if BOOTSTRAP_TEST_CALLS="$WORK_DIR/no-base-calls" \
 fi
 grep -q 'embedded base config is not populated' "$WORK_DIR/no-base.log" || \
     fail "missing base config rejection was not reported"
-
-if BOOTSTRAP_TEST_CALLS="$WORK_DIR/insecure-calls" \
-    AKS_FLEX_NODE_BASE_CONFIG_FILE="$WORK_DIR/fetch-base.json" \
-    AKS_FLEX_NODE_IMDS_ENDPOINT="http://127.0.0.1:${port}/metadata/identity/oauth2/token" \
-    AKS_FLEX_NODE_AGENT_URL="$AGENT_URL" \
-        bash "$SCRIPT" --fetch-bootstrap-data --auth msi \
-            --cluster-resource-id '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster' \
-            --agent-pool-name aksflexnodes \
-            --resource-manager-endpoint "http://127.0.0.1:${port}" \
-            --install-dir "$WORK_DIR/insecure-bin" \
-            --config-path "$WORK_DIR/insecure-etc/config.json" \
-            >"$WORK_DIR/insecure.log" 2>&1; then
-    fail "HTTP resource manager endpoint was accepted"
-fi
-grep -q 'resource manager endpoint must use HTTPS' "$WORK_DIR/insecure.log" || \
-    fail "HTTP endpoint rejection was not reported"
 
 printf '%s' 'base-sp-secret' > "$WORK_DIR/fetch-sp-secret"
 chmod 0600 "$WORK_DIR/fetch-sp-secret"


### PR DESCRIPTION
## Summary

- add `aks-flex-node fetch-bootstrap-data` for authenticated AKS RP bootstrap-data retrieval
- support MSI, SP secret, protected secret file, auto-detected credential file, PEM certificate, and unencrypted PFX
- use Azure Identity for certificate parsing, x5t/x5c client assertions, cloud configuration, and token caching behavior
- require a protected output file and write it atomically as mode 0600
- simplify `scripts/bootstrap.sh` to download/install the agent first and delegate authentication/RP details to the Go command
- remove shell-built JWTs, x5t/x5c extraction, PFX parsing, Entra token exchange, bearer-header handling, and OpenSSL runtime dependency

## Command

```console
aks-flex-node fetch-bootstrap-data \
  --cluster-resource-id "$AKS_CLUSTER_RESOURCE_ID" \
  --agent-pool-name aksflexnodes \
  --auth service-principal \
  --sp-tenant-id "$TENANT_ID" \
  --sp-client-id "$CLIENT_ID" \
  --sp-client-certificate-file /run/credentials/aks-flex-node-certificate \
  --output /run/aks-flex-node/bootstrap-data.json
```

The command never writes bootstrap credentials to stdout. It validates the response contains a bootstrap token and bounds response size to 16 MiB.

## Shell integration

`bootstrap.sh` now installs the selected `aks-flex-node` binary before config rendering, invokes `fetch-bootstrap-data`, merges the protected response with jq, and continues with artifact overrides, config validation, preflight, and start. Direct SP secrets are staged as protected files instead of passed on the command line.

## Security

- Azure SDK handles MSI, client-secret, PEM/PFX parsing, x5t, x5c, and assertions
- certificate auth enables `SendCertificateChain: true`
- ARM and authority endpoints require HTTPS
- redirects are rejected
- resource ID, pool, and API version are validated
- response and final config writes are atomic and mode 0600
- secret CLI flag is intentionally omitted; direct secret input is environment-only

## Validation

- `go test ./...`
- `make check`
- `scripts/bootstrap_test.sh`
- live SNI credential probe: Go subcommand acquired an ARM token and reached AKS RP, returning expected `HTTP 404` for a random cluster with no output file content

## Dependency

This is a stacked draft PR based on `hbc/install-script` / PR #248. It intentionally does not include the Go `boot` command from PR #257.


## Published prerelease validation

Published `v0.1.6.alpha-5` from commit `bd8c549`.

```text
AMD64 SHA-256: 31cafa551dcf0c52ae257b7ac4d2971f167f797faa9272736c3309558c2f397a
ARM64 SHA-256: 2da20bc53e323a07e8284cb92ee4179d7dcf662159b3a36de75f64b5be15d44f
```

The released ARM64 binary was downloaded, checksum-verified, and run with the SNI test certificate. `fetch-bootstrap-data` acquired an ARM token and reached AKS RP; the deliberate random-cluster probe returned expected `HTTP 404` with an empty output file, confirming authentication was delegated to the released Go binary.

A full node-join retry was blocked by backend availability rather than auth: westus3 and eastus2 allowed FlexNodes pool creation but `listBootstrapData` returned `Flex node support is not yet available in this region or environment`; eastus was capacity-blocked; eastus2euap VNet creation was unavailable to this subscription. All VM/AKS/VNet/IP/NSG/disk resources and isolated auth caches were deleted. Local diagnostics are under `/home/bahe/workshop/msft/flex/api-test/sni-cert-e2e/logs/`.
