### PR TITLE
Add cross-platform `aks-flex-config` binaries

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,6 +83,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Validate config helper parity
+        run: ./hack/e2e/config-helper-parity.sh
+
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    name: Build and Release
+    name: Build ${{ matrix.binary_name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,9 +26,33 @@ jobs:
           - os: linux
             arch: amd64
             goarch: amd64
+            binary_name: aks-flex-node-linux-amd64
+            target: ./cmd/aks-flex-node
+            package: tar.gz
           - os: linux
             arch: arm64
             goarch: arm64
+            binary_name: aks-flex-node-linux-arm64
+            target: ./cmd/aks-flex-node
+            package: tar.gz
+          - os: windows
+            arch: amd64
+            goarch: amd64
+            binary_name: aks-flex-config-windows-amd64.exe
+            target: ./cmd/aks-flex-config
+            package: raw
+          - os: darwin
+            arch: amd64
+            goarch: amd64
+            binary_name: aks-flex-config-darwin-amd64
+            target: ./cmd/aks-flex-config
+            package: raw
+          - os: darwin
+            arch: arm64
+            goarch: arm64
+            binary_name: aks-flex-config-darwin-arm64
+            target: ./cmd/aks-flex-config
+            package: raw
 
     steps:
       - name: Checkout code
@@ -55,6 +79,9 @@ jobs:
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.goarch }}
+          BINARY_NAME: ${{ matrix.binary_name }}
+          TARGET: ${{ matrix.target }}
+          PACKAGE: ${{ matrix.package }}
         run: |
           set -euo pipefail
           GIT_COMMIT=$(git rev-parse --short HEAD)
@@ -62,18 +89,20 @@ jobs:
 
           LDFLAGS="-X github.com/Azure/AKSFlexNode/pkg/cmd/version.Version=${RELEASE_VERSION} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.GitCommit=${GIT_COMMIT} -X github.com/Azure/AKSFlexNode/pkg/cmd/version.BuildTime=${BUILD_DATE} -w -s"
 
-          BINARY_NAME="aks-flex-node-${GOOS}-${GOARCH}"
 
-          go build -ldflags "${LDFLAGS}" -o "${BINARY_NAME}" ./cmd/aks-flex-node
+          go build -ldflags "${LDFLAGS}" -o "${BINARY_NAME}" "${TARGET}"
 
-          # Create tarball
-          tar -czf "${BINARY_NAME}.tar.gz" "${BINARY_NAME}"
-          echo "ASSET=${BINARY_NAME}.tar.gz" >> "$GITHUB_ENV"
+          if [[ "${PACKAGE}" == "tar.gz" ]]; then
+            tar -czf "${BINARY_NAME}.tar.gz" "${BINARY_NAME}"
+            echo "ASSET=${BINARY_NAME}.tar.gz" >> "$GITHUB_ENV"
+          else
+            echo "ASSET=${BINARY_NAME}" >> "$GITHUB_ENV"
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: binaries-${{ matrix.os }}-${{ matrix.arch }}
+          name: binaries-${{ matrix.binary_name }}
           path: ${{ env.ASSET }}
 
   release:
@@ -99,19 +128,19 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: binaries-*
+          pattern: "*"
           path: ./artifacts
 
       - name: Consolidate artifacts
         run: |
           mkdir -p release-assets
-          find artifacts -name "*.tar.gz" -exec cp {} release-assets/ \;
+          find artifacts -type f -name "aks-flex-*" -exec cp {} release-assets/ \;
           ls -lh release-assets/
 
       - name: Generate checksums
         run: |
           cd release-assets
-          sha256sum *.tar.gz > checksums.txt
+          sha256sum aks-flex-* > checksums.txt
           cat checksums.txt
 
       - name: Create Release
@@ -135,11 +164,19 @@ jobs:
           3. Move the binary to your PATH: \`sudo mv aks-flex-node-* /usr/local/bin/aks-flex-node\`
           4. Make it executable: \`sudo chmod +x /usr/local/bin/aks-flex-node\`
 
-          ### Supported Platforms
+          **Windows workstation config helper:**
+          Download \`aks-flex-config-windows-amd64.exe\` and run it from PowerShell to prepare the cluster and generate the node configuration.
+
+          **macOS workstation config helper:**
+          Download \`aks-flex-config-darwin-amd64\` for Intel Macs or \`aks-flex-config-darwin-arm64\` for Apple Silicon, make it executable, and run it from a terminal.
+
+          ### Supported Node Platforms
 
           - **Ubuntu 22.04 LTS (AMD64)**: \`aks-flex-node-linux-amd64.tar.gz\`
           - **Ubuntu 22.04 LTS (ARM64)**: \`aks-flex-node-linux-arm64.tar.gz\`
           - **Ubuntu 24.04 LTS**: Compatible with AMD64 and ARM64 binaries above
+
+          The config-helper assets support Windows AMD64 and macOS AMD64/ARM64 workstations. The Flex Node machine itself must run a supported Linux distribution.
 
           ### Verification
 
@@ -156,7 +193,7 @@ jobs:
           fi
 
           gh release create "${RELEASE_VERSION}" \
-            release-assets/*.tar.gz \
+            release-assets/aks-flex-* \
             release-assets/checksums.txt \
             --repo "${GITHUB_REPOSITORY}" \
             --title "Release ${RELEASE_VERSION}" \

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,24 @@ build-linux-arm64:
 	@echo "Building for Linux ARM64..."
 	@GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o aks-flex-node-linux-arm64 ./cmd/aks-flex-node
 
+.PHONY: build-config-windows-amd64
+build-config-windows-amd64:
+	@echo "Building AKS Flex config helper for Windows AMD64..."
+	@GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o aks-flex-config-windows-amd64.exe ./cmd/aks-flex-config
+
+.PHONY: build-config-darwin-amd64
+build-config-darwin-amd64:
+	@echo "Building AKS Flex config helper for macOS AMD64..."
+	@GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o aks-flex-config-darwin-amd64 ./cmd/aks-flex-config
+
+.PHONY: build-config-darwin-arm64
+build-config-darwin-arm64:
+	@echo "Building AKS Flex config helper for macOS ARM64..."
+	@GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o aks-flex-config-darwin-arm64 ./cmd/aks-flex-config
+
 # Build all supported platforms
 .PHONY: build-all
-build-all: build-linux-amd64 build-linux-arm64
+build-all: build-linux-amd64 build-linux-arm64 build-config-windows-amd64 build-config-darwin-amd64 build-config-darwin-arm64
 	@echo "Built binaries for all supported platforms"
 
 # Create release archives
@@ -46,9 +61,9 @@ package-linux-arm64: build-linux-arm64
 
 # Package all supported platforms
 .PHONY: package-all
-package-all: package-linux-amd64 package-linux-arm64
+package-all: package-linux-amd64 package-linux-arm64 build-config-windows-amd64 build-config-darwin-amd64 build-config-darwin-arm64
 	@echo "Packaged all supported platforms"
-	@ls -la *.tar.gz
+	@ls -la *.tar.gz aks-flex-config-windows-amd64.exe aks-flex-config-darwin-*
 
 # Testing and quality checks
 .PHONY: test
@@ -133,6 +148,7 @@ clean:
 	@echo "Cleaning build artifacts..."
 	@go clean
 	@rm -f aks-flex-node aks-flex-node-*
+	@rm -f aks-flex-config aks-flex-config-*
 	@rm -f aks-flex-controller
 	@rm -f *.tar.gz
 	@rm -f coverage.out coverage.html
@@ -151,16 +167,19 @@ help:
 	@echo "======================"
 	@echo ""
 	@echo "Build Targets:"
-	@echo "  build              Build for current platform"
-	@echo "  build-controller   Build AKS Flex controller for current platform"
-	@echo "  build-linux-amd64  Build for Linux AMD64"
-	@echo "  build-linux-arm64  Build for Linux ARM64"
-	@echo "  build-all          Build for all supported platforms"
+	@echo "  build              		Build for current platform"
+	@echo "  build-controller   		Build AKS Flex controller for current platform"
+	@echo "  build-linux-amd64  		Build for Linux AMD64"
+	@echo "  build-linux-arm64  		Build for Linux ARM64"
+	@echo "  build-config-windows-amd64 Build config helper for Windows AMD64"
+	@echo "  build-config-darwin-amd64 	Build config helper for macOS AMD64"
+	@echo "  build-config-darwin-arm64 	Build config helper for macOS ARM64"
+@echo "  build-all          			Build for all supported platforms"
 	@echo ""
 	@echo "Package Targets:"
 	@echo "  package-linux-amd64 Package Linux AMD64 binary"
 	@echo "  package-linux-arm64 Package Linux ARM64 binary"
-	@echo "  package-all        Package all supported platforms"
+	@echo "  package-all        Build all release assets"
 	@echo ""
 	@echo "Test & Quality Targets:"
 	@echo "  test               Run tests"

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ help:
 	@echo "  build-config-windows-amd64 Build config helper for Windows AMD64"
 	@echo "  build-config-darwin-amd64 	Build config helper for macOS AMD64"
 	@echo "  build-config-darwin-arm64 	Build config helper for macOS ARM64"
-@echo "  build-all          			Build for all supported platforms"
+	@echo "  build-all          			Build for all supported platforms"
 	@echo ""
 	@echo "Package Targets:"
 	@echo "  package-linux-amd64 Package Linux AMD64 binary"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This quickstart involves two machines. Keep them distinct:
 Before you begin, make sure you have:
 
 - An Azure subscription. [Create one for free](https://azure.microsoft.com/free/).
-- **Your workstation**, with the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli), `kubectl`, `curl`, and `python3` installed. Sign in with `az login`, then `az account set --subscription "<subscription-id>"`.
+- **Your workstation**, with the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) and `kubectl` installed. Linux workstations need `curl` and `python3` for the script-based helper. macOS can use either the native release binary or the Python helper. Windows workstations need PowerShell and the OpenSSH client for `ssh` and `scp`. Sign in with `az login`, then `az account set --subscription "<subscription-id>"`.
 - **An existing AKS cluster** with a Linux node pool. Azure CNI is recommended so pods are reachable across your network, and you need permission to configure RBAC on the cluster. If you don't have a cluster yet, see [create an AKS cluster](https://learn.microsoft.com/azure/aks/learn/quick-kubernetes-deploy-cli).
 - **A Flex Node machine you own**: an on-premises physical server or a virtual machine to join as the worker node. It must:
   - run `systemd` and allow root installation,
@@ -74,6 +74,26 @@ az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME"
 kubectl get nodes
 ```
 
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+$SubscriptionId = "<subscription-id>"
+$ResourceGroup = "<resource-group-of-your-aks-cluster>"
+$ClusterName = "<cluster-name>"
+$AgentPoolName = "aksflexnodes"
+
+# Your Flex Node machine, as an SSH target (for example: azureuser@203.0.113.10)
+$TargetHost = "<user>@<flex-node-machine-ip-or-hostname>"
+
+az login
+az account set --subscription $SubscriptionId
+az aks get-credentials --resource-group $ResourceGroup --name $ClusterName
+kubectl get nodes
+```
+
+</details>
+
 You should see your existing cluster nodes in `Ready` state.
 
 ### Step 2: Generate the join configuration
@@ -99,6 +119,68 @@ chmod +x ./aks-flex-config
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```
+
+<details>
+<summary>macOS workstation (native binary)</summary>
+
+Download the helper for Intel or Apple Silicon from a tagged release, then generate the config with the same arguments:
+
+```bash
+export AKS_FLEX_NODE_VERSION="<release-tag>"
+case "$(uname -m)" in
+  x86_64) CONFIG_ARCH="amd64" ;;
+  arm64) CONFIG_ARCH="arm64" ;;
+  *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+curl -fL -o ./aks-flex-config \
+  "https://github.com/Azure/AKSFlexNode/releases/download/${AKS_FLEX_NODE_VERSION}/aks-flex-config-darwin-${CONFIG_ARCH}"
+chmod +x ./aks-flex-config
+
+./aks-flex-config setup-node-rbac \
+  --resource-group "$RESOURCE_GROUP" \
+  --cluster-name "$CLUSTER_NAME" \
+  --subscription "$SUBSCRIPTION_ID"
+
+./aks-flex-config generate-node-config \
+  --resource-group "$RESOURCE_GROUP" \
+  --cluster-name "$CLUSTER_NAME" \
+  --subscription "$SUBSCRIPTION_ID" \
+  --agent-pool-name "$AGENT_POOL_NAME" \
+  --bootstrap-token \
+  --output ./aks-flex-node-config.json
+```
+
+</details>
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+Download the helper from a tagged release, apply the RBAC bindings, and generate the config:
+
+```powershell
+$AksFlexNodeVersion = "<release-tag>"
+$Binary = "aks-flex-config-windows-amd64.exe"
+$DownloadUrl = "https://github.com/Azure/AKSFlexNode/releases/download/$AksFlexNodeVersion/$Binary"
+
+Invoke-WebRequest -Uri $DownloadUrl -OutFile $Binary
+$AksFlexConfig = ".\$Binary"
+
+& $AksFlexConfig setup-node-rbac `
+  --resource-group $ResourceGroup `
+  --cluster-name $ClusterName `
+  --subscription $SubscriptionId
+
+& $AksFlexConfig generate-node-config `
+  --resource-group $ResourceGroup `
+  --cluster-name $ClusterName `
+  --subscription $SubscriptionId `
+  --agent-pool-name $AgentPoolName `
+  --bootstrap-token `
+  --output .\aks-flex-node-config.json
+```
+
+</details>
 
 This produces `aks-flex-node-config.json` in your current folder. `generate-node-config` supports one of the following auth modes: `--bootstrap-token`, `--identity`, `--service-principal --username <client-id> --password <client-secret>`, or `--arc`. This quickstart uses `--bootstrap-token`.
 
@@ -150,6 +232,15 @@ The rendered config should look like this. Comments are shown here only to expla
 scp ./aks-flex-node-config.json "$TARGET_HOST:/tmp/aks-flex-node-config.json"
 ```
 
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+scp .\aks-flex-node-config.json "${TargetHost}:/tmp/aks-flex-node-config.json"
+```
+
+</details>
+
 > **Note**
 > The config is staged in `/tmp` because your SSH user cannot write to root-owned `/etc`, and `/etc/aks-flex-node` does not exist yet. The next step creates that directory and installs the file as root with owner-only `0600` permissions.
 
@@ -162,6 +253,15 @@ First, from your workstation, open an SSH session on the Flex Node machine.
 ```bash
 ssh "$TARGET_HOST"
 ```
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+ssh $TargetHost
+```
+
+</details>
 
 You are now connected to the Flex Node machine. Install the agent and move the generated config into place, as root.
 
@@ -236,6 +336,15 @@ When you are finished, press `Ctrl+C` to stop following the logs, then run `exit
 kubectl get nodes -o wide
 ```
 
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+kubectl get nodes -o wide
+```
+
+</details>
+
 Example output:
 
 ```text
@@ -250,6 +359,17 @@ kubectl run hello --image=mcr.microsoft.com/azuredocs/aks-helloworld:v1 \
   --overrides='{"spec":{"nodeName":"<node-name>"}}'
 kubectl get pod hello -o wide
 ```
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+kubectl run hello --image=mcr.microsoft.com/azuredocs/aks-helloworld:v1 `
+  --overrides='{"spec":{"nodeName":"<node-name>"}}'
+kubectl get pod hello -o wide
+```
+
+</details>
 
 <details>
 <summary>Inspect the nspawn worker (optional)</summary>
@@ -274,6 +394,8 @@ Remove the test workload from your workstation:
 ```bash
 kubectl delete pod hello --ignore-not-found
 ```
+
+This cleanup command works unchanged in PowerShell.
 
 <details>
 <summary>Reset And Uninstall</summary>

--- a/cmd/aks-flex-config/main.go
+++ b/cmd/aks-flex-config/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	configcmd "github.com/Azure/AKSFlexNode/pkg/cmd/config"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := configcmd.NewCommand().ExecuteContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/usages/aks-flex-config.md
+++ b/docs/usages/aks-flex-config.md
@@ -1,22 +1,69 @@
 # AKS Flex Config Helper
 
-`scripts/aks-flex-config` is a workstation-side helper for generating AKS Flex Node config files from AKS cluster metadata.
+`aks-flex-config` is a workstation-side helper for generating AKS Flex Node config files from AKS cluster metadata. It is available as a Python script and as native Windows AMD64 and macOS AMD64/ARM64 executables in tagged releases.
 
 The helper does not install anything on the target host. It uses Azure CLI and, for bootstrap-token mode, `kubectl` to prepare cluster-side bootstrap material and render a config that can be copied to the host.
 
 ## Prerequisites
 
 - Azure CLI authenticated to the subscription that contains the AKS cluster.
-- `python3` on the workstation.
 - `kubectl` on the workstation for `setup-node-rbac` and `--bootstrap-token` config generation.
 - Permission to run `az aks get-credentials --admin` and create Kubernetes `ClusterRoleBinding` and bootstrap token `Secret` objects.
+- Linux, or macOS using the script: `python3` and `curl`.
+- macOS using a native release binary: `curl`.
+- Windows: PowerShell and the OpenSSH client when copying the generated config with `scp`.
 
 ## Save The Helper
+
+<details open>
+<summary>Linux or macOS workstation (Python)</summary>
 
 ```bash
 curl -fsSLo ./aks-flex-config https://raw.githubusercontent.com/Azure/AKSFlexNode/main/scripts/aks-flex-config
 chmod +x ./aks-flex-config
 ```
+
+</details>
+
+<details>
+<summary>macOS workstation (native binary)</summary>
+
+Set an explicit tagged release and download the binary for Intel or Apple Silicon:
+
+```bash
+AKS_FLEX_NODE_VERSION="<release-tag>"
+case "$(uname -m)" in
+  x86_64) CONFIG_ARCH="amd64" ;;
+  arm64) CONFIG_ARCH="arm64" ;;
+  *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+curl -fL -o ./aks-flex-config \
+  "https://github.com/Azure/AKSFlexNode/releases/download/${AKS_FLEX_NODE_VERSION}/aks-flex-config-darwin-${CONFIG_ARCH}"
+chmod +x ./aks-flex-config
+./aks-flex-config --help
+```
+
+</details>
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+Set an explicit tagged release, then download the Windows AMD64 helper:
+
+```powershell
+$AksFlexNodeVersion = "<release-tag>"
+$Binary = "aks-flex-config-windows-amd64.exe"
+$DownloadUrl = "https://github.com/Azure/AKSFlexNode/releases/download/$AksFlexNodeVersion/$Binary"
+
+Invoke-WebRequest -Uri $DownloadUrl -OutFile $Binary
+$AksFlexConfig = ".\$Binary"
+& $AksFlexConfig --help
+```
+
+The executable runs on the Windows workstation. The Flex Node machine remains a supported Linux host. Existing labs and E2E automation continue to use `scripts/aks-flex-config` during the compatibility period.
+
+</details>
 
 ## Shared Cluster Arguments
 
@@ -28,6 +75,18 @@ CLUSTER_NAME="<cluster-name>"
 SUBSCRIPTION_ID="<subscription-id>"
 AGENT_POOL_NAME="${AGENT_POOL_NAME:-aksflexnodes}"
 ```
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+$ResourceGroup = "<resource-group>"
+$ClusterName = "<cluster-name>"
+$SubscriptionId = "<subscription-id>"
+$AgentPoolName = "aksflexnodes"
+```
+
+</details>
 
 | Flag | Required | Description |
 |------|----------|-------------|
@@ -46,13 +105,25 @@ Run this once per cluster for bootstrap-token joins:
   --subscription "$SUBSCRIPTION_ID"
 ```
 
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+& $AksFlexConfig setup-node-rbac `
+  --resource-group $ResourceGroup `
+  --cluster-name $ClusterName `
+  --subscription $SubscriptionId
+```
+
+</details>
+
 This applies the bootstrap-related `ClusterRoleBinding` objects for the `system:bootstrappers:aks-flex-node` group.
 
 ## Generate Node Config
 
 `generate-node-config` fetches AKS metadata and renders a config file. It requires exactly one auth mode.
 
-Use `--output <path>` to write a config file with mode `0600`. If omitted, the config is written to stdout.
+Use `--output <path>` to write a config file. On Linux and macOS, the helper sets mode `0600`; on Windows, access is governed by the destination directory's Windows ACL. If omitted, the config is written to stdout.
 The helper writes `azure.resourceManagerEndpoint` with the public ARM endpoint and writes the selected agent pool name to `azure.targetAgentPoolName`. If `--agent-pool-name` is omitted, it defaults to the historical `aksflexnodes` pool name.
 
 | Flag | Required | Description |
@@ -70,6 +141,21 @@ The helper writes `azure.resourceManagerEndpoint` with the public ARM endpoint a
   --bootstrap-token \
   --output ./aks-flex-node-config.json
 ```
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+& $AksFlexConfig generate-node-config `
+  --resource-group $ResourceGroup `
+  --cluster-name $ClusterName `
+  --subscription $SubscriptionId `
+  --agent-pool-name $AgentPoolName `
+  --bootstrap-token `
+  --output .\aks-flex-node-config.json
+```
+
+</details>
 
 Bootstrap-token mode creates a Kubernetes bootstrap token `Secret`, reads the AKS API server and CA data from kubeconfig, and includes those values plus the AKS DNS service IP in the generated config.
 
@@ -130,6 +216,16 @@ TARGET_HOST="<user>@<host>"
 
 scp ./aks-flex-node-config.json "$TARGET_HOST:/tmp/aks-flex-node-config.json"
 ```
+
+<details>
+<summary>Windows workstation (PowerShell)</summary>
+
+```powershell
+$TargetHost = "<user>@<host>"
+scp .\aks-flex-node-config.json "${TargetHost}:/tmp/aks-flex-node-config.json"
+```
+
+</details>
 
 On the target host:
 

--- a/hack/e2e/config-helper-parity.sh
+++ b/hack/e2e/config-helper-parity.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+mkdir -p "${WORK_DIR}/bin"
+cat > "${WORK_DIR}/bin/az" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+query=""
+for ((index = 1; index <= $#; index++)); do
+  if [[ "${!index}" == "--query" ]]; then
+    next=$((index + 1))
+    query="${!next}"
+    break
+  fi
+done
+
+case "$1 $2|${query}" in
+  "account show|id") printf '%s\n' "00000000-0000-0000-0000-000000000001" ;;
+  "account show|tenantId") printf '%s\n' "00000000-0000-0000-0000-000000000002" ;;
+  "aks show|id") printf '%s\n' "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/parity-rg/providers/Microsoft.ContainerService/managedClusters/parity-cluster" ;;
+  "aks show|location") printf '%s\n' "westus2" ;;
+  "aks show|currentKubernetesVersion || kubernetesVersion") printf '%s\n' "1.35.0" ;;
+  "aks show|networkProfile.dnsServiceIp") printf '%s\n' "10.0.0.10" ;;
+  *)
+    printf 'unexpected az invocation: %q ' "$@" >&2
+    printf '\n' >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${WORK_DIR}/bin/az"
+
+cat > "${WORK_DIR}/expected.json" <<'EOF'
+{
+  "azure": {
+    "subscriptionId": "00000000-0000-0000-0000-000000000001",
+    "tenantId": "00000000-0000-0000-0000-000000000002",
+    "resourceManagerEndpoint": "https://management.azure.com",
+    "targetAgentPoolName": "paritypool",
+    "targetCluster": {
+      "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/parity-rg/providers/Microsoft.ContainerService/managedClusters/parity-cluster",
+      "location": "westus2"
+    },
+    "managedIdentity": {
+      "clientId": "00000000-0000-0000-0000-000000000003"
+    },
+    "arc": {
+      "enabled": false
+    }
+  },
+  "agent": {
+    "logLevel": "info",
+    "logDir": "/var/log/aks-flex-node"
+  },
+  "components": {
+    "kubernetes": "1.35.0"
+  }
+}
+EOF
+
+go build -o "${WORK_DIR}/aks-flex-config" "${REPO_ROOT}/cmd/aks-flex-config"
+
+common_args=(
+  generate-node-config
+  --resource-group parity-rg
+  --cluster-name parity-cluster
+  --subscription 00000000-0000-0000-0000-000000000001
+  --agent-pool-name paritypool
+  --identity
+  --username 00000000-0000-0000-0000-000000000003
+)
+
+PATH="${WORK_DIR}/bin:${PATH}" python3 "${REPO_ROOT}/scripts/aks-flex-config" \
+  "${common_args[@]}" --output "${WORK_DIR}/python.json"
+PATH="${WORK_DIR}/bin:${PATH}" "${WORK_DIR}/aks-flex-config" \
+  "${common_args[@]}" --output "${WORK_DIR}/binary.json"
+
+for name in expected python binary; do
+  jq --sort-keys --compact-output . "${WORK_DIR}/${name}.json" > "${WORK_DIR}/${name}.canonical.json"
+done
+
+diff -u "${WORK_DIR}/expected.canonical.json" "${WORK_DIR}/python.canonical.json"
+diff -u "${WORK_DIR}/expected.canonical.json" "${WORK_DIR}/binary.canonical.json"
+diff -u "${WORK_DIR}/python.canonical.json" "${WORK_DIR}/binary.canonical.json"
+
+echo "aks-flex-config Python and native binary outputs match the expected config"

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,0 +1,445 @@
+package config
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultAgentPoolName    = "aksflexnodes"
+	resourceManagerEndpoint = "https://management.azure.com"
+)
+
+type commandRunner interface {
+	LookPath(name string) error
+	Run(ctx context.Context, name string, args []string, input string) (string, error)
+}
+
+type execRunner struct {
+	stderr io.Writer
+}
+
+func (runner execRunner) LookPath(name string) error {
+	_, err := exec.LookPath(name)
+	return err
+}
+
+func (runner execRunner) Run(ctx context.Context, name string, args []string, input string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- executable names are fixed to az and kubectl
+	if input != "" {
+		cmd.Stdin = strings.NewReader(input)
+	}
+	cmd.Stderr = runner.stderr
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+type dependencies struct {
+	runner commandRunner
+	now    func() time.Time
+	random io.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+type clusterOptions struct {
+	resourceGroup string
+	clusterName   string
+	subscription  string
+}
+
+type generateOptions struct {
+	clusterOptions
+	agentPoolName    string
+	bootstrapToken   bool
+	identity         bool
+	servicePrincipal bool
+	username         string
+	password         string
+	tenant           string
+	arc              bool
+	output           string
+}
+
+func NewCommand() *cobra.Command {
+	deps := dependencies{
+		now:    time.Now,
+		random: rand.Reader,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+	deps.runner = execRunner{stderr: deps.stderr}
+	return newCommand(deps)
+}
+
+func newCommand(deps dependencies) *cobra.Command {
+	root := &cobra.Command{
+		Use:           "aks-flex-config",
+		Short:         "Prepare AKS Flex Node configuration",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	root.SetOut(deps.stdout)
+	root.SetErr(deps.stderr)
+
+	rbacOptions := clusterOptions{}
+	rbac := &cobra.Command{
+		Use:   "setup-node-rbac",
+		Short: "Apply node bootstrap RBAC bindings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return setupNodeRBAC(cmd.Context(), deps, rbacOptions)
+		},
+	}
+	addClusterFlags(rbac, &rbacOptions)
+
+	generateOptions := generateOptions{agentPoolName: defaultAgentPoolName, output: "-"}
+	generate := &cobra.Command{
+		Use:   "generate-node-config",
+		Short: "Render a Flex Node config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return generateNodeConfig(cmd.Context(), deps, generateOptions)
+		},
+	}
+	addClusterFlags(generate, &generateOptions.clusterOptions)
+	generate.Flags().StringVar(&generateOptions.agentPoolName, "agent-pool-name", defaultAgentPoolName, "AKS agent pool name")
+	generate.Flags().BoolVar(&generateOptions.bootstrapToken, "bootstrap-token", false, "Use Kubernetes bootstrap token authentication")
+	generate.Flags().BoolVar(&generateOptions.identity, "identity", false, "Use managed identity authentication")
+	generate.Flags().BoolVar(&generateOptions.servicePrincipal, "service-principal", false, "Use service principal authentication")
+	generate.Flags().StringVar(&generateOptions.username, "username", "", "Managed identity client ID or service principal client ID")
+	generate.Flags().StringVar(&generateOptions.password, "password", "", "Service principal client secret")
+	generate.Flags().StringVar(&generateOptions.tenant, "tenant", "", "Service principal tenant ID")
+	generate.Flags().BoolVar(&generateOptions.arc, "arc", false, "Use Azure Arc authentication")
+	generate.Flags().StringVar(&generateOptions.output, "output", "-", "Output path, or - for stdout")
+
+	root.AddCommand(rbac, generate)
+	return root
+}
+
+func addClusterFlags(cmd *cobra.Command, options *clusterOptions) {
+	cmd.Flags().StringVar(&options.resourceGroup, "resource-group", "", "Resource group containing the AKS cluster")
+	cmd.Flags().StringVar(&options.clusterName, "cluster-name", "", "AKS cluster name")
+	cmd.Flags().StringVar(&options.subscription, "subscription", "", "Azure subscription ID or name")
+	_ = cmd.MarkFlagRequired("resource-group")
+	_ = cmd.MarkFlagRequired("cluster-name")
+}
+
+func setupNodeRBAC(ctx context.Context, deps dependencies, options clusterOptions) error {
+	if err := requireCommands(deps.runner, "az", "kubectl"); err != nil {
+		return err
+	}
+	if err := loadAdminKubeconfig(ctx, deps, options); err != nil {
+		return err
+	}
+	fmt.Fprintln(deps.stderr, "INFO: applying bootstrap token RBAC bindings")
+	if _, err := deps.runner.Run(ctx, "kubectl", []string{"apply", "-f", "-"}, rbacManifest); err != nil {
+		return fmt.Errorf("apply bootstrap token RBAC: %w", err)
+	}
+	return nil
+}
+
+func generateNodeConfig(ctx context.Context, deps dependencies, options generateOptions) error {
+	mode, err := selectedAuthMode(options)
+	if err != nil {
+		return err
+	}
+	commands := []string{"az"}
+	if mode == "bootstrap-token" {
+		commands = append(commands, "kubectl")
+	}
+	if err := requireCommands(deps.runner, commands...); err != nil {
+		return err
+	}
+
+	metadata, err := getClusterMetadata(ctx, deps, options.clusterOptions)
+	if err != nil {
+		return err
+	}
+	poolName := strings.TrimSpace(options.agentPoolName)
+	if poolName == "" {
+		poolName = defaultAgentPoolName
+	}
+	metadata["agent_pool_name"] = poolName
+
+	config, err := renderConfig(ctx, deps, options, mode, metadata)
+	if err != nil {
+		return err
+	}
+	return writeConfig(deps, config, options.output)
+}
+
+func selectedAuthMode(options generateOptions) (string, error) {
+	modes := []struct {
+		name     string
+		selected bool
+	}{
+		{name: "bootstrap-token", selected: options.bootstrapToken},
+		{name: "identity", selected: options.identity},
+		{name: "service-principal", selected: options.servicePrincipal || options.password != ""},
+		{name: "arc", selected: options.arc},
+	}
+	selected := ""
+	for _, mode := range modes {
+		if !mode.selected {
+			continue
+		}
+		if selected != "" {
+			return "", errors.New("choose exactly one auth mode: --bootstrap-token, --identity, --service-principal, or --arc")
+		}
+		selected = mode.name
+	}
+	if selected == "" {
+		return "", errors.New("choose exactly one auth mode: --bootstrap-token, --identity, --service-principal, or --arc")
+	}
+	if selected == "service-principal" && (options.username == "" || options.password == "") {
+		return "", errors.New("service principal auth requires --username <client-id> and --password <client-secret>")
+	}
+	if selected == "arc" {
+		return "", errors.New("arc bootstrap data must be fetched on the connected host; use scripts/bootstrap.sh --auth arc --fetch-bootstrap-data")
+	}
+	return selected, nil
+}
+
+func requireCommands(runner commandRunner, names ...string) error {
+	for _, name := range names {
+		if err := runner.LookPath(name); err != nil {
+			return fmt.Errorf("missing required command: %s", name)
+		}
+	}
+	return nil
+}
+
+func loadAdminKubeconfig(ctx context.Context, deps dependencies, options clusterOptions) error {
+	fmt.Fprintln(deps.stderr, "INFO: loading AKS admin kubeconfig")
+	args := append([]string{"aks", "get-credentials"}, aksArgs(options)...)
+	args = append(args, "--admin", "--overwrite-existing")
+	if _, err := deps.runner.Run(ctx, "az", args, ""); err != nil {
+		return fmt.Errorf("load AKS admin kubeconfig: %w", err)
+	}
+	return nil
+}
+
+func aksArgs(options clusterOptions) []string {
+	args := []string{"--resource-group", options.resourceGroup, "--name", options.clusterName}
+	if options.subscription != "" {
+		args = append(args, "--subscription", options.subscription)
+	}
+	return args
+}
+
+func accountArgs(subscription string) []string {
+	if subscription == "" {
+		return nil
+	}
+	return []string{"--subscription", subscription}
+}
+
+func getClusterMetadata(ctx context.Context, deps dependencies, options clusterOptions) (map[string]string, error) {
+	fmt.Fprintln(deps.stderr, "INFO: fetching AKS cluster metadata")
+	queries := []struct {
+		key  string
+		args []string
+	}{
+		{key: "subscription_id", args: append([]string{"account", "show"}, accountArgs(options.subscription)...)},
+		{key: "tenant_id", args: append([]string{"account", "show"}, accountArgs(options.subscription)...)},
+		{key: "resource_id", args: append([]string{"aks", "show"}, aksArgs(options)...)},
+		{key: "location", args: append([]string{"aks", "show"}, aksArgs(options)...)},
+		{key: "kubernetes_version", args: append([]string{"aks", "show"}, aksArgs(options)...)},
+		{key: "dns_service_ip", args: append([]string{"aks", "show"}, aksArgs(options)...)},
+	}
+	queryValues := []string{"id", "tenantId", "id", "location", "currentKubernetesVersion || kubernetesVersion", "networkProfile.dnsServiceIp"}
+	metadata := make(map[string]string, len(queries))
+	for index, query := range queries {
+		args := append(query.args, "--query", queryValues[index], "-o", "tsv")
+		value, err := deps.runner.Run(ctx, "az", args, "")
+		if err != nil {
+			return nil, fmt.Errorf("fetch AKS %s: %w", query.key, err)
+		}
+		metadata[query.key] = value
+	}
+	return metadata, nil
+}
+
+func renderConfig(ctx context.Context, deps dependencies, options generateOptions, mode string, metadata map[string]string) (map[string]any, error) {
+	azure := map[string]any{
+		"subscriptionId":          metadata["subscription_id"],
+		"tenantId":                metadata["tenant_id"],
+		"resourceManagerEndpoint": resourceManagerEndpoint,
+		"targetAgentPoolName":     metadata["agent_pool_name"],
+		"targetCluster": map[string]any{
+			"resourceId": metadata["resource_id"],
+			"location":   metadata["location"],
+		},
+	}
+	config := map[string]any{
+		"azure":      azure,
+		"agent":      map[string]any{"logLevel": "info", "logDir": "/var/log/aks-flex-node"},
+		"components": map[string]any{"kubernetes": metadata["kubernetes_version"]},
+	}
+
+	switch mode {
+	case "bootstrap-token":
+		if err := loadAdminKubeconfig(ctx, deps, options.clusterOptions); err != nil {
+			return nil, err
+		}
+		token, err := generateBootstrapToken(ctx, deps)
+		if err != nil {
+			return nil, err
+		}
+		serverURL, err := deps.runner.Run(ctx, "kubectl", []string{"config", "view", "--minify", "-o", "jsonpath={.clusters[0].cluster.server}"}, "")
+		if err != nil {
+			return nil, fmt.Errorf("read Kubernetes API server: %w", err)
+		}
+		caCertData, err := deps.runner.Run(ctx, "kubectl", []string{"config", "view", "--minify", "--raw", "-o", "jsonpath={.clusters[0].cluster.certificate-authority-data}"}, "")
+		if err != nil {
+			return nil, fmt.Errorf("read Kubernetes CA data: %w", err)
+		}
+		azure["bootstrapToken"] = map[string]any{"token": token}
+		azure["arc"] = map[string]any{"enabled": false}
+		config["node"] = map[string]any{"kubelet": map[string]any{"clusterFQDN": clusterFQDN(serverURL), "caCertData": caCertData}}
+		if metadata["dns_service_ip"] != "" {
+			config["networking"] = map[string]any{"dnsServiceIP": metadata["dns_service_ip"]}
+		}
+	case "identity":
+		identity := map[string]any{}
+		if options.username != "" {
+			identity["clientId"] = options.username
+		}
+		azure["managedIdentity"] = identity
+		azure["arc"] = map[string]any{"enabled": false}
+	case "service-principal":
+		tenantID := options.tenant
+		if tenantID == "" {
+			tenantID = metadata["tenant_id"]
+		}
+		azure["servicePrincipal"] = map[string]any{"tenantId": tenantID, "clientId": options.username, "clientSecret": options.password}
+		azure["arc"] = map[string]any{"enabled": false}
+	default:
+		return nil, fmt.Errorf("unsupported auth mode: %s", mode)
+	}
+	return config, nil
+}
+
+func generateBootstrapToken(ctx context.Context, deps dependencies) (string, error) {
+	tokenID := make([]byte, 3)
+	tokenSecret := make([]byte, 8)
+	if _, err := io.ReadFull(deps.random, tokenID); err != nil {
+		return "", fmt.Errorf("generate bootstrap token ID: %w", err)
+	}
+	if _, err := io.ReadFull(deps.random, tokenSecret); err != nil {
+		return "", fmt.Errorf("generate bootstrap token secret: %w", err)
+	}
+	id := hex.EncodeToString(tokenID)
+	secret := hex.EncodeToString(tokenSecret)
+	expiration := deps.now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: bootstrap-token-%s
+  namespace: kube-system
+type: bootstrap.kubernetes.io/token
+stringData:
+  description: "AKS Flex Node bootstrap token"
+  token-id: "%s"
+  token-secret: "%s"
+  expiration: "%s"
+  usage-bootstrap-authentication: "true"
+  usage-bootstrap-signing: "true"
+  auth-extra-groups: "system:bootstrappers:aks-flex-node"
+`, id, id, secret, expiration)
+	fmt.Fprintln(deps.stderr, "INFO: creating bootstrap token")
+	if _, err := deps.runner.Run(ctx, "kubectl", []string{"apply", "-f", "-"}, manifest); err != nil {
+		return "", fmt.Errorf("create bootstrap token: %w", err)
+	}
+	return id + "." + secret, nil
+}
+
+func clusterFQDN(serverURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(serverURL))
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return parsed.Host
+	}
+	return strings.TrimSpace(serverURL)
+}
+
+func writeConfig(deps dependencies, config map[string]any, output string) error {
+	rendered, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("render config: %w", err)
+	}
+	rendered = append(rendered, '\n')
+	if output == "-" {
+		if _, err := deps.stdout.Write(rendered); err != nil {
+			return fmt.Errorf("write config: %w", err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0o700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	if err := os.WriteFile(output, rendered, 0o600); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := os.Chmod(output, 0o600); err != nil {
+		return fmt.Errorf("set config permissions: %w", err)
+	}
+	fmt.Fprintf(deps.stderr, "INFO: wrote %s\n", output)
+	return nil
+}
+
+const rbacManifest = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-bootstrapper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-bootstrapper
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-auto-approve-csr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:nodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aks-flex-node-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers:aks-flex-node
+`

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -1,0 +1,249 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type runnerCall struct {
+	name  string
+	args  []string
+	input string
+}
+
+type fakeRunner struct {
+	responses []string
+	calls     []runnerCall
+	missing   map[string]bool
+}
+
+func (runner *fakeRunner) LookPath(name string) error {
+	if runner.missing[name] {
+		return errors.New("not found")
+	}
+	return nil
+}
+
+func (runner *fakeRunner) Run(_ context.Context, name string, args []string, input string) (string, error) {
+	runner.calls = append(runner.calls, runnerCall{name: name, args: append([]string(nil), args...), input: input})
+	if len(runner.responses) == 0 {
+		return "", nil
+	}
+	response := runner.responses[0]
+	runner.responses = runner.responses[1:]
+	return response, nil
+}
+
+func TestRootCommandRegistersCommands(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCommand(testDependencies(&fakeRunner{}))
+	for _, name := range []string{"setup-node-rbac", "generate-node-config"} {
+		found, _, err := cmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("Find(%q) error = %v", name, err)
+		}
+		if found.Name() != name {
+			t.Fatalf("Find(%q) command = %q", name, found.Name())
+		}
+	}
+}
+
+func TestSelectedAuthModeValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options generateOptions
+		want    string
+		wantErr string
+	}{
+		{name: "bootstrap token", options: generateOptions{bootstrapToken: true}, want: "bootstrap-token"},
+		{name: "identity", options: generateOptions{identity: true}, want: "identity"},
+		{name: "service principal", options: generateOptions{servicePrincipal: true, username: "client", password: "secret"}, want: "service-principal"},
+		{name: "password implies service principal", options: generateOptions{username: "client", password: "secret"}, want: "service-principal"},
+		{name: "none", options: generateOptions{}, wantErr: "choose exactly one"},
+		{name: "multiple", options: generateOptions{bootstrapToken: true, identity: true}, wantErr: "choose exactly one"},
+		{name: "missing client", options: generateOptions{servicePrincipal: true, password: "secret"}, wantErr: "requires --username"},
+		{name: "arc", options: generateOptions{arc: true}, wantErr: "must be fetched on the connected host"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := selectedAuthMode(test.options)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("selectedAuthMode() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("selectedAuthMode() error = %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("selectedAuthMode() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGenerateBootstrapTokenConfig(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRunner{responses: []string{
+		"sub-id", "tenant-id", "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		"westus", "1.34.3", "10.0.0.10", "", "", "https://cluster.example:443", "Y2E=",
+	}}
+	deps := testDependencies(runner)
+	var stdout bytes.Buffer
+	deps.stdout = &stdout
+	options := generateOptions{
+		clusterOptions: clusterOptions{resourceGroup: "rg", clusterName: "cluster", subscription: "sub-id"},
+		agentPoolName:  defaultAgentPoolName,
+		bootstrapToken: true,
+		output:         "-",
+	}
+
+	if err := generateNodeConfig(context.Background(), deps, options); err != nil {
+		t.Fatalf("generateNodeConfig() error = %v", err)
+	}
+
+	var config map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &config); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	azure := config["azure"].(map[string]any)
+	if got := azure["targetAgentPoolName"]; got != defaultAgentPoolName {
+		t.Fatalf("targetAgentPoolName = %v, want %q", got, defaultAgentPoolName)
+	}
+	bootstrap := azure["bootstrapToken"].(map[string]any)
+	if got := bootstrap["token"]; got != "000102.030405060708090a" {
+		t.Fatalf("bootstrap token = %v", got)
+	}
+	node := config["node"].(map[string]any)
+	kubelet := node["kubelet"].(map[string]any)
+	if got := kubelet["clusterFQDN"]; got != "cluster.example:443" {
+		t.Fatalf("clusterFQDN = %v", got)
+	}
+
+	var tokenManifest string
+	for _, call := range runner.calls {
+		if call.name == "kubectl" && len(call.args) > 0 && call.args[0] == "apply" && strings.Contains(call.input, "kind: Secret") {
+			tokenManifest = call.input
+		}
+	}
+	for _, value := range []string{"bootstrap-token-000102", `token-secret: "030405060708090a"`, `expiration: "2026-08-21T12:00:00Z"`} {
+		if !strings.Contains(tokenManifest, value) {
+			t.Errorf("token manifest missing %q:\n%s", value, tokenManifest)
+		}
+	}
+}
+
+func TestSetupNodeRBACAppliesManifest(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRunner{}
+	deps := testDependencies(runner)
+	options := clusterOptions{resourceGroup: "rg", clusterName: "cluster", subscription: "sub"}
+	if err := setupNodeRBAC(context.Background(), deps, options); err != nil {
+		t.Fatalf("setupNodeRBAC() error = %v", err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("calls = %d, want 2", len(runner.calls))
+	}
+	if !strings.Contains(runner.calls[1].input, "aks-flex-node-auto-approve-csr") {
+		t.Fatalf("RBAC manifest was not passed to kubectl")
+	}
+}
+
+func TestRenderConfigAuthModes(t *testing.T) {
+	t.Parallel()
+
+	metadata := map[string]string{
+		"subscription_id":    "sub-id",
+		"tenant_id":          "tenant-id",
+		"resource_id":        "cluster-id",
+		"location":           "westus",
+		"kubernetes_version": "1.34.3",
+		"agent_pool_name":    "pool",
+	}
+	tests := []struct {
+		name       string
+		mode       string
+		options    generateOptions
+		azureKey   string
+		wantValues map[string]any
+	}{
+		{name: "system assigned identity", mode: "identity", options: generateOptions{}, azureKey: "managedIdentity", wantValues: map[string]any{}},
+		{name: "user assigned identity", mode: "identity", options: generateOptions{username: "identity-client"}, azureKey: "managedIdentity", wantValues: map[string]any{"clientId": "identity-client"}},
+		{name: "service principal defaults tenant", mode: "service-principal", options: generateOptions{username: "client", password: "secret"}, azureKey: "servicePrincipal", wantValues: map[string]any{"tenantId": "tenant-id", "clientId": "client", "clientSecret": "secret"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			config, err := renderConfig(context.Background(), testDependencies(&fakeRunner{}), test.options, test.mode, metadata)
+			if err != nil {
+				t.Fatalf("renderConfig() error = %v", err)
+			}
+			azure := config["azure"].(map[string]any)
+			got := azure[test.azureKey].(map[string]any)
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(test.wantValues)
+			if !bytes.Equal(gotJSON, wantJSON) {
+				t.Fatalf("%s = %s, want %s", test.azureKey, gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestWriteConfigFile(t *testing.T) {
+	t.Parallel()
+
+	output := filepath.Join(t.TempDir(), "nested", "config.json")
+	if err := writeConfig(testDependencies(&fakeRunner{}), map[string]any{"value": "test"}, output); err != nil {
+		t.Fatalf("writeConfig() error = %v", err)
+	}
+	rendered, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	if got, want := string(rendered), "{\n  \"value\": \"test\"\n}\n"; got != want {
+		t.Fatalf("config = %q, want %q", got, want)
+	}
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config permissions = %o, want 600", got)
+	}
+}
+
+func TestMissingRequiredCommand(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRunner{missing: map[string]bool{"kubectl": true}}
+	err := setupNodeRBAC(context.Background(), testDependencies(runner), clusterOptions{})
+	if err == nil || err.Error() != "missing required command: kubectl" {
+		t.Fatalf("setupNodeRBAC() error = %v", err)
+	}
+}
+
+func testDependencies(runner commandRunner) dependencies {
+	return dependencies{
+		runner: runner,
+		now: func() time.Time {
+			return time.Date(2026, time.August, 20, 12, 0, 0, 0, time.UTC)
+		},
+		random: bytes.NewReader([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+		stdout: &bytes.Buffer{},
+		stderr: &bytes.Buffer{},
+	}
+}


### PR DESCRIPTION
This PR adds a native, cross-platform aks-flex-config CLI and documents a Windows/PowerShell onboarding path for AKS Flex Node.

<img width="1136" height="452" alt="image" src="https://github.com/user-attachments/assets/beed4f4d-5293-43aa-bfa8-16c91ed07d19" />


The existing Python helper remains available for compatibility with current labs and automation.

## Changes

- Added a native Go implementation of aks-flex-config.
- Kept the binary entry point small under aks-flex-config.
- Moved Cobra command construction and implementation into config.
- Preserved the existing helper interface:
  - `setup-node-rbac`
  - `generate-node-config`
  - Bootstrap token, managed identity, service principal, and Arc options
  - Existing configuration fields and defaults
- Added unit tests covering
- 
## Release artifacts

Integrated the config helper into the existing release build matrix and added these raw release assets:

- `aks-flex-config-windows-amd64.exe`
- `aks-flex-config-darwin-amd64`
- `aks-flex-config-darwin-arm64`
The Linux `aks-flex-node` agent continues to be released as amd64 and arm64 tarballs. All artifacts are included in release checksums.

## Documentation

Updated the quickstart and config-helper guide with collapsible platform-specific instructions:

- Windows PowerShell variable setup, download, config generation, SCP, SSH, verification, and cleanup
- Native macOS download instructions for Intel and Apple Silicon
- Clear separation between the operator workstation and the Linux Flex Node host
- Windows ACL guidance for generated configuration files

## E2E coverage

Added a deterministic parity test that:

- Builds the native helper on the E2E runner
- Runs both the Python helper and native binary
- Supplies identical mocked Azure CLI metadata
- Compares both outputs with an explicit expected configuration
- Canonicalizes JSON before comparison

The parity check runs before Azure login and does not mutate cloud or Kubernetes resources.