### PR TITLE
Mark E2E bootstrap tokens as AKS-managed

### DIFF
--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -340,6 +340,25 @@ with_cluster_lock() {
   return "${rc}"
 }
 
+# The managed AKS FlexNode CSR approver accepts only RP-owned bootstrap tokens.
+# E2E creates equivalent token Secrets directly, so mark only the generated
+# Secret referenced by the test config with the ownership label it validates.
+mark_e2e_bootstrap_token_aks_managed() {
+  local bootstrap_token="$1"
+  if [[ ! "${bootstrap_token}" =~ ^([a-z0-9]{6})\.[a-z0-9]{16}$ ]]; then
+    log_error "Cannot mark E2E bootstrap token: invalid token format"
+    return 1
+  fi
+
+  local token_id="${BASH_REMATCH[1]}"
+  kubectl -n kube-system label \
+    "secret/bootstrap-token-${token_id}" \
+    kubernetes.azure.com/managedby=aks \
+    --overwrite \
+    >/dev/null
+  log_info "Marked E2E bootstrap token Secret as AKS-managed" >&2
+}
+
 # ---------------------------------------------------------------------------
 # SSH helpers
 # ---------------------------------------------------------------------------

--- a/hack/e2e/lib/node-join-kubeadm.sh
+++ b/hack/e2e/lib/node-join-kubeadm.sh
@@ -271,6 +271,9 @@ stringData:
   auth-extra-groups: "system:bootstrappers:aks-flex-node,${kubeadmBootstrapGroup}"
 EOF
 
+  # This function already runs under the cluster lock in node_join_kubeadm.
+  mark_e2e_bootstrap_token_aks_managed "${bootstrap_token}"
+
   echo "${bootstrap_token}"
 }
 

--- a/hack/e2e/lib/node-join-offline.sh
+++ b/hack/e2e/lib/node-join-offline.sh
@@ -178,6 +178,11 @@ node_join_offline() {
     --bootstrap-token \
     --output "${config_file}"
 
+  # The production approver uses this label to distinguish RP-issued tokens
+  # from arbitrary bootstrap token Secrets.
+  with_cluster_lock mark_e2e_bootstrap_token_aks_managed \
+    "$(jq -er '.azure.bootstrapToken.token' "${config_file}")"
+
   jq \
     --arg nodeIP "${vm_private_ip}" \
     --arg machineEndpointURL "${E2E_CONTROLLER_SERVICE_PROXY_PATH}" \

--- a/hack/e2e/lib/node-join-token.sh
+++ b/hack/e2e/lib/node-join-token.sh
@@ -62,6 +62,11 @@ node_join_token() {
     --bootstrap-token \
     --output "${config_file}"
 
+  # The production approver uses this label to distinguish RP-issued tokens
+  # from arbitrary bootstrap token Secrets.
+  with_cluster_lock mark_e2e_bootstrap_token_aks_managed \
+    "$(jq -er '.azure.bootstrapToken.token' "${config_file}")"
+
   jq \
     --arg nodeIP "${vm_private_ip}" \
     --arg machineEndpointURL "${E2E_CONTROLLER_SERVICE_PROXY_PATH}" \


### PR DESCRIPTION
## Summary

- mark E2E-created bootstrap token Secrets with `kubernetes.azure.com/managedby=aks`
- apply the marker to token, offline, and kubeadm join flows
- validate the token format before deriving the Secret name and avoid logging token values

## Why

The managed AKS FlexNode CSR approver now runs alongside the E2E controller. It rejects bootstrap-token daemon CSRs unless the backing Secret carries the AKS managed-by label. The rejection wins before the E2E controller can approve, leaving token-backed daemons without credentials and causing unjoin to time out.

Example failure: https://github.com/Azure/AKSFlexNode/actions/runs/32195931630/job/95899825113

The required contract is implemented by aks-rp PR 16150772. This change is intentionally limited to the E2E harness; public token generation and production behavior are unchanged.

## Validation

- `make check`
- `bash -n hack/e2e/run.sh hack/e2e/lib/*.sh`
- focused helper validation for valid and invalid token formats
