### PR TITLE
Order nspawn after required host systemd services

### DIFF
--- a/docs/usages/configuration.md
+++ b/docs/usages/configuration.md
@@ -115,6 +115,7 @@ At least one join or Azure authentication method must be configured. `azure.boot
 | `bootstrap.offlineArtifacts.source` | string | Optional complete offline binary artifact bundle source. Supports absolute paths, `file://`, and unauthenticated `oci://` artifact references. The value is rendered as a strict Go template with `.KubernetesVersion` and `.KubernetesVersionNoV`. Preflight treats missing host packages as fatal when this is set. | `/opt/aks-flex-node/artifacts/{{ .KubernetesVersion }}` |
 | `bootstrap.additionalHostDevices` | array of strings | Optional extra host device nodes under `/dev` to expose to the nspawn machine in addition to devices discovered automatically by the shared agent. Entries must be clean absolute `/dev/...` paths. | `["/dev/uinput"]` |
 | `bootstrap.additionalHostMounts` | array of objects | Optional non-device host paths to bind mount into the nspawn machine. `source` is required, `target` defaults to `source`, and `readOnly` defaults to `false`. Source and target must be clean absolute paths without whitespace, control characters, or `:`. Prefer read-only mounts unless write access is required. | `[{"source":"/opt/config","target":"/etc/config","readOnly":true}]` |
+| `bootstrap.additionalRequiredServices` | array of strings | Optional host systemd service units that the nspawn machine requires and starts after. Use this when a host service must finish configuring or renaming devices before nspawn starts. | `["ib_rdma_configure.service"]` |
 
 ## Networking
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -223,6 +223,10 @@ type BootstrapConfig struct {
 	// nspawn machine. Read-only mounts should be preferred unless write access is
 	// required.
 	AdditionalHostMounts []AdditionalHostMount `json:"additionalHostMounts,omitempty"`
+
+	// AdditionalRequiredServices lists host systemd services that must start
+	// successfully before the nspawn machine starts.
+	AdditionalRequiredServices []string `json:"additionalRequiredServices,omitempty"`
 }
 
 // AdditionalHostMount re-exports the shared agent's host bind-mount config.
@@ -501,6 +505,8 @@ var AKSClusterResourceIDPattern = regexp.MustCompile(`(?i)^/subscriptions/([0-9a
 // BootstrapTokenPattern is the regex pattern for Kubernetes bootstrap tokens
 // Format: <token-id>.<token-secret> where token-id is 6 chars [a-z0-9] and token-secret is 16 chars [a-z0-9]
 var BootstrapTokenPattern = regexp.MustCompile(`^[a-z0-9]{6}\.[a-z0-9]{16}$`)
+
+var systemdServiceNamePattern = regexp.MustCompile(`^[A-Za-z0-9:_.@-]+\.service$`)
 
 // validateAzureResourceID validates the format of an AKS cluster resource ID using regex pattern matching
 func validateAzureResourceID(resourceID string) error {
@@ -828,6 +834,11 @@ func (c *BootstrapConfig) validate() error {
 	}
 	if err := agentconfig.ValidateAdditionalHostMounts(c.AdditionalHostMounts); err != nil {
 		return fmt.Errorf("invalid bootstrap.additionalHostMounts: %w", err)
+	}
+	for _, service := range c.AdditionalRequiredServices {
+		if len(service) > 255 || !systemdServiceNamePattern.MatchString(service) {
+			return fmt.Errorf("invalid bootstrap.additionalRequiredServices entry %q: must be a valid systemd .service unit name", service)
+		}
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -883,7 +883,8 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 			"additionalHostMounts": [
 				{"source": "/opt/config", "target": "/etc/config", "readOnly": true},
 				{"source": "/var/lib/example"}
-			]
+			],
+			"additionalRequiredServices": ["ib_rdma_configure.service"]
 		},
 		"networking": {
 			"dnsServiceIP": "10.42.0.10",
@@ -980,6 +981,9 @@ func TestLoadConfigPoolBootstrapData(t *testing.T) {
 	}
 	if got := agentCfg.AdditionalHostMounts[1]; got.Source != "/var/lib/example" || got.Target != "" || got.ReadOnly {
 		t.Fatalf("Agent AdditionalHostMounts[1] = %#v", got)
+	}
+	if len(cfg.Bootstrap.AdditionalRequiredServices) != 1 || cfg.Bootstrap.AdditionalRequiredServices[0] != "ib_rdma_configure.service" {
+		t.Fatalf("Bootstrap.AdditionalRequiredServices = %#v", cfg.Bootstrap.AdditionalRequiredServices)
 	}
 	if agentCfg.CNI.PluginVersion != "1.5.1" {
 		t.Fatalf("Agent CNI.PluginVersion = %q, want 1.5.1", agentCfg.CNI.PluginVersion)
@@ -1078,6 +1082,50 @@ func TestBootstrapConfigValidatesAdditionalHostMounts(t *testing.T) {
 			}
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("BootstrapConfig.validate() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBootstrapConfigValidatesAdditionalRequiredServices(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		services []string
+		wantErr  bool
+	}{
+		{
+			name:     "valid services",
+			services: []string{"ib_rdma_configure.service", "storage-ready@data.service"},
+		},
+		{
+			name:     "missing service suffix",
+			services: []string{"ib_rdma_configure"},
+			wantErr:  true,
+		},
+		{
+			name:     "contains whitespace",
+			services: []string{"ib rdma.service"},
+			wantErr:  true,
+		},
+		{
+			name:     "contains systemd directive",
+			services: []string{"valid.service\nAfter=unexpected.service"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := (&BootstrapConfig{AdditionalRequiredServices: tt.services}).validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("validate() error = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validate() error = %v", err)
 			}
 		})
 	}

--- a/pkg/daemon/assets/aks-flex-node-agent.service
+++ b/pkg/daemon/assets/aks-flex-node-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=AKS Flex Node Agent
 After=network-online.target systemd-udev-settle.service
-Wants=network-online.target
+Wants=network-online.target systemd-udev-settle.service
 OnFailure=aks-flex-node-agent-recovery.service
 # Trigger last-good recovery after the upgraded daemon repeatedly fails.
 StartLimitIntervalSec=300

--- a/pkg/daemon/assets/aks-flex-node-agent.service
+++ b/pkg/daemon/assets/aks-flex-node-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=AKS Flex Node Agent
-After=network-online.target
+After=network-online.target systemd-udev-settle.service
 Wants=network-online.target
 OnFailure=aks-flex-node-agent-recovery.service
 # Trigger last-good recovery after the upgraded daemon repeatedly fails.

--- a/pkg/daemon/lifecycle_test.go
+++ b/pkg/daemon/lifecycle_test.go
@@ -78,6 +78,9 @@ func TestAgentServiceIncludesUpgradeRecovery(t *testing.T) {
 	t.Parallel()
 
 	service := string(serviceUnitContent)
+	if !strings.Contains(service, "After=network-online.target systemd-udev-settle.service") {
+		t.Fatal("service does not start after systemd-udev-settle.service")
+	}
 	if !strings.Contains(service, "OnFailure="+recoveryServiceUnitName) {
 		t.Fatalf("service does not activate %s on failure", recoveryServiceUnitName)
 	}

--- a/pkg/daemon/lifecycle_test.go
+++ b/pkg/daemon/lifecycle_test.go
@@ -81,6 +81,9 @@ func TestAgentServiceIncludesUpgradeRecovery(t *testing.T) {
 	if !strings.Contains(service, "After=network-online.target systemd-udev-settle.service") {
 		t.Fatal("service does not start after systemd-udev-settle.service")
 	}
+	if !strings.Contains(service, "Wants=network-online.target systemd-udev-settle.service") {
+		t.Fatal("service does not activate systemd-udev-settle.service")
+	}
 	if !strings.Contains(service, "OnFailure="+recoveryServiceUnitName) {
 		t.Fatalf("service does not activate %s on failure", recoveryServiceUnitName)
 	}

--- a/pkg/daemon/start.go
+++ b/pkg/daemon/start.go
@@ -49,6 +49,7 @@ func StartNode(
 	return phases.Serial(log,
 		stageContainerImageArchiveBindSource(log, containerImageArchives),
 		rootfs.Provision(log, gs.RootFS),
+		ConfigureNSpawnDependencies(log, gs.RootFS, cfg.Bootstrap.AdditionalRequiredServices),
 		phases.Parallel(log,
 			npd.Download(log, cfg, gs.RootFS.MachineDir),
 			InstallBinary(gs.RootFS.MachineDir),

--- a/pkg/daemon/systemd_dependencies.go
+++ b/pkg/daemon/systemd_dependencies.go
@@ -40,9 +40,9 @@ func (t *configureNSpawnDependenciesTask) Name() string {
 
 func (t *configureNSpawnDependenciesTask) Do(ctx context.Context) error {
 	var content bytes.Buffer
-content.WriteString("[Unit]\n")
-content.WriteString("Wants=systemd-udev-settle.service\n")
-content.WriteString("After=systemd-udev-settle.service\n")
+	content.WriteString("[Unit]\n")
+	content.WriteString("Wants=systemd-udev-settle.service\n")
+	content.WriteString("After=systemd-udev-settle.service\n")
 	if len(t.requiredServices) > 0 {
 		services := strings.Join(t.requiredServices, " ")
 		fmt.Fprintf(&content, "Requires=%s\n", services)

--- a/pkg/daemon/systemd_dependencies.go
+++ b/pkg/daemon/systemd_dependencies.go
@@ -40,8 +40,9 @@ func (t *configureNSpawnDependenciesTask) Name() string {
 
 func (t *configureNSpawnDependenciesTask) Do(ctx context.Context) error {
 	var content bytes.Buffer
-	content.WriteString("[Unit]\n")
-	content.WriteString("After=systemd-udev-settle.service\n")
+content.WriteString("[Unit]\n")
+content.WriteString("Wants=systemd-udev-settle.service\n")
+content.WriteString("After=systemd-udev-settle.service\n")
 	if len(t.requiredServices) > 0 {
 		services := strings.Join(t.requiredServices, " ")
 		fmt.Fprintf(&content, "Requires=%s\n", services)

--- a/pkg/daemon/systemd_dependencies.go
+++ b/pkg/daemon/systemd_dependencies.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/AKSFlexNode/pkg/utils/utilexec"
+	"github.com/Azure/AKSFlexNode/pkg/utils/utilio"
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+	"github.com/Azure/unbounded/pkg/agent/phases"
+)
+
+const nspawnDependenciesDropIn = "aks-flex-node-dependencies.conf"
+
+type configureNSpawnDependenciesTask struct {
+	log               *slog.Logger
+	serviceDropInPath string
+	requiredServices  []string
+	reload            func(context.Context, *slog.Logger) error
+}
+
+// ConfigureNSpawnDependencies orders the machine after host services that
+// must finish changing host devices before nspawn starts.
+func ConfigureNSpawnDependencies(log *slog.Logger, rootFS *goalstates.RootFS, requiredServices []string) phases.Task {
+	return &configureNSpawnDependenciesTask{
+		log:               log,
+		serviceDropInPath: filepath.Join(filepath.Dir(rootFS.ServiceOverrideFile), nspawnDependenciesDropIn),
+		requiredServices:  requiredServices,
+		reload:            utilexec.ReloadSystemd,
+	}
+}
+
+func (t *configureNSpawnDependenciesTask) Name() string {
+	return "configure-nspawn-systemd-dependencies"
+}
+
+func (t *configureNSpawnDependenciesTask) Do(ctx context.Context) error {
+	var content bytes.Buffer
+	content.WriteString("[Unit]\n")
+	content.WriteString("After=systemd-udev-settle.service\n")
+	if len(t.requiredServices) > 0 {
+		services := strings.Join(t.requiredServices, " ")
+		fmt.Fprintf(&content, "Requires=%s\n", services)
+		fmt.Fprintf(&content, "After=%s\n", services)
+	}
+
+	if err := utilio.WriteFile(t.serviceDropInPath, content.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write nspawn dependency drop-in %s: %w", t.serviceDropInPath, err)
+	}
+	if err := t.reload(ctx, t.log); err != nil {
+		return fmt.Errorf("reload systemd after configuring nspawn dependencies: %w", err)
+	}
+	return nil
+}

--- a/pkg/daemon/systemd_dependencies_test.go
+++ b/pkg/daemon/systemd_dependencies_test.go
@@ -39,6 +39,7 @@ func TestConfigureNSpawnDependencies(t *testing.T) {
 	}
 	content := string(data)
 	for _, expected := range []string{
+		"Wants=systemd-udev-settle.service",
 		"After=systemd-udev-settle.service",
 		"Requires=ib_rdma_configure.service storage-ready.service",
 		"After=ib_rdma_configure.service storage-ready.service",

--- a/pkg/daemon/systemd_dependencies_test.go
+++ b/pkg/daemon/systemd_dependencies_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/unbounded/pkg/agent/goalstates"
+)
+
+func TestConfigureNSpawnDependencies(t *testing.T) {
+	t.Parallel()
+
+	systemdDir := filepath.Join(t.TempDir(), "systemd-nspawn@kube1.service.d")
+	task := ConfigureNSpawnDependencies(slog.Default(), &goalstates.RootFS{
+		ServiceOverrideFile: filepath.Join(systemdDir, "override.conf"),
+	}, []string{"ib_rdma_configure.service", "storage-ready.service"}).(*configureNSpawnDependenciesTask)
+
+	reloadCount := 0
+	task.reload = func(context.Context, *slog.Logger) error {
+		reloadCount++
+		return nil
+	}
+	for range 2 {
+		if err := task.Do(t.Context()); err != nil {
+			t.Fatalf("Do() error = %v", err)
+		}
+	}
+	if reloadCount != 2 {
+		t.Fatalf("systemd reload count = %d, want 2", reloadCount)
+	}
+
+	data, err := os.ReadFile(filepath.Join(systemdDir, nspawnDependenciesDropIn))
+	if err != nil {
+		t.Fatalf("read dependency drop-in: %v", err)
+	}
+	content := string(data)
+	for _, expected := range []string{
+		"After=systemd-udev-settle.service",
+		"Requires=ib_rdma_configure.service storage-ready.service",
+		"After=ib_rdma_configure.service storage-ready.service",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Errorf("dependency drop-in missing %q:\n%s", expected, content)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- order the AKS Flex Node agent and nspawn machine after `systemd-udev-settle.service`
- add `bootstrap.additionalRequiredServices` for host services that must complete before nspawn starts
- render configured services into the per-machine nspawn drop-in as both `Requires=` and `After=` dependencies
- validate configured values as systemd `.service` unit names and document the new setting

## Motivation

Some host images run services such as `ib_rdma_configure.service` that rename or otherwise reconfigure devices during boot. If nspawn starts concurrently, it can capture stale device names and fail to expose the expected objects to the worker node. Explicit ordering ensures host device discovery and renaming finish before the machine starts.

## Configuration

```json
{
  "bootstrap": {
    "additionalRequiredServices": [
      "ib_rdma_configure.service"
    ]
  }
}
```

The generated nspawn drop-in requires each configured service and orders nspawn after it. The dependency configuration is reconciled during bootstrap and repave and remains safe to apply repeatedly.

## Validation

- `make check`
- focused config and daemon tests, including invalid unit names and idempotent drop-in reconciliation