### PR TITLE
Add CodeQL workflow for S360 compliance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: "CodeQL"
+
+# S360 standard Microsoft.Security.CodeQL.10000 requires every active,
+# production repo to publish a non-expired CodeQL snapshot per language.
+# AKSFlexNode (module github.com/Azure/AKSFlexNode, Go) had no CodeQL workflow,
+# so it showed up non-compliant. This scans the Go code on every push to main
+# plus a weekly schedule so a fresh snapshot is always uploaded.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 7 * * 1" # Mondays at 7:00 AM UTC
+  workflow_dispatch: # allow manual runs (e.g. to refresh an expired snapshot)
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c793b717bc78562f491db7b0e93a3a178b099162
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What / Why

`AKSFlexNode` (module `github.com/Azure/AKSFlexNode`, primarily **Go**) has **no CodeQL workflow**, so it is flagged non-compliant for S360 standard **Microsoft.Security.CodeQL.10000** (every active, production repo must publish a non-expired CodeQL snapshot per language).

This adds `.github/workflows/codeql.yml` that runs CodeQL Go `autobuild` on:
- every push / PR to `main`,
- a weekly schedule (`cron: "0 7 * * 1"`), so a fresh snapshot is uploaded even without commits,
- manual `workflow_dispatch`.

Pattern mirrors the existing `Azure/gpu-provisioner` CodeQL workflow (pinned action SHAs, `security-events: write`, autobuild for Go).

## Notes
- Scanning Go only for now (the repo's primary language). If S360 later flags another language for this repo, add it to the `matrix.language` list.
- Scheduled workflows on low-activity repos can be auto-disabled by GitHub after 60 days of inactivity; re-enable + re-run to refresh if that happens.
- After merge, confirm a fresh `go` snapshot is attributed to this repo (allow 48–72h).
