### PR TITLE
Refresh AKS bootstrap data before blue-green repave

### DIFF
--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -108,7 +108,9 @@ Additional environment variables:
 | `E2E_KUBERNETES_VERSION` | `1.35.0` | Kubernetes version used in generated node configs. |
 | `E2E_CONTAINERD_VERSION` | `2.0.4` | Containerd version used in generated node configs. |
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
-| `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Target AKS agent pool name written to generated node configs. |
+| `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Synthetic target agent pool name used by controller-backed test modes. |
+| `E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME` | `system` | Existing ARM agent pool used by the MSI scenario for `listBootstrapData`. |
+| `E2E_BOOTSTRAP_DATA_API_VERSION` | `2026-05-02-preview` | AKS API version used for MSI bootstrap-data retrieval and repave refresh. |
 | `E2E_KUBELET_MAX_PODS` | `58` | `node.maxPods` override written to the bootstrap-token node config. |
 | `E2E_KUBELET_SYSTEM_RESERVED_CPU` | `50m` | `node.kubelet.systemReserved.cpu` override written to the bootstrap-token node config. |
 | `E2E_KUBELET_SYSTEM_RESERVED_MEMORY` | `100Mi` | `node.kubelet.systemReserved.memory` override written to the bootstrap-token node config. |
@@ -141,7 +143,7 @@ The suite validates four join paths:
 
 | VM | Auth Mode | Join Path |
 |----|-----------|-----------|
-| `vm-e2e-msi-*` | Managed Identity | Generated managed-identity config and `aks-flex-node start` flow. |
+| `vm-e2e-msi-*` | Managed Identity + Bootstrap Token | Operator-first dual-auth config using AKS RP `listBootstrapData`; repave invalidates the original token and requires an in-memory refresh. |
 | `vm-e2e-token-*` | Bootstrap Token | Kubernetes bootstrap token, RBAC, generated config, and `aks-flex-node start` flow. |
 | `vm-e2e-offline-*` | Bootstrap Token + Offline Artifacts | Bootstrap token config pins `bootstrap.ociImage=ghcr.io/azure/agent-ubuntu2404:v20260619`; the test builds a bootstrap artifact bundle at runtime, publishes it to a VM-local loopback registry, and sets `bootstrap.offlineArtifacts.source=oci://127.0.0.1:5000/aks-flex/bootstrap-artifacts:v20260708-k8s-{{ .KubernetesVersion }}`. |
 | `vm-e2e-kubeadm-*` | Bootstrap Token | Kubeadm-style bootstrap resources plus generated config and `aks-flex-node start` flow. |
@@ -200,11 +202,13 @@ Run it against joined infrastructure:
 The `upgrade-drift` command validates the controller-machine-driven repave path:
 
 1. Ensure the selected mode is joined.
-2. Update the machine goal in the controller's `kube-system/aks-flex-machines` ConfigMap.
-3. Delete the Kubernetes `Node` object to trigger repave.
-4. Wait for the active nspawn side to report the desired kubelet version.
-5. Wait for the Kubernetes `Node` to become `Ready` again with the desired kubelet version.
-6. Run a smoke workload on the repaved node.
+2. For MSI, delete the original bootstrap-token Secret so the alternate kubelet cannot reuse its persisted token.
+3. Update the machine goal in the controller's `kube-system/aks-flex-machines` ConfigMap.
+4. Delete the Kubernetes `Node` object to trigger repave.
+5. Wait for the active nspawn side to report the desired kubelet version.
+6. Wait for the Kubernetes `Node` to return with a new UID, become `Ready`, and report the desired kubelet version.
+7. For MSI, verify the daemon logged a bootstrap-data refresh, did not persist the fresh response, and did not recreate the deleted token.
+8. Run a smoke workload on the repaved node.
 
 Run it after infrastructure is deployed:
 

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -110,7 +110,6 @@ Additional environment variables:
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
 | `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Synthetic target agent pool name used by controller-backed test modes. |
 | `E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME` | `$E2E_TARGET_AGENT_POOL_NAME` | ARM FlexNodes agent pool provisioned for the MSI scenario and used for `listBootstrapData`. |
-| `E2E_BOOTSTRAP_DATA_API_VERSION` | `2026-05-02-preview` | AKS API version used for MSI bootstrap-data retrieval and repave refresh. |
 | `E2E_KUBELET_MAX_PODS` | `58` | `node.maxPods` override written to the bootstrap-token node config. |
 | `E2E_KUBELET_SYSTEM_RESERVED_CPU` | `50m` | `node.kubelet.systemReserved.cpu` override written to the bootstrap-token node config. |
 | `E2E_KUBELET_SYSTEM_RESERVED_MEMORY` | `100Mi` | `node.kubelet.systemReserved.memory` override written to the bootstrap-token node config. |

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -109,7 +109,7 @@ Additional environment variables:
 | `E2E_CONTAINERD_VERSION` | `2.0.4` | Containerd version used in generated node configs. |
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
 | `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Synthetic target agent pool name used by controller-backed test modes. |
-| `E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME` | `system` | Existing ARM agent pool used by the MSI scenario for `listBootstrapData`. |
+| `E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME` | `$E2E_TARGET_AGENT_POOL_NAME` | ARM FlexNodes agent pool provisioned for the MSI scenario and used for `listBootstrapData`. |
 | `E2E_BOOTSTRAP_DATA_API_VERSION` | `2026-05-02-preview` | AKS API version used for MSI bootstrap-data retrieval and repave refresh. |
 | `E2E_KUBELET_MAX_PODS` | `58` | `node.maxPods` override written to the bootstrap-token node config. |
 | `E2E_KUBELET_SYSTEM_RESERVED_CPU` | `50m` | `node.kubelet.systemReserved.cpu` override written to the bootstrap-token node config. |

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -206,7 +206,7 @@ The `upgrade-drift` command validates the controller-machine-driven repave path:
 4. Delete the Kubernetes `Node` object to trigger repave.
 5. Wait for the active nspawn side to report the desired kubelet version.
 6. Wait for the Kubernetes `Node` to return with a new UID, become `Ready`, and report the desired kubelet version.
-7. For MSI, verify the daemon logged a bootstrap-data refresh, did not persist the fresh response, and did not recreate the deleted token.
+7. For MSI, verify the daemon logged a bootstrap-data refresh and did not persist the fresh response. AKS RP may recreate the deleted Secret with the same token ID while renewing its validity.
 8. Run a smoke workload on the repaved node.
 
 Run it after infrastructure is deployed:

--- a/hack/e2e/infra/main.bicep
+++ b/hack/e2e/infra/main.bicep
@@ -24,6 +24,12 @@ param aksNodeVmSize string = 'Standard_B2s'
 @description('Flex node VM size.')
 param vmSize string = 'Standard_B2as_v2'
 
+@description('Kubernetes version used by the AKS cluster and FlexNodes pool.')
+param kubernetesVersion string = '1.35.0'
+
+@description('Name of the ARM FlexNodes agent pool.')
+param flexAgentPoolName string = 'aksflexnodes'
+
 @description('Admin username for VMs.')
 param adminUsername string = 'azureuser'
 
@@ -117,6 +123,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
   }
   properties: {
     dnsPrefix: clusterName
+    kubernetesVersion: kubernetesVersion
     enableRBAC: true
     aadProfile: {
       managed: true
@@ -138,6 +145,19 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
         vnetSubnetID: vnet.properties.subnets[0].id
       }
     ]
+  }
+}
+
+// listBootstrapData is available only on an ARM FlexNodes pool. This pool has
+// no Azure-managed VMSS capacity; the external E2E VM joins it during bootstrap.
+resource flexAgentPool 'Microsoft.ContainerService/managedClusters/agentPools@2026-05-02-preview' = {
+  parent: aksCluster
+  name: flexAgentPoolName
+  properties: {
+    type: 'FlexNodes'
+    mode: 'User'
+    orchestratorVersion: kubernetesVersion
+    maxPods: 250
   }
 }
 
@@ -213,6 +233,18 @@ resource roleClusterAdmin 'Microsoft.Authorization/roleAssignments@2022-04-01' =
     principalId: vmMsi.outputs.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8')
+  }
+}
+
+// Azure Kubernetes Service Contributor Role permits runtime Machine API and
+// listBootstrapData calls from the MSI Flex Node.
+resource roleAKSContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aksCluster.id, msiVmName, 'aks-contributor')
+  scope: aksCluster
+  properties: {
+    principalId: vmMsi.outputs.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8')
   }
 }
 

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -201,7 +201,6 @@ load_config() {
   # controller still uses E2E_TARGET_AGENT_POOL_NAME for its synthetic machine
   # contract, while the MSI repave scenario uses this real pool for join data.
   E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-${E2E_TARGET_AGENT_POOL_NAME}}"
-  E2E_BOOTSTRAP_DATA_API_VERSION="${E2E_BOOTSTRAP_DATA_API_VERSION:-2026-05-02-preview}"
 
   # Kubelet resource reservation overrides applied to the token node config.
   # The remaining nodes keep the AKS-compatible defaults computed by the agent.

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -200,7 +200,7 @@ load_config() {
   # listBootstrapData requires an existing ARM agent pool. The in-cluster
   # controller still uses E2E_TARGET_AGENT_POOL_NAME for its synthetic machine
   # contract, while the MSI repave scenario uses this real pool for join data.
-  E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-system}"
+  E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-${E2E_TARGET_AGENT_POOL_NAME}}"
   E2E_BOOTSTRAP_DATA_API_VERSION="${E2E_BOOTSTRAP_DATA_API_VERSION:-2026-05-02-preview}"
 
   # Kubelet resource reservation overrides applied to the token node config.

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -197,6 +197,11 @@ load_config() {
   E2E_CONTAINERD_VERSION="${E2E_CONTAINERD_VERSION:-2.0.4}"
   E2E_RUNC_VERSION="${E2E_RUNC_VERSION:-1.1.12}"
   E2E_TARGET_AGENT_POOL_NAME="${E2E_TARGET_AGENT_POOL_NAME:-aksflexnodes}"
+  # listBootstrapData requires an existing ARM agent pool. The in-cluster
+  # controller still uses E2E_TARGET_AGENT_POOL_NAME for its synthetic machine
+  # contract, while the MSI repave scenario uses this real pool for join data.
+  E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-system}"
+  E2E_BOOTSTRAP_DATA_API_VERSION="${E2E_BOOTSTRAP_DATA_API_VERSION:-2026-05-02-preview}"
 
   # Kubelet resource reservation overrides applied to the token node config.
   # The remaining nodes keep the AKS-compatible defaults computed by the agent.
@@ -222,6 +227,7 @@ load_config() {
   log_info "  Subscription:     ${AZURE_SUBSCRIPTION_ID}"
   log_info "  Name Suffix:      ${E2E_NAME_SUFFIX}"
   log_info "  Agent Pool:       ${E2E_TARGET_AGENT_POOL_NAME}"
+  log_info "  Bootstrap Pool:   ${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}"
   log_info "  AKS Node VM Size: ${E2E_AKS_NODE_VM_SIZE}"
   log_info "  Flex VM Size:     ${E2E_VM_SIZE}"
   log_info "  Kubeconfig:       ${KUBECONFIG}"

--- a/hack/e2e/lib/infra.sh
+++ b/hack/e2e/lib/infra.sh
@@ -94,6 +94,8 @@ infra_deploy() {
       nameSuffix="${E2E_NAME_SUFFIX}" \
       aksNodeVmSize="${E2E_AKS_NODE_VM_SIZE}" \
       vmSize="${E2E_VM_SIZE}" \
+      kubernetesVersion="${E2E_KUBERNETES_VERSION}" \
+      flexAgentPoolName="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}" \
       sshPublicKey="${ssh_key}" \
       tags="${tags_json}" \
     --output none

--- a/hack/e2e/lib/node-join-msi.sh
+++ b/hack/e2e/lib/node-join-msi.sh
@@ -168,13 +168,14 @@ node_join_msi() {
 EOF
 
   log_info "Fetching initial AKS RP bootstrap data for the MSI repave scenario..."
+  install -m 0600 /dev/null "${bootstrap_data_file}"
   with_cluster_lock az rest \
     --only-show-errors \
     --method post \
-    --url "https://management.azure.com${cluster_id}/agentPools/${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}/listBootstrapData?api-version=${E2E_BOOTSTRAP_DATA_API_VERSION}" \
+    --url "https://management.azure.com${cluster_id}/agentPools/${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}/listBootstrapData?api-version=2026-05-02-preview" \
     --output json > "${bootstrap_data_file}"
-  chmod 0600 "${bootstrap_data_file}"
   jq -e '.azure.bootstrapToken.token | type == "string" and length > 0' "${bootstrap_data_file}" >/dev/null
+  install -m 0600 /dev/null "${config_file}.tmp"
   jq --slurpfile bootstrapData "${bootstrap_data_file}" '
     .azure.bootstrapToken = $bootstrapData[0].azure.bootstrapToken
     | .node.kubelet.clusterFQDN = ($bootstrapData[0].node.kubelet.clusterFQDN // .node.kubelet.clusterFQDN)

--- a/hack/e2e/lib/node-join-msi.sh
+++ b/hack/e2e/lib/node-join-msi.sh
@@ -96,15 +96,18 @@ node_join_msi() {
   local ca_cert_data
   ca_cert_data="$(state_get ca_cert_data)"
 
-  # Step 1: Generate MSI config
+  # Step 1: Generate a dual-auth operator-first config. The initial token comes
+  # from the same RP action that repave must refresh, while MSI remains available
+  # to the host daemon for subsequent listBootstrapData calls.
   local config_file="${E2E_WORK_DIR}/config-msi.json"
+  local bootstrap_data_file="${E2E_WORK_DIR}/bootstrap-data-msi.json"
   cat > "${config_file}" <<EOF
 {
   "azure": {
     "subscriptionId": "${subscription_id}",
     "tenantId": "${tenant_id}",
     "resourceManagerEndpoint": "https://management.azure.com",
-    "targetAgentPoolName": "${E2E_TARGET_AGENT_POOL_NAME}",
+    "targetAgentPoolName": "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}",
     "managedIdentity": {},
     "targetCluster": {
       "resourceId": "${cluster_id}",
@@ -163,6 +166,23 @@ node_join_msi() {
   }
 }
 EOF
+
+  log_info "Fetching initial AKS RP bootstrap data for the MSI repave scenario..."
+  with_cluster_lock az rest \
+    --only-show-errors \
+    --method post \
+    --url "https://management.azure.com${cluster_id}/agentPools/${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}/listBootstrapData?api-version=${E2E_BOOTSTRAP_DATA_API_VERSION}" \
+    --output json > "${bootstrap_data_file}"
+  chmod 0600 "${bootstrap_data_file}"
+  jq -e '.azure.bootstrapToken.token | type == "string" and length > 0' "${bootstrap_data_file}" >/dev/null
+  jq --slurpfile bootstrapData "${bootstrap_data_file}" '
+    .azure.bootstrapToken = $bootstrapData[0].azure.bootstrapToken
+    | .node.kubelet.clusterFQDN = ($bootstrapData[0].node.kubelet.clusterFQDN // .node.kubelet.clusterFQDN)
+    | .node.kubelet.caCertData = ($bootstrapData[0].node.kubelet.caCertData // .node.kubelet.caCertData)
+  ' "${config_file}" > "${config_file}.tmp"
+  mv "${config_file}.tmp" "${config_file}"
+  chmod 0600 "${config_file}"
+  rm -f "${bootstrap_data_file}"
 
   # Step 2: Put systemd-resolved into the layout supported by LocalDNS.
   prepare_localdns_host_resolver "${vm_ip}"

--- a/hack/e2e/lib/upgrade-drift.sh
+++ b/hack/e2e/lib/upgrade-drift.sh
@@ -213,10 +213,10 @@ _verify_msi_bootstrap_refresh() {
   fi
   remote_exec "${vm_ip}" 'bash -s' <<'REMOTE'
 set -euo pipefail
-if sudo journalctl -u aks-flex-node-agent.service --no-pager 2>/dev/null | grep -Fq 'refreshing AKS bootstrap data for repave'; then
+if sudo journalctl -u aks-flex-node-agent.service --no-pager 2>/dev/null | grep -Fq 'refreshed AKS bootstrap data for repave'; then
   exit 0
 fi
-sudo grep -Fq 'refreshing AKS bootstrap data for repave' /var/log/aks-flex-node/aks-flex-node.log
+sudo grep -Fq 'refreshed AKS bootstrap data for repave' /var/log/aks-flex-node/aks-flex-node.log
 REMOTE
   log_success "MSI repave fetched fresh bootstrap data without persisting it"
 }

--- a/hack/e2e/lib/upgrade-drift.sh
+++ b/hack/e2e/lib/upgrade-drift.sh
@@ -178,10 +178,53 @@ REMOTE
   return 1
 }
 
+_msi_bootstrap_token_id() {
+  local vm_ip="$1"
+  remote_exec "${vm_ip}" 'sudo jq -er '\''.azure.bootstrapToken.token | split(".")[0]'\'' /etc/aks-flex-node/config.json'
+}
+
+_invalidate_msi_bootstrap_token() {
+  local vm_ip="$1"
+  local token_id
+  token_id="$(_msi_bootstrap_token_id "${vm_ip}")"
+  if [[ ! "${token_id}" =~ ^[a-z0-9]{6}$ ]]; then
+    log_error "MSI config did not contain a valid bootstrap token ID"
+    return 1
+  fi
+
+  kubectl -n kube-system delete secret "bootstrap-token-${token_id}" --ignore-not-found --wait=true >&2
+  if kubectl -n kube-system get secret "bootstrap-token-${token_id}" >/dev/null 2>&1; then
+    log_error "Original MSI bootstrap-token Secret still exists after deletion"
+    return 1
+  fi
+  printf '%s\n' "${token_id}"
+}
+
+_verify_msi_bootstrap_refresh() {
+  local vm_ip="$1" old_token_id="$2"
+
+  if [[ "$(_msi_bootstrap_token_id "${vm_ip}")" != "${old_token_id}" ]]; then
+    log_error "Repave unexpectedly persisted refreshed bootstrap data"
+    return 1
+  fi
+  if kubectl -n kube-system get secret "bootstrap-token-${old_token_id}" >/dev/null 2>&1; then
+    log_error "Repave reused or recreated the deleted bootstrap-token Secret"
+    return 1
+  fi
+  remote_exec "${vm_ip}" 'bash -s' <<'REMOTE'
+set -euo pipefail
+if sudo journalctl -u aks-flex-node-agent.service --no-pager 2>/dev/null | grep -Fq 'refreshing AKS bootstrap data for repave'; then
+  exit 0
+fi
+sudo grep -Fq 'refreshing AKS bootstrap data for repave' /var/log/aks-flex-node/aks-flex-node.log
+REMOTE
+  log_success "MSI repave fetched fresh bootstrap data without persisting it"
+}
+
 upgrade_drift_mode() {
   local mode="$1"
   log_section "Controller Machine Repave (${mode} node)"
-  local start desired_version settings_version vm_name vm_ip old_machine_snapshot old_active_machine old_state old_version old_settings_version old_node_uid
+  local start desired_version settings_version vm_name vm_ip old_machine_snapshot old_active_machine old_state old_version old_settings_version old_node_uid old_bootstrap_token_id
   start="$(timer_start)"
 
   desired_version="$(_cluster_current_kubernetes_version)"
@@ -202,8 +245,17 @@ upgrade_drift_mode() {
   fi
   log_debug "${mode} pre-repave state: active_machine=${old_active_machine} state=${old_state:-unknown} kubelet=${old_version:-unknown} applied_settings=${old_settings_version:-unknown} node_uid=${old_node_uid}"
 
+  old_bootstrap_token_id=""
+  if [[ "${mode}" == "msi" ]]; then
+    log_info "Deleting the MSI node's original bootstrap-token Secret before repave"
+    old_bootstrap_token_id="$(_invalidate_msi_bootstrap_token "${vm_ip}")"
+  fi
+
   _trigger_mode_repave "${mode}" "${desired_version}" "${settings_version}"
   _wait_for_mode_repave "${mode}" "${desired_version}" "${settings_version}" "${old_active_machine}" "${old_node_uid}"
+  if [[ "${mode}" == "msi" ]]; then
+    _verify_msi_bootstrap_refresh "${vm_ip}" "${old_bootstrap_token_id}"
+  fi
   smoke_test "${vm_name}" "${mode}-repave"
 
   log_success "${mode} controller machine repave passed in $(timer_elapsed "${start}")s"

--- a/hack/e2e/lib/upgrade-drift.sh
+++ b/hack/e2e/lib/upgrade-drift.sh
@@ -207,10 +207,9 @@ _verify_msi_bootstrap_refresh() {
     log_error "Repave unexpectedly persisted refreshed bootstrap data"
     return 1
   fi
-  if kubectl -n kube-system get secret "bootstrap-token-${old_token_id}" >/dev/null 2>&1; then
-    log_error "Repave reused or recreated the deleted bootstrap-token Secret"
-    return 1
-  fi
+  # AKS RP may recreate the Secret with the same token ID while renewing its
+  # validity. Successful registration after deletion plus the daemon refresh log
+  # proves the alternate kubelet received usable data from listBootstrapData.
   remote_exec "${vm_ip}" 'bash -s' <<'REMOTE'
 set -euo pipefail
 if sudo journalctl -u aks-flex-node-agent.service --no-pager 2>/dev/null | grep -Fq 'refreshed AKS bootstrap data for repave'; then

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -54,6 +54,16 @@ type Options struct {
 	OutputPath              string
 }
 
+// Data contains the short-lived Kubernetes join credentials returned by
+// listBootstrapData. The raw response is retained only so the bootstrap CLI can
+// write the complete RP response; runtime callers should use the typed fields.
+type Data struct {
+	BootstrapToken string
+	ClusterFQDN    string
+	CACertData     string
+	raw            map[string]any
+}
+
 type dependencies struct {
 	credential func(Options, azcore.ClientOptions) (azcore.TokenCredential, error)
 	httpClient *http.Client
@@ -71,67 +81,24 @@ func defaultDependencies() dependencies {
 	}
 }
 
+// Fetch obtains fresh bootstrap data without persisting the sensitive response.
+func Fetch(ctx context.Context, options Options) (*Data, error) {
+	return fetch(ctx, options, defaultDependencies())
+}
+
 func FetchAndWrite(ctx context.Context, options Options) error {
 	return fetchAndWrite(ctx, options, defaultDependencies())
 }
 
 func fetchAndWrite(ctx context.Context, options Options, deps dependencies) error {
-	if err := validateOptions(options); err != nil {
-		return err
+	if strings.TrimSpace(options.OutputPath) == "" {
+		return fmt.Errorf("output path is required")
 	}
-	endpoint := strings.TrimRight(options.ResourceManagerEndpoint, "/")
-	clientOptions := azcore.ClientOptions{Cloud: cloud.Configuration{
-		ActiveDirectoryAuthorityHost: options.AuthorityHost,
-		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-			cloud.ResourceManager: {Endpoint: endpoint, Audience: endpoint},
-		},
-	}}
-	credential, err := deps.credential(options, clientOptions)
+	result, err := fetch(ctx, options, deps)
 	if err != nil {
 		return err
 	}
-	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{endpoint + "/.default"}})
-	if err != nil {
-		return fmt.Errorf("acquire ARM token: %w", err)
-	}
-	requestURL := endpoint + options.ClusterResourceID + "/agentPools/" + options.AgentPoolName +
-		"/listBootstrapData?api-version=" + options.APIVersion
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, http.NoBody)
-	if err != nil {
-		return fmt.Errorf("create bootstrap-data request: %w", err)
-	}
-	request.Header.Set("Authorization", "Bearer "+token.Token)
-	request.Header.Set("Content-Type", "application/json")
-	response, err := deps.httpClient.Do(request)
-	if err != nil {
-		return fmt.Errorf("fetch bootstrap data: %w", err)
-	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		_ = response.Body.Close()
-		return fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
-	}
-	data, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
-	closeErr := response.Body.Close()
-	if readErr != nil {
-		return fmt.Errorf("read bootstrap data: %w", readErr)
-	}
-	if closeErr != nil {
-		return fmt.Errorf("close bootstrap-data response: %w", closeErr)
-	}
-	if int64(len(data)) > maxResponseBytes {
-		return fmt.Errorf("bootstrap data exceeds %d bytes", maxResponseBytes)
-	}
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
-		return fmt.Errorf("parse bootstrap data: %w", err)
-	}
-	azure, _ := result["azure"].(map[string]any)
-	bootstrapToken, _ := azure["bootstrapToken"].(map[string]any)
-	value, _ := bootstrapToken["token"].(string)
-	if value == "" {
-		return fmt.Errorf("bootstrap-data response did not contain a bootstrap token")
-	}
-	formatted, err := json.MarshalIndent(result, "", "  ")
+	formatted, err := json.MarshalIndent(result.raw, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal bootstrap data: %w", err)
 	}
@@ -143,6 +110,83 @@ func fetchAndWrite(ctx context.Context, options Options, deps dependencies) erro
 		return fmt.Errorf("atomically write bootstrap data: %w", err)
 	}
 	return os.Chmod(options.OutputPath, 0o600)
+}
+
+func fetch(ctx context.Context, options Options, deps dependencies) (*Data, error) {
+	if err := validateOptions(options); err != nil {
+		return nil, err
+	}
+	endpoint := strings.TrimRight(options.ResourceManagerEndpoint, "/")
+	clientOptions := azcore.ClientOptions{Cloud: cloud.Configuration{
+		ActiveDirectoryAuthorityHost: options.AuthorityHost,
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: endpoint, Audience: endpoint},
+		},
+	}}
+	credential, err := deps.credential(options, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{endpoint + "/.default"}})
+	if err != nil {
+		return nil, fmt.Errorf("acquire ARM token: %w", err)
+	}
+	requestURL := endpoint + options.ClusterResourceID + "/agentPools/" + options.AgentPoolName +
+		"/listBootstrapData?api-version=" + options.APIVersion
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create bootstrap-data request: %w", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token.Token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := deps.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch bootstrap data: %w", err)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		_ = response.Body.Close()
+		return nil, fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	closeErr := response.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read bootstrap data: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close bootstrap-data response: %w", closeErr)
+	}
+	if int64(len(data)) > maxResponseBytes {
+		return nil, fmt.Errorf("bootstrap data exceeds %d bytes", maxResponseBytes)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse bootstrap data: %w", err)
+	}
+	var responseData struct {
+		Azure struct {
+			BootstrapToken struct {
+				Token string `json:"token"`
+			} `json:"bootstrapToken"`
+		} `json:"azure"`
+		Node struct {
+			Kubelet struct {
+				ClusterFQDN string `json:"clusterFQDN"`
+				CACertData  string `json:"caCertData"`
+			} `json:"kubelet"`
+		} `json:"node"`
+	}
+	if err := json.Unmarshal(data, &responseData); err != nil {
+		return nil, fmt.Errorf("parse typed bootstrap data: %w", err)
+	}
+	if responseData.Azure.BootstrapToken.Token == "" {
+		return nil, fmt.Errorf("bootstrap-data response did not contain a bootstrap token")
+	}
+	return &Data{
+		BootstrapToken: responseData.Azure.BootstrapToken.Token,
+		ClusterFQDN:    responseData.Node.Kubelet.ClusterFQDN,
+		CACertData:     responseData.Node.Kubelet.CACertData,
+		raw:            raw,
+	}, nil
 }
 
 func validateOptions(options Options) error {
@@ -166,9 +210,6 @@ func validateOptions(options Options) error {
 	}
 	if !apiVersionPattern.MatchString(options.APIVersion) {
 		return fmt.Errorf("invalid API version %q", options.APIVersion)
-	}
-	if strings.TrimSpace(options.OutputPath) == "" {
-		return fmt.Errorf("output path is required")
 	}
 	return nil
 }

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -225,6 +225,9 @@ func fetch(ctx context.Context, options Options, deps dependencies) (*Data, erro
 	if responseData.Azure.BootstrapToken.Token == "" {
 		return nil, fmt.Errorf("bootstrap-data response did not contain a bootstrap token")
 	}
+	if !config.BootstrapTokenPattern.MatchString(responseData.Azure.BootstrapToken.Token) {
+		return nil, fmt.Errorf("bootstrap-data response contained an invalid bootstrap token")
+	}
 	return &Data{
 		BootstrapToken: responseData.Azure.BootstrapToken.Token,
 		ClusterFQDN:    responseData.Node.Kubelet.ClusterFQDN,

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -50,6 +50,7 @@ type Options struct {
 	SPClientCertificateFile string
 	SPClientCredentialFile  string
 	ResourceManagerEndpoint string
+	ResourceManagerAudience string
 	AuthorityHost           string
 	APIVersion              string
 	OutputPath              string
@@ -66,6 +67,7 @@ func OptionsFromConfig(cfg *config.Config) (Options, error) {
 		ClusterResourceID:       cfg.Azure.TargetCluster.ResourceID,
 		AgentPoolName:           cfg.Azure.TargetAgentPoolName,
 		ResourceManagerEndpoint: environment.Endpoint,
+		ResourceManagerAudience: environment.Audience,
 		AuthorityHost:           environment.AuthorityHost,
 		APIVersion:              DefaultAPIVersion,
 	}
@@ -155,17 +157,21 @@ func fetch(ctx context.Context, options Options, deps dependencies) (*Data, erro
 		return nil, err
 	}
 	endpoint := strings.TrimRight(options.ResourceManagerEndpoint, "/")
+	audience := strings.TrimRight(options.ResourceManagerAudience, "/")
+	if audience == "" {
+		audience = endpoint
+	}
 	clientOptions := azcore.ClientOptions{Cloud: cloud.Configuration{
 		ActiveDirectoryAuthorityHost: options.AuthorityHost,
 		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-			cloud.ResourceManager: {Endpoint: endpoint, Audience: endpoint},
+			cloud.ResourceManager: {Endpoint: endpoint, Audience: audience},
 		},
 	}}
 	credential, err := deps.credential(options, clientOptions)
 	if err != nil {
 		return nil, err
 	}
-	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{endpoint + "/.default"}})
+	token, err := credential.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{audience + "/.default"}})
 	if err != nil {
 		return nil, fmt.Errorf("acquire ARM token: %w", err)
 	}
@@ -231,6 +237,12 @@ func validateOptions(options Options) error {
 	endpoint, err := url.Parse(options.ResourceManagerEndpoint)
 	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil {
 		return fmt.Errorf("resource manager endpoint must be an absolute HTTPS URL")
+	}
+	if options.ResourceManagerAudience != "" {
+		audience, err := url.Parse(options.ResourceManagerAudience)
+		if err != nil || audience.Scheme != "https" || audience.Host == "" || audience.User != nil {
+			return fmt.Errorf("resource manager audience must be an absolute HTTPS URL")
+		}
 	}
 	authority, err := url.Parse(options.AuthorityHost)
 	if err != nil || authority.Scheme != "https" || authority.Host == "" || authority.User != nil {

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/google/renameio/v2"
 
+	"github.com/Azure/AKSFlexNode/pkg/azclient"
 	"github.com/Azure/AKSFlexNode/pkg/config"
 )
 
@@ -52,6 +53,43 @@ type Options struct {
 	AuthorityHost           string
 	APIVersion              string
 	OutputPath              string
+}
+
+// OptionsFromConfig converts validated runtime configuration into options for
+// an in-memory listBootstrapData request.
+func OptionsFromConfig(cfg *config.Config) (Options, error) {
+	if cfg == nil || cfg.Azure.TargetCluster == nil {
+		return Options{}, fmt.Errorf("target AKS cluster is not configured")
+	}
+	environment := azclient.ResourceManagerEnvironmentFromConfig(cfg)
+	options := Options{
+		ClusterResourceID:       cfg.Azure.TargetCluster.ResourceID,
+		AgentPoolName:           cfg.Azure.TargetAgentPoolName,
+		ResourceManagerEndpoint: environment.Endpoint,
+		AuthorityHost:           environment.AuthorityHost,
+		APIVersion:              DefaultAPIVersion,
+	}
+
+	switch {
+	case cfg.IsMIConfigured():
+		options.AuthMode = "managed-identity"
+		options.MSIClientID = cfg.Azure.ManagedIdentity.ClientID
+	case cfg.IsSPConfigured():
+		options.AuthMode = "service-principal"
+		options.SPTenantID = cfg.Azure.ServicePrincipal.TenantID
+		options.SPClientID = cfg.Azure.ServicePrincipal.ClientID
+		if cfg.Azure.ServicePrincipal.ClientSecretFile != "" {
+			// Config validation leaves ClientSecretFile populated only when it
+			// contains a certificate. Secret files are loaded into ClientSecret.
+			options.SPClientCertificateFile = cfg.Azure.ServicePrincipal.ClientSecretFile
+		} else {
+			options.SPClientSecret = cfg.Azure.ServicePrincipal.ClientSecret
+		}
+	default:
+		return Options{}, fmt.Errorf("bootstrap-data refresh requires managed identity or service-principal authentication")
+	}
+
+	return options, nil
 }
 
 // Data contains the short-lived Kubernetes join credentials returned by

--- a/pkg/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/bootstrapdata/bootstrap_data_test.go
@@ -14,11 +14,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
-type staticCredential struct{}
+type staticCredential struct {
+	scope *string
+}
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
-func (staticCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
+func (c staticCredential) GetToken(_ context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if c.scope != nil && len(options.Scopes) == 1 {
+		*c.scope = options.Scopes[0]
+	}
 	return azcore.AccessToken{Token: "arm-token", ExpiresOn: time.Now().Add(time.Hour)}, nil
 }
 
@@ -78,12 +83,20 @@ func TestFetchInMemory(t *testing.T) {
 		ClusterResourceID:       "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
 		AgentPoolName:           "aksflexnodes",
 		AuthMode:                "msi",
-		ResourceManagerEndpoint: DefaultResourceManagerEndpoint,
-		AuthorityHost:           DefaultAuthorityHost,
+		ResourceManagerEndpoint: "https://management.usgovcloudapi.net",
+		ResourceManagerAudience: "https://management.core.usgovcloudapi.net",
+		AuthorityHost:           "https://login.microsoftonline.us/",
 		APIVersion:              DefaultAPIVersion,
 	}
+	var scope string
 	got, err := fetch(t.Context(), options, dependencies{
-		credential: func(Options, azcore.ClientOptions) (azcore.TokenCredential, error) { return staticCredential{}, nil },
+		credential: func(_ Options, clientOptions azcore.ClientOptions) (azcore.TokenCredential, error) {
+			service := clientOptions.Cloud.Services["resourceManager"]
+			if service.Audience != options.ResourceManagerAudience {
+				t.Errorf("ARM audience = %q, want %q", service.Audience, options.ResourceManagerAudience)
+			}
+			return staticCredential{scope: &scope}, nil
+		},
 		httpClient: client,
 	})
 	if err != nil {
@@ -97,6 +110,9 @@ func TestFetchInMemory(t *testing.T) {
 	}
 	if got.CACertData != "Y2E=" {
 		t.Fatalf("CACertData = %q", got.CACertData)
+	}
+	if scope != "https://management.core.usgovcloudapi.net/.default" {
+		t.Fatalf("ARM token scope = %q", scope)
 	}
 }
 

--- a/pkg/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/bootstrapdata/bootstrap_data_test.go
@@ -116,6 +116,38 @@ func TestFetchInMemory(t *testing.T) {
 	}
 }
 
+func TestFetchRejectsMalformedBootstrapToken(t *testing.T) {
+	t.Parallel()
+
+	const malformedToken = "truncated.token"
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		body := `{"azure":{"bootstrapToken":{"token":"` + malformedToken + `"}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	options := Options{
+		ClusterResourceID:       "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		AgentPoolName:           "aksflexnodes",
+		AuthMode:                "msi",
+		ResourceManagerEndpoint: DefaultResourceManagerEndpoint,
+		AuthorityHost:           DefaultAuthorityHost,
+		APIVersion:              DefaultAPIVersion,
+	}
+	_, err := fetch(t.Context(), options, dependencies{
+		credential: func(Options, azcore.ClientOptions) (azcore.TokenCredential, error) { return staticCredential{}, nil },
+		httpClient: client,
+	})
+	if err == nil || err.Error() != "bootstrap-data response contained an invalid bootstrap token" {
+		t.Fatalf("fetch() error = %v, want invalid token error", err)
+	}
+	if strings.Contains(err.Error(), malformedToken) {
+		t.Fatal("fetch() error exposed malformed bootstrap token")
+	}
+}
+
 func TestFetchAndWriteRequiresOutput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/bootstrapdata/bootstrap_data_test.go
@@ -60,6 +60,55 @@ func TestFetchAndWrite(t *testing.T) {
 	}
 }
 
+func TestFetchInMemory(t *testing.T) {
+	t.Parallel()
+
+	const response = `{
+		"azure":{"bootstrapToken":{"token":"abcdef.0123456789abcdef"}},
+		"node":{"kubelet":{"clusterFQDN":"api.example.test","caCertData":"Y2E="}}
+	}`
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(response)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	options := Options{
+		ClusterResourceID:       "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		AgentPoolName:           "aksflexnodes",
+		AuthMode:                "msi",
+		ResourceManagerEndpoint: DefaultResourceManagerEndpoint,
+		AuthorityHost:           DefaultAuthorityHost,
+		APIVersion:              DefaultAPIVersion,
+	}
+	got, err := fetch(t.Context(), options, dependencies{
+		credential: func(Options, azcore.ClientOptions) (azcore.TokenCredential, error) { return staticCredential{}, nil },
+		httpClient: client,
+	})
+	if err != nil {
+		t.Fatalf("fetch() error = %v", err)
+	}
+	if got.BootstrapToken != "abcdef.0123456789abcdef" {
+		t.Fatalf("BootstrapToken = %q", got.BootstrapToken)
+	}
+	if got.ClusterFQDN != "api.example.test" {
+		t.Fatalf("ClusterFQDN = %q", got.ClusterFQDN)
+	}
+	if got.CACertData != "Y2E=" {
+		t.Fatalf("CACertData = %q", got.CACertData)
+	}
+}
+
+func TestFetchAndWriteRequiresOutput(t *testing.T) {
+	t.Parallel()
+
+	err := fetchAndWrite(t.Context(), Options{}, dependencies{})
+	if err == nil || err.Error() != "output path is required" {
+		t.Fatalf("fetchAndWrite() error = %v, want output path error", err)
+	}
+}
+
 func TestClientCertificateCredentialOptions(t *testing.T) {
 	t.Parallel()
 	options := clientCertificateCredentialOptions(azcore.ClientOptions{})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -303,6 +303,12 @@ func (cfg *Config) IsBootstrapTokenConfigured() bool {
 	return cfg.Azure.BootstrapToken != nil
 }
 
+// NeedsBootstrapDataRefresh reports whether repave can replace the short-lived
+// bootstrap token by authenticating to AKS RP with a durable Azure credential.
+func (cfg *Config) NeedsBootstrapDataRefresh() bool {
+	return cfg != nil && cfg.IsBootstrapTokenConfigured() && (cfg.IsMIConfigured() || cfg.IsSPConfigured())
+}
+
 // resolveNodeName resolves the Kubernetes Node name once and stores it on the
 // config so bootstrap, daemon watches, and lifecycle operations use one value.
 func (cfg *Config) resolveNodeName(hostnameFunc func() (string, error)) (string, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2619,6 +2619,55 @@ func labelKeys(m map[string]string) []string {
 	return keys
 }
 
+func TestNeedsBootstrapDataRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg  *Config
+		want bool
+	}{
+		"nil config": {},
+		"bootstrap token only": {
+			cfg: &Config{Azure: AzureConfig{BootstrapToken: &BootstrapTokenConfig{Token: "abcdef.0123456789abcdef"}}},
+		},
+		"managed identity only": {
+			cfg: &Config{Azure: AzureConfig{ManagedIdentity: &ManagedIdentityConfig{}}},
+		},
+		"bootstrap token and managed identity": {
+			cfg: &Config{Azure: AzureConfig{
+				BootstrapToken:  &BootstrapTokenConfig{Token: "abcdef.0123456789abcdef"},
+				ManagedIdentity: &ManagedIdentityConfig{},
+			}},
+			want: true,
+		},
+		"bootstrap token and service principal": {
+			cfg: &Config{Azure: AzureConfig{
+				BootstrapToken: &BootstrapTokenConfig{Token: "abcdef.0123456789abcdef"},
+				ServicePrincipal: &ServicePrincipalConfig{
+					TenantID: "tenant",
+					ClientID: "client",
+				},
+			}},
+			want: true,
+		},
+		"bootstrap token and Arc": {
+			cfg: &Config{Azure: AzureConfig{
+				BootstrapToken: &BootstrapTokenConfig{Token: "abcdef.0123456789abcdef"},
+				Arc:            &ArcConfig{Enabled: true},
+			}},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.NeedsBootstrapDataRefresh(); got != tt.want {
+				t.Errorf("NeedsBootstrapDataRefresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsBootstrapTokenConfigured(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/daemon/bootstrap_data.go
+++ b/pkg/daemon/bootstrap_data.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/AKSFlexNode/pkg/azclient"
+	"github.com/Azure/AKSFlexNode/pkg/bootstrapdata"
+	"github.com/Azure/AKSFlexNode/pkg/config"
+)
+
+type bootstrapDataRefresher interface {
+	Fetch(context.Context, *config.Config) (*bootstrapdata.Data, error)
+}
+
+type aksBootstrapDataRefresher struct{}
+
+func (aksBootstrapDataRefresher) Fetch(ctx context.Context, cfg *config.Config) (*bootstrapdata.Data, error) {
+	options, err := bootstrapDataOptionsFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return bootstrapdata.Fetch(ctx, options)
+}
+
+func bootstrapDataOptionsFromConfig(cfg *config.Config) (bootstrapdata.Options, error) {
+	if cfg == nil || cfg.Azure.TargetCluster == nil {
+		return bootstrapdata.Options{}, fmt.Errorf("target AKS cluster is not configured")
+	}
+	environment := azclient.ResourceManagerEnvironmentFromConfig(cfg)
+	options := bootstrapdata.Options{
+		ClusterResourceID:       cfg.Azure.TargetCluster.ResourceID,
+		AgentPoolName:           cfg.Azure.TargetAgentPoolName,
+		ResourceManagerEndpoint: environment.Endpoint,
+		AuthorityHost:           environment.AuthorityHost,
+		APIVersion:              bootstrapdata.DefaultAPIVersion,
+	}
+
+	switch {
+	case cfg.IsMIConfigured():
+		options.AuthMode = "managed-identity"
+		options.MSIClientID = cfg.Azure.ManagedIdentity.ClientID
+	case cfg.IsSPConfigured():
+		options.AuthMode = "service-principal"
+		options.SPTenantID = cfg.Azure.ServicePrincipal.TenantID
+		options.SPClientID = cfg.Azure.ServicePrincipal.ClientID
+		if cfg.Azure.ServicePrincipal.ClientSecretFile != "" {
+			// Config validation leaves ClientSecretFile populated only when it
+			// contains a certificate. Secret files are loaded into ClientSecret.
+			options.SPClientCertificateFile = cfg.Azure.ServicePrincipal.ClientSecretFile
+		} else {
+			options.SPClientSecret = cfg.Azure.ServicePrincipal.ClientSecret
+		}
+	default:
+		return bootstrapdata.Options{}, fmt.Errorf("bootstrap-data refresh requires managed identity or service-principal authentication")
+	}
+
+	return options, nil
+}
+
+func shouldRefreshBootstrapData(cfg *config.Config) bool {
+	return cfg != nil && cfg.IsBootstrapTokenConfigured() && (cfg.IsMIConfigured() || cfg.IsSPConfigured())
+}

--- a/pkg/daemon/bootstrap_data.go
+++ b/pkg/daemon/bootstrap_data.go
@@ -13,6 +13,12 @@ type bootstrapDataRefresher interface {
 	Fetch(context.Context, *config.Config) (*bootstrapdata.Data, error)
 }
 
+type noopBootstrapDataRefresher struct{}
+
+func (noopBootstrapDataRefresher) Fetch(context.Context, *config.Config) (*bootstrapdata.Data, error) {
+	return nil, nil
+}
+
 type aksBootstrapDataRefresher struct{}
 
 func (aksBootstrapDataRefresher) Fetch(ctx context.Context, cfg *config.Config) (*bootstrapdata.Data, error) {
@@ -58,6 +64,9 @@ func bootstrapDataOptionsFromConfig(cfg *config.Config) (bootstrapdata.Options, 
 	return options, nil
 }
 
-func shouldRefreshBootstrapData(cfg *config.Config) bool {
-	return cfg != nil && cfg.IsBootstrapTokenConfigured() && (cfg.IsMIConfigured() || cfg.IsSPConfigured())
+func bootstrapDataRefresherForConfig(cfg *config.Config) bootstrapDataRefresher {
+	if cfg != nil && cfg.IsBootstrapTokenConfigured() && (cfg.IsMIConfigured() || cfg.IsSPConfigured()) {
+		return aksBootstrapDataRefresher{}
+	}
+	return noopBootstrapDataRefresher{}
 }

--- a/pkg/daemon/bootstrap_data.go
+++ b/pkg/daemon/bootstrap_data.go
@@ -2,9 +2,7 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/Azure/AKSFlexNode/pkg/azclient"
 	"github.com/Azure/AKSFlexNode/pkg/bootstrapdata"
 	"github.com/Azure/AKSFlexNode/pkg/config"
 )
@@ -22,50 +20,15 @@ func (noopBootstrapDataRefresher) Fetch(context.Context, *config.Config) (*boots
 type aksBootstrapDataRefresher struct{}
 
 func (aksBootstrapDataRefresher) Fetch(ctx context.Context, cfg *config.Config) (*bootstrapdata.Data, error) {
-	options, err := bootstrapDataOptionsFromConfig(cfg)
+	options, err := bootstrapdata.OptionsFromConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 	return bootstrapdata.Fetch(ctx, options)
 }
 
-func bootstrapDataOptionsFromConfig(cfg *config.Config) (bootstrapdata.Options, error) {
-	if cfg == nil || cfg.Azure.TargetCluster == nil {
-		return bootstrapdata.Options{}, fmt.Errorf("target AKS cluster is not configured")
-	}
-	environment := azclient.ResourceManagerEnvironmentFromConfig(cfg)
-	options := bootstrapdata.Options{
-		ClusterResourceID:       cfg.Azure.TargetCluster.ResourceID,
-		AgentPoolName:           cfg.Azure.TargetAgentPoolName,
-		ResourceManagerEndpoint: environment.Endpoint,
-		AuthorityHost:           environment.AuthorityHost,
-		APIVersion:              bootstrapdata.DefaultAPIVersion,
-	}
-
-	switch {
-	case cfg.IsMIConfigured():
-		options.AuthMode = "managed-identity"
-		options.MSIClientID = cfg.Azure.ManagedIdentity.ClientID
-	case cfg.IsSPConfigured():
-		options.AuthMode = "service-principal"
-		options.SPTenantID = cfg.Azure.ServicePrincipal.TenantID
-		options.SPClientID = cfg.Azure.ServicePrincipal.ClientID
-		if cfg.Azure.ServicePrincipal.ClientSecretFile != "" {
-			// Config validation leaves ClientSecretFile populated only when it
-			// contains a certificate. Secret files are loaded into ClientSecret.
-			options.SPClientCertificateFile = cfg.Azure.ServicePrincipal.ClientSecretFile
-		} else {
-			options.SPClientSecret = cfg.Azure.ServicePrincipal.ClientSecret
-		}
-	default:
-		return bootstrapdata.Options{}, fmt.Errorf("bootstrap-data refresh requires managed identity or service-principal authentication")
-	}
-
-	return options, nil
-}
-
 func bootstrapDataRefresherForConfig(cfg *config.Config) bootstrapDataRefresher {
-	if cfg != nil && cfg.IsBootstrapTokenConfigured() && (cfg.IsMIConfigured() || cfg.IsSPConfigured()) {
+	if cfg.NeedsBootstrapDataRefresh() {
 		return aksBootstrapDataRefresher{}
 	}
 	return noopBootstrapDataRefresher{}

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -69,7 +69,7 @@ func newNSpawnNodeOperator(cfg *config.Config, state stateStore) (*nspawnNodeOpe
 	return &nspawnNodeOperator{
 		cfg:                    cfg,
 		state:                  state,
-		bootstrapDataRefresher: aksBootstrapDataRefresher{},
+		bootstrapDataRefresher: bootstrapDataRefresherForConfig(cfg),
 	}, nil
 }
 
@@ -124,27 +124,31 @@ func (o *nspawnNodeOperator) configForGoalState(ctx context.Context, log *slog.L
 	if cfg == nil {
 		return nil, fmt.Errorf("copy config for repave")
 	}
-	if shouldRefreshBootstrapData(cfg) {
-		if o.bootstrapDataRefresher == nil {
-			return nil, fmt.Errorf("bootstrap-data refresher is not configured")
-		}
-		log.Info("refreshing AKS bootstrap data for repave")
-		data, err := o.bootstrapDataRefresher.Fetch(ctx, cfg)
-		if err != nil {
-			return nil, fmt.Errorf("refresh bootstrap data for repave: %w", err)
-		}
-		if data == nil || data.BootstrapToken == "" {
+	data, err := o.bootstrapDataRefresher.Fetch(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("refresh bootstrap data for repave: %w", err)
+	}
+	if data != nil {
+		log.Info("refreshed AKS bootstrap data for repave")
+		if data.BootstrapToken == "" {
 			return nil, fmt.Errorf("refresh bootstrap data for repave: response did not contain a bootstrap token")
 		}
-		cfg.Azure.BootstrapToken.Token = data.BootstrapToken
-		if data.ClusterFQDN != "" {
-			cfg.Node.Kubelet.ClusterFQDN = data.ClusterFQDN
+		if cfg.Azure.BootstrapToken.Token != data.BootstrapToken {
+			// Never log either token value; only record that the sensitive value changed.
+			log.Info("updated bootstrap token for repave")
+			cfg.Azure.BootstrapToken.Token = data.BootstrapToken
 		}
-		if data.CACertData != "" {
+		if data.CACertData != "" && cfg.Node.Kubelet.CACertData != data.CACertData {
+			// Log only the change so the complete bootstrap response stays private.
+			log.Info("updated kubelet CA data for repave")
 			cfg.Node.Kubelet.CACertData = data.CACertData
 		}
 	}
-	if goal.KubernetesVersion != "" {
+	if goal.KubernetesVersion != "" && cfg.Components.Kubernetes != goal.KubernetesVersion {
+		log.Info("updated Kubernetes version for repave",
+			"oldVersion", cfg.Components.Kubernetes,
+			"newVersion", goal.KubernetesVersion,
+		)
 		cfg.Components.Kubernetes = goal.KubernetesVersion
 	}
 	return cfg, nil

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -57,15 +57,20 @@ func (o *nspawnNodeOperator) RestartNode(ctx context.Context, log *slog.Logger) 
 }
 
 type nspawnNodeOperator struct {
-	cfg   *config.Config
-	state stateStore
+	cfg                    *config.Config
+	state                  stateStore
+	bootstrapDataRefresher bootstrapDataRefresher
 }
 
 func newNSpawnNodeOperator(cfg *config.Config, state stateStore) (*nspawnNodeOperator, error) {
 	if state == nil {
 		return nil, fmt.Errorf("state store is nil")
 	}
-	return &nspawnNodeOperator{cfg: cfg, state: state}, nil
+	return &nspawnNodeOperator{
+		cfg:                    cfg,
+		state:                  state,
+		bootstrapDataRefresher: aksBootstrapDataRefresher{},
+	}, nil
 }
 
 func (o *nspawnNodeOperator) LoadState(ctx context.Context) (*State, error) {
@@ -81,13 +86,9 @@ func (o *nspawnNodeOperator) ApplyGoalState(ctx context.Context, log *slog.Logge
 	if err != nil {
 		return nil, err
 	}
-	// TODO: This per-goal config copy/mutation is not ideal. Refactor goal-state
-	// resolution to avoid rewriting shared config-shaped data here.
-	cfg := o.cfg.DeepCopy()
-	// MaxPods is immutable in AKS, so the startup configuration remains its
-	// authoritative source rather than reapplying the value from each goal.
-	if goal.KubernetesVersion != "" {
-		cfg.Components.Kubernetes = goal.KubernetesVersion
+	cfg, err := o.configForGoalState(ctx, log, goal)
+	if err != nil {
+		return nil, err
 	}
 	oldMachine := active.Name
 	newMachine := goalstates.AlternateMachine(oldMachine)
@@ -114,6 +115,39 @@ func (o *nspawnNodeOperator) ApplyGoalState(ctx context.Context, log *slog.Logge
 		return nil, fmt.Errorf("apply machine goal state: %w", err)
 	}
 	return newState, nil
+}
+
+func (o *nspawnNodeOperator) configForGoalState(ctx context.Context, log *slog.Logger, goal aksmachine.GoalState) (*config.Config, error) {
+	// Keep short-lived bootstrap credentials scoped to this repave. Persisting
+	// them would make a later repave depend on this token's lifetime again.
+	cfg := o.cfg.DeepCopy()
+	if cfg == nil {
+		return nil, fmt.Errorf("copy config for repave")
+	}
+	if shouldRefreshBootstrapData(cfg) {
+		if o.bootstrapDataRefresher == nil {
+			return nil, fmt.Errorf("bootstrap-data refresher is not configured")
+		}
+		log.Info("refreshing AKS bootstrap data for repave")
+		data, err := o.bootstrapDataRefresher.Fetch(ctx, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("refresh bootstrap data for repave: %w", err)
+		}
+		if data == nil || data.BootstrapToken == "" {
+			return nil, fmt.Errorf("refresh bootstrap data for repave: response did not contain a bootstrap token")
+		}
+		cfg.Azure.BootstrapToken.Token = data.BootstrapToken
+		if data.ClusterFQDN != "" {
+			cfg.Node.Kubelet.ClusterFQDN = data.ClusterFQDN
+		}
+		if data.CACertData != "" {
+			cfg.Node.Kubelet.CACertData = data.CACertData
+		}
+	}
+	if goal.KubernetesVersion != "" {
+		cfg.Components.Kubernetes = goal.KubernetesVersion
+	}
+	return cfg, nil
 }
 
 func (o *nspawnNodeOperator) ResetNode(ctx context.Context, log *slog.Logger) error {

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -125,10 +125,10 @@ func (o *nspawnNodeOperator) configForGoalState(ctx context.Context, log *slog.L
 		return nil, fmt.Errorf("copy config for repave")
 	}
 	data, err := o.bootstrapDataRefresher.Fetch(ctx, cfg)
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, fmt.Errorf("refresh bootstrap data for repave: %w", err)
-	}
-	if data != nil {
+	case data != nil:
 		log.Info("refreshed AKS bootstrap data for repave")
 		if data.BootstrapToken == "" {
 			return nil, fmt.Errorf("refresh bootstrap data for repave: response did not contain a bootstrap token")

--- a/pkg/daemon/nodeoperator.go
+++ b/pkg/daemon/nodeoperator.go
@@ -144,6 +144,8 @@ func (o *nspawnNodeOperator) configForGoalState(ctx context.Context, log *slog.L
 			cfg.Node.Kubelet.CACertData = data.CACertData
 		}
 	}
+	// MaxPods is immutable in AKS, so the startup configuration remains its
+	// authoritative source rather than reapplying the value from each goal.
 	if goal.KubernetesVersion != "" && cfg.Components.Kubernetes != goal.KubernetesVersion {
 		log.Info("updated Kubernetes version for repave",
 			"oldVersion", cfg.Components.Kubernetes,

--- a/pkg/daemon/nodeoperator_test.go
+++ b/pkg/daemon/nodeoperator_test.go
@@ -206,7 +206,9 @@ func TestBootstrapDataOptionsFromConfig(t *testing.T) {
 	if got.AuthMode != "managed-identity" || got.MSIClientID != "identity" {
 		t.Fatalf("managed identity options = %#v", got)
 	}
-	if got.ResourceManagerEndpoint != "https://management.usgovcloudapi.net" || got.AuthorityHost != "https://login.microsoftonline.us/" {
+	if got.ResourceManagerEndpoint != "https://management.usgovcloudapi.net" ||
+		got.ResourceManagerAudience != "https://management.core.usgovcloudapi.net" ||
+		got.AuthorityHost != "https://login.microsoftonline.us/" {
 		t.Fatalf("sovereign cloud options = %#v", got)
 	}
 	if got.APIVersion != bootstrapdata.DefaultAPIVersion {

--- a/pkg/daemon/nodeoperator_test.go
+++ b/pkg/daemon/nodeoperator_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/Azure/AKSFlexNode/pkg/aksmachine"
@@ -83,8 +85,10 @@ func TestConfigForGoalStateRefreshesBootstrapData(t *testing.T) {
 		CACertData:     "bmV3",
 	}}
 	operator := &nspawnNodeOperator{cfg: cfg, bootstrapDataRefresher: refresher}
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, nil))
 
-	got, err := operator.configForGoalState(t.Context(), discardLogger(), aksmachine.GoalState{KubernetesVersion: "1.36.2"})
+	got, err := operator.configForGoalState(t.Context(), log, aksmachine.GoalState{KubernetesVersion: "1.36.2"})
 	if err != nil {
 		t.Fatalf("configForGoalState() error = %v", err)
 	}
@@ -94,14 +98,34 @@ func TestConfigForGoalStateRefreshesBootstrapData(t *testing.T) {
 	if got.Azure.BootstrapToken.Token != "newtok.0123456789abcdef" {
 		t.Fatalf("bootstrap token was not refreshed")
 	}
-	if got.Node.Kubelet.ClusterFQDN != "new.example.test" || got.Node.Kubelet.CACertData != "bmV3" {
-		t.Fatalf("kubelet bootstrap data = %#v", got.Node.Kubelet)
+	if got.Node.Kubelet.ClusterFQDN != "old.example.test" {
+		t.Fatalf("immutable cluster FQDN = %q", got.Node.Kubelet.ClusterFQDN)
+	}
+	if got.Node.Kubelet.CACertData != "bmV3" {
+		t.Fatalf("kubelet CA data = %q", got.Node.Kubelet.CACertData)
 	}
 	if got.Components.Kubernetes != "1.36.2" {
 		t.Fatalf("Kubernetes version = %q", got.Components.Kubernetes)
 	}
 	if cfg.Azure.BootstrapToken.Token != "oldtok.0123456789abcdef" {
 		t.Fatal("original config bootstrap token was mutated")
+	}
+	for _, message := range []string{
+		"refreshed AKS bootstrap data for repave",
+		"updated bootstrap token for repave",
+		"updated kubelet CA data for repave",
+		"updated Kubernetes version for repave",
+		"oldVersion=1.35.0",
+		"newVersion=1.36.2",
+	} {
+		if !strings.Contains(logs.String(), message) {
+			t.Errorf("logs did not contain %q: %s", message, logs.String())
+		}
+	}
+	for _, sensitive := range []string{"oldtok.0123456789abcdef", "newtok.0123456789abcdef", "b2xk", "bmV3"} {
+		if strings.Contains(logs.String(), sensitive) {
+			t.Errorf("logs exposed bootstrap data %q", sensitive)
+		}
 	}
 }
 
@@ -119,15 +143,28 @@ func TestConfigForGoalStateSkipsBootstrapDataRefreshWithoutBothAuthTypes(t *test
 	for name, cfg := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			refresher := &fakeBootstrapDataRefresher{}
+			refresher := bootstrapDataRefresherForConfig(cfg)
 			operator := &nspawnNodeOperator{cfg: cfg, bootstrapDataRefresher: refresher}
 			if _, err := operator.configForGoalState(t.Context(), discardLogger(), aksmachine.GoalState{}); err != nil {
 				t.Fatalf("configForGoalState() error = %v", err)
 			}
-			if refresher.calls != 0 {
-				t.Fatalf("refresh calls = %d, want 0", refresher.calls)
+			if _, ok := refresher.(noopBootstrapDataRefresher); !ok {
+				t.Fatalf("refresher = %T, want noopBootstrapDataRefresher", refresher)
 			}
 		})
+	}
+}
+
+func TestBootstrapDataRefresherForDualAuthConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Azure: config.AzureConfig{
+		BootstrapToken:  &config.BootstrapTokenConfig{Token: "oldtok.0123456789abcdef"},
+		ManagedIdentity: &config.ManagedIdentityConfig{},
+	}}
+	refresher := bootstrapDataRefresherForConfig(cfg)
+	if _, ok := refresher.(aksBootstrapDataRefresher); !ok {
+		t.Fatalf("refresher = %T, want aksBootstrapDataRefresher", refresher)
 	}
 }
 

--- a/pkg/daemon/nodeoperator_test.go
+++ b/pkg/daemon/nodeoperator_test.go
@@ -199,9 +199,9 @@ func TestBootstrapDataOptionsFromConfig(t *testing.T) {
 		},
 		TargetAgentPoolName: "pool",
 	}}
-	got, err := bootstrapDataOptionsFromConfig(cfg)
+	got, err := bootstrapdata.OptionsFromConfig(cfg)
 	if err != nil {
-		t.Fatalf("bootstrapDataOptionsFromConfig() error = %v", err)
+		t.Fatalf("bootstrapdata.OptionsFromConfig() error = %v", err)
 	}
 	if got.AuthMode != "managed-identity" || got.MSIClientID != "identity" {
 		t.Fatalf("managed identity options = %#v", got)
@@ -241,9 +241,9 @@ func TestBootstrapDataOptionsFromServicePrincipal(t *testing.T) {
 				},
 				TargetAgentPoolName: "pool",
 			}}
-			got, err := bootstrapDataOptionsFromConfig(cfg)
+			got, err := bootstrapdata.OptionsFromConfig(cfg)
 			if err != nil {
-				t.Fatalf("bootstrapDataOptionsFromConfig() error = %v", err)
+				t.Fatalf("bootstrapdata.OptionsFromConfig() error = %v", err)
 			}
 			if got.AuthMode != "service-principal" || got.SPTenantID != "tenant" || got.SPClientID != "client" {
 				t.Fatalf("service-principal identity options = %#v", got)

--- a/pkg/daemon/nodeoperator_test.go
+++ b/pkg/daemon/nodeoperator_test.go
@@ -2,8 +2,14 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"testing"
 
+	"github.com/Azure/AKSFlexNode/pkg/aksmachine"
+	"github.com/Azure/AKSFlexNode/pkg/bootstrapdata"
+	"github.com/Azure/AKSFlexNode/pkg/config"
 	"github.com/Azure/unbounded/pkg/agent/goalstates"
 )
 
@@ -55,6 +61,176 @@ func TestFindActiveMachine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigForGoalStateRefreshesBootstrapData(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Azure: config.AzureConfig{
+			BootstrapToken:  &config.BootstrapTokenConfig{Token: "oldtok.0123456789abcdef"},
+			ManagedIdentity: &config.ManagedIdentityConfig{ClientID: "identity"},
+		},
+		Components: config.ComponentsConfig{Kubernetes: "1.35.0"},
+		Node: config.NodeConfig{Kubelet: config.KubeletConfig{
+			ClusterFQDN: "old.example.test",
+			CACertData:  "b2xk",
+		}},
+	}
+	refresher := &fakeBootstrapDataRefresher{data: &bootstrapdata.Data{
+		BootstrapToken: "newtok.0123456789abcdef",
+		ClusterFQDN:    "new.example.test",
+		CACertData:     "bmV3",
+	}}
+	operator := &nspawnNodeOperator{cfg: cfg, bootstrapDataRefresher: refresher}
+
+	got, err := operator.configForGoalState(t.Context(), discardLogger(), aksmachine.GoalState{KubernetesVersion: "1.36.2"})
+	if err != nil {
+		t.Fatalf("configForGoalState() error = %v", err)
+	}
+	if refresher.calls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", refresher.calls)
+	}
+	if got.Azure.BootstrapToken.Token != "newtok.0123456789abcdef" {
+		t.Fatalf("bootstrap token was not refreshed")
+	}
+	if got.Node.Kubelet.ClusterFQDN != "new.example.test" || got.Node.Kubelet.CACertData != "bmV3" {
+		t.Fatalf("kubelet bootstrap data = %#v", got.Node.Kubelet)
+	}
+	if got.Components.Kubernetes != "1.36.2" {
+		t.Fatalf("Kubernetes version = %q", got.Components.Kubernetes)
+	}
+	if cfg.Azure.BootstrapToken.Token != "oldtok.0123456789abcdef" {
+		t.Fatal("original config bootstrap token was mutated")
+	}
+}
+
+func TestConfigForGoalStateSkipsBootstrapDataRefreshWithoutBothAuthTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]*config.Config{
+		"token only": {
+			Azure: config.AzureConfig{BootstrapToken: &config.BootstrapTokenConfig{Token: "oldtok.0123456789abcdef"}},
+		},
+		"managed identity only": {
+			Azure: config.AzureConfig{ManagedIdentity: &config.ManagedIdentityConfig{}},
+		},
+	}
+	for name, cfg := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			refresher := &fakeBootstrapDataRefresher{}
+			operator := &nspawnNodeOperator{cfg: cfg, bootstrapDataRefresher: refresher}
+			if _, err := operator.configForGoalState(t.Context(), discardLogger(), aksmachine.GoalState{}); err != nil {
+				t.Fatalf("configForGoalState() error = %v", err)
+			}
+			if refresher.calls != 0 {
+				t.Fatalf("refresh calls = %d, want 0", refresher.calls)
+			}
+		})
+	}
+}
+
+func TestConfigForGoalStateBootstrapDataRefreshFailure(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Azure: config.AzureConfig{
+		BootstrapToken:  &config.BootstrapTokenConfig{Token: "oldtok.0123456789abcdef"},
+		ManagedIdentity: &config.ManagedIdentityConfig{},
+	}}
+	operator := &nspawnNodeOperator{
+		cfg:                    cfg,
+		bootstrapDataRefresher: &fakeBootstrapDataRefresher{err: errors.New("ARM unavailable")},
+	}
+	_, err := operator.configForGoalState(t.Context(), discardLogger(), aksmachine.GoalState{})
+	if err == nil || !errors.Is(err, operator.bootstrapDataRefresher.(*fakeBootstrapDataRefresher).err) {
+		t.Fatalf("configForGoalState() error = %v", err)
+	}
+	if cfg.Azure.BootstrapToken.Token != "oldtok.0123456789abcdef" {
+		t.Fatal("original config bootstrap token was mutated")
+	}
+}
+
+func TestBootstrapDataOptionsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Azure: config.AzureConfig{
+		ResourceManagerEndpointURL: "https://management.usgovcloudapi.net",
+		ManagedIdentity:            &config.ManagedIdentityConfig{ClientID: "identity"},
+		TargetCluster: &config.TargetClusterConfig{
+			ResourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		},
+		TargetAgentPoolName: "pool",
+	}}
+	got, err := bootstrapDataOptionsFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("bootstrapDataOptionsFromConfig() error = %v", err)
+	}
+	if got.AuthMode != "managed-identity" || got.MSIClientID != "identity" {
+		t.Fatalf("managed identity options = %#v", got)
+	}
+	if got.ResourceManagerEndpoint != "https://management.usgovcloudapi.net" || got.AuthorityHost != "https://login.microsoftonline.us/" {
+		t.Fatalf("sovereign cloud options = %#v", got)
+	}
+	if got.APIVersion != bootstrapdata.DefaultAPIVersion {
+		t.Fatalf("API version = %q", got.APIVersion)
+	}
+}
+
+func TestBootstrapDataOptionsFromServicePrincipal(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		servicePrincipal config.ServicePrincipalConfig
+		wantSecret       string
+		wantCertificate  string
+	}{
+		"inline secret": {
+			servicePrincipal: config.ServicePrincipalConfig{TenantID: "tenant", ClientID: "client", ClientSecret: "secret"},
+			wantSecret:       "secret",
+		},
+		"certificate file": {
+			servicePrincipal: config.ServicePrincipalConfig{TenantID: "tenant", ClientID: "client", ClientSecretFile: "/credentials/client.pem"},
+			wantCertificate:  "/credentials/client.pem",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &config.Config{Azure: config.AzureConfig{
+				ServicePrincipal: &tt.servicePrincipal,
+				TargetCluster: &config.TargetClusterConfig{
+					ResourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+				},
+				TargetAgentPoolName: "pool",
+			}}
+			got, err := bootstrapDataOptionsFromConfig(cfg)
+			if err != nil {
+				t.Fatalf("bootstrapDataOptionsFromConfig() error = %v", err)
+			}
+			if got.AuthMode != "service-principal" || got.SPTenantID != "tenant" || got.SPClientID != "client" {
+				t.Fatalf("service-principal identity options = %#v", got)
+			}
+			if got.SPClientSecret != tt.wantSecret || got.SPClientCertificateFile != tt.wantCertificate {
+				t.Fatalf("service-principal credential options = %#v", got)
+			}
+		})
+	}
+}
+
+type fakeBootstrapDataRefresher struct {
+	data  *bootstrapdata.Data
+	err   error
+	calls int
+}
+
+func (f *fakeBootstrapDataRefresher) Fetch(context.Context, *config.Config) (*bootstrapdata.Data, error) {
+	f.calls++
+	return f.data, f.err
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 type testStateStore struct {


### PR DESCRIPTION
## Summary

- fetch fresh AKS RP `listBootstrapData` in memory before resolving an alternate nspawn machine during repave
- use configured managed identity or service-principal authentication and preserve sovereign-cloud endpoint and token-audience handling
- merge the fresh bootstrap token and CA into the per-repave config copy while retaining the immutable API FQDN, so credentials are neither logged nor persisted
- fail before stopping the active nspawn side when bootstrap-data refresh fails
- extend the MSI repave E2E scenario to delete the original bootstrap-token Secret and require successful registration with refreshed data

## Testing

- `make check`
- `bash -n hack/e2e/lib/common.sh hack/e2e/lib/node-join-msi.sh hack/e2e/lib/upgrade-drift.sh`
- `shellcheck hack/e2e/lib/common.sh hack/e2e/lib/node-join-msi.sh hack/e2e/lib/upgrade-drift.sh`
- Azure E2E reached the MSI dual-auth preflight after successfully creating a FlexNodes pool and calling `listBootstrapData`; the run then failed on transient GitHub-hosted artifact reachability before node bootstrap

Closes #273
