### PR TITLE
[2/3] Harden E2E state, cleanup, and Arc diagnostics

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,11 @@ name: E2E Tests
 on:
   workflow_dispatch:
     inputs:
+      kubernetes_version:
+        description: "Exact AKS/Flex Node Kubernetes patch version (for example, 1.34.9)"
+        required: false
+        default: "1.35.0"
+        type: string
       skip_cleanup:
         description: "Skip cleanup (keep resources for debugging)"
         required: false
@@ -56,7 +61,9 @@ env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   GITHUB_RUN_ID: ${{ github.run_id }}
-  E2E_WORK_DIR: /tmp/aks-flex-node-e2e-${{ github.run_id }}
+  E2E_NAME_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}
+  E2E_WORK_DIR: /tmp/aks-flex-node-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+  E2E_KUBERNETES_VERSION: ${{ inputs.kubernetes_version || '1.35.0' }}
 
 jobs:
   e2e:
@@ -105,16 +112,59 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: e2e-logs-${{ github.run_id }}
-          path: /tmp/aks-flex-node-e2e-${{ github.run_id }}/logs/
+          name: e2e-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/aks-flex-node-e2e-${{ github.run_id }}-${{ github.run_attempt }}/logs/
           retention-days: 7
 
       - name: Cleanup
+        id: cleanup
         if: always()
         env:
           E2E_SKIP_CLEANUP: ${{ inputs.skip_cleanup && '1' || '0' }}
         run: ./hack/e2e/run.sh cleanup
 
-      - name: Cleanup runner workspace
+      - name: Prepare cleanup diagnostics
         if: always()
+        run: |
+          set -euo pipefail
+          umask 077
+          state_file="${E2E_WORK_DIR}/state.json"
+          artifact_file="${E2E_WORK_DIR}/cleanup-state.json"
+          [[ -f "${state_file}" ]] || exit 0
+          # Keep the resource names needed for investigation without publishing
+          # secret-sourced account identifiers, addresses, or cluster access data.
+          jq '{
+            lifecycle,
+            cleanup_complete,
+            deployment_name,
+            run_id,
+            resource_owner,
+            name_suffix,
+            cluster_name,
+            node_resource_group,
+            msi_vm_name,
+            token_vm_name,
+            offline_vm_name,
+            kubeadm_vm_name,
+            arc_vm_name,
+            arc_machine_name,
+            vnet_name,
+            nsg_name
+          } | with_entries(select(.value != null and .value != ""))' \
+            "${state_file}" > "${artifact_file}"
+          chmod 0600 "${artifact_file}"
+
+      - name: Upload cleanup diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-cleanup-state-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/aks-flex-node-e2e-${{ github.run_id }}-${{ github.run_attempt }}/cleanup-state.json
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Cleanup runner workspace
+        # Preserve retry metadata when Azure cleanup fails or is deliberately
+        # skipped. A later successful run must not delete another attempt's state.
+        if: always() && steps.cleanup.outcome == 'success' && inputs.skip_cleanup != true
         run: ./hack/e2e/run.sh runner-cleanup

--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -12,6 +12,7 @@ The E2E suite provisions a no-CNI AKS cluster, installs Unbounded-Net as the clu
 | `python3` | Local registry port readiness checks and helper scripts. |
 | `ssh` / `scp` | VM access and artifact copy. |
 | `openssl` | Bootstrap token generation. |
+| `flock` | Serialize atomic updates to the per-run cleanup state. |
 | `docker` | Build and push the controller image into the in-cluster local registry. |
 | `git` / `make` | Fetch and render Unbounded-Net manifests. |
 | `go` | Build the agent binary unless `--binary` is supplied. |
@@ -107,7 +108,7 @@ Additional environment variables:
 | `E2E_SSH_KEY_FILE` | auto-detected | SSH public key used for VM access. |
 | `E2E_WORK_DIR` | `/tmp/aks-flex-node-e2e` | Working directory for state, configs, and logs. |
 | `E2E_KUBECONFIG` | `$E2E_WORK_DIR/kubeconfig` | Per-run kubeconfig path. Defaults to an isolated file instead of the runner-global kubeconfig. |
-| `E2E_KUBERNETES_VERSION` | `1.35.0` | Kubernetes version used in generated node configs. |
+| `E2E_KUBERNETES_VERSION` | `1.35.0` | Exact Kubernetes version used for the AKS control plane, agent pools, and generated node configs. |
 | `E2E_CONTAINERD_VERSION` | `2.0.4` | Containerd version used in generated node configs. |
 | `E2E_RUNC_VERSION` | `1.1.12` | Runc version used in generated node configs. |
 | `E2E_TARGET_AGENT_POOL_NAME` | `aksflexnodes` | Synthetic target agent pool name used by controller-backed test modes. |
@@ -135,6 +136,8 @@ Additional environment variables:
 | `E2E_POD_READY_TIMEOUT` | `120` | Timeout in seconds while waiting for smoke pods. |
 | `E2E_AGENT_UPGRADE_TIMEOUT` | `300` | Timeout in seconds while waiting for an AgentUpgrade result. |
 | `E2E_DRIFT_UPGRADE_TIMEOUT` | `900` | Timeout in seconds while waiting for repave. |
+| `E2E_CLEANUP_TIMEOUT` | `900` | Shared deadline in seconds for deployment cancellation and Azure resource deletion. |
+| `E2E_CLEANUP_POLL_INTERVAL` | `5` | Poll interval in seconds for deployment and cleanup convergence. |
 | `AZURE_SUBSCRIPTION_ID` | auto-detected | Azure subscription. |
 | `AZURE_TENANT_ID` | auto-detected | Azure tenant. |
 

--- a/hack/e2e/cleanup_safety_test.go
+++ b/hack/e2e/cleanup_safety_test.go
@@ -1,0 +1,376 @@
+package e2e_test
+
+import (
+	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+//go:embed lib/infra.sh
+var infraScript string
+
+func TestCleanupTargetNameValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"test",
+		"e2e-test",
+		"aks-e2e-test",
+		"MC_aksflex-e2e-test",
+		"vm-e2e-msi-test",
+		"vm-e2e-token-test",
+		"vm-e2e-offline-test",
+		"vm-e2e-kubeadm-test",
+		"vm-e2e-arc-test",
+		"vm-e2e-arc-test-connected",
+		"vnet-e2e-test",
+		"nsg-e2e-test",
+		"test-rg",
+		"test-location",
+	}
+
+	tests := []struct {
+		name        string
+		argument    int
+		value       string
+		wantSuccess bool
+		wantError   string
+	}{
+		{name: "matching targets", argument: -1, wantSuccess: true},
+		{name: "legacy default node resource group", argument: 3, value: "MC_test-rg_aks-e2e-test_test-location", wantSuccess: true},
+		{name: "missing optional target", argument: 4, value: "", wantSuccess: true},
+		{name: "missing suffix", argument: 0, value: "", wantError: "without an E2E name suffix"},
+		{name: "deployment", argument: 1, value: "production-deployment", wantError: "unexpected ARM deployment"},
+		{name: "cluster", argument: 2, value: "production-cluster", wantError: "unexpected AKS cluster"},
+		{name: "node resource group", argument: 3, value: "production-node-rg", wantError: "unexpected AKS node resource group"},
+		{name: "MSI VM", argument: 4, value: "production-msi", wantError: "unexpected MSI VM"},
+		{name: "token VM", argument: 5, value: "production-token", wantError: "unexpected token VM"},
+		{name: "offline VM", argument: 6, value: "production-offline", wantError: "unexpected offline VM"},
+		{name: "kubeadm VM", argument: 7, value: "production-kubeadm", wantError: "unexpected kubeadm VM"},
+		{name: "Arc VM", argument: 8, value: "production-arc", wantError: "unexpected Arc VM"},
+		{name: "Arc machine", argument: 9, value: "production-machine", wantError: "unexpected Arc machine"},
+		{name: "virtual network", argument: 10, value: "production-vnet", wantError: "unexpected virtual network"},
+		{name: "network security group", argument: 11, value: "production-nsg", wantError: "unexpected network security group"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			args := append([]string(nil), valid...)
+			if test.argument >= 0 {
+				args[test.argument] = test.value
+			}
+			cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+shift 2
+if _validate_cleanup_target_names "$@"; then
+  printf 'RESULT=success\n'
+else
+  printf 'RESULT=error\n'
+fi
+`
+			output, err := runBash(t, script, append([]string{t.TempDir(), cleanupScript}, args...)...)
+			if err != nil {
+				t.Fatalf("target validation harness failed: %v\n%s", err, output)
+			}
+			if test.wantSuccess {
+				if !strings.Contains(string(output), "RESULT=success") {
+					t.Fatalf("matching cleanup targets were rejected:\n%s", output)
+				}
+				return
+			}
+			if !strings.Contains(string(output), "RESULT=error") ||
+				!strings.Contains(string(output), test.wantError) {
+				t.Fatalf("unsafe cleanup target was not rejected with %q:\n%s", test.wantError, output)
+			}
+		})
+	}
+}
+
+func TestCleanupHandlesLegacyDefaultNodeResourceGroup(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name              string
+		parentGroupAbsent bool
+	}{
+		{name: "live cluster"},
+		{name: "orphan after parent deletion", parentGroupAbsent: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, callLog, output, err := runCleanup(t, cleanupOptions{
+				runTwice:                  true,
+				parentGroupAbsent:         test.parentGroupAbsent,
+				legacyDefaultNodeResource: true,
+			})
+			if err != nil {
+				t.Fatalf("legacy node resource group cleanup failed: %v\n%s", err, output)
+			}
+			if strings.Count(string(output), "RESULT=success") != 2 {
+				t.Fatalf("legacy node resource group cleanup was not idempotent:\n%s", output)
+			}
+			calls, readErr := os.ReadFile(callLog)
+			if readErr != nil {
+				t.Fatalf("read az calls: %v", readErr)
+			}
+			if test.parentGroupAbsent {
+				if !strings.Contains(string(calls), "group delete --name MC_test-rg_aks-e2e-test_test-location") {
+					t.Fatalf("cleanup did not delete the proven orphan node resource group:\n%s", calls)
+				}
+				return
+			}
+			if !strings.Contains(string(calls), "aks wait --resource-group test-rg --name aks-e2e-test") {
+				t.Fatalf("cleanup did not wait for AKS to delete its legacy node resource group:\n%s", calls)
+			}
+			for _, operation := range []string{
+				"group exists --name MC_test-rg_aks-e2e-test_test-location",
+				"group delete --name MC_test-rg_aks-e2e-test_test-location",
+				"group wait --name MC_test-rg_aks-e2e-test_test-location",
+			} {
+				if strings.Contains(string(calls), operation) {
+					t.Fatalf("live-cluster cleanup directly managed its node resource group with %q:\n%s", operation, calls)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupResourceOwnerCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		state       string
+		githubRunID string
+		want        string
+		wantError   string
+	}{
+		{
+			name:        "new state uses attempt-scoped owner",
+			state:       `{"resource_owner":"12345-2","run_id":"12345","name_suffix":"12345-2"}`,
+			githubRunID: "12345",
+			want:        "12345-2",
+		},
+		{
+			name:        "legacy state falls back to run ID",
+			state:       `{"run_id":"12345"}`,
+			githubRunID: "different-run",
+			want:        "12345",
+		},
+		{
+			name:        "partial legacy state falls back to environment",
+			state:       `{}`,
+			githubRunID: "12345",
+			want:        "12345",
+		},
+		{
+			name:        "new state rejects another attempts owner",
+			state:       `{"resource_owner":"12345-1","run_id":"12345","name_suffix":"12345-2"}`,
+			githubRunID: "12345",
+			wantError:   "does not match E2E name suffix",
+		},
+		{
+			name:        "new partial state rejects unverifiable owner",
+			state:       `{"resource_owner":"12345-2","run_id":"12345"}`,
+			githubRunID: "12345",
+			wantError:   "does not match E2E name suffix",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			workDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(workDir, "state.json"), []byte(test.state), 0o600); err != nil {
+				t.Fatalf("write state: %v", err)
+			}
+			cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+GITHUB_RUN_ID="$2"
+source "$3"
+if owner="$(_cleanup_resource_owner)"; then
+  printf 'OWNER=%s\n' "${owner}"
+else
+  printf 'OWNER=error\n'
+fi
+`
+			output, err := runBash(t, script, workDir, test.githubRunID, cleanupScript)
+			if err != nil {
+				t.Fatalf("resolve cleanup owner: %v\n%s", err, output)
+			}
+			if test.wantError != "" {
+				if !strings.Contains(string(output), "OWNER=error\n") ||
+					!strings.Contains(string(output), test.wantError) {
+					t.Fatalf("unsafe cleanup owner was not rejected with %q: %q", test.wantError, output)
+				}
+				return
+			}
+			if !strings.Contains(string(output), "OWNER="+test.want+"\n") {
+				t.Fatalf("cleanup owner = %q, want %q", output, test.want)
+			}
+		})
+	}
+}
+
+func TestInfrastructureUsesAttemptScopedOwnershipTag(t *testing.T) {
+	t.Parallel()
+
+	for _, required := range []string{
+		`local resource_owner="${E2E_NAME_SUFFIX}"`,
+		`--arg resource_owner "${resource_owner}"`,
+		`run_id: $run_id, resource_owner: $resource_owner`,
+		`--arg run "${resource_owner}"`,
+		`'{"github-run": $run, "purpose": $purpose}'`,
+	} {
+		if !strings.Contains(infraScript, required) {
+			t.Errorf("infrastructure ownership metadata is missing %q", required)
+		}
+	}
+}
+
+func TestLegacyRunTagCleanupIsScopedToNameSuffix(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	inventoryPath := filepath.Join(workDir, "inventory.json")
+	inventory := `[
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-1_OsDisk_1_abcd","id":"/own-disk"},
+  {"type":"Microsoft.Network/networkInterfaces","name":"vm-e2e-msi-12345-1-nic","id":"/own-nic"},
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-2_OsDisk_1_efgh","id":"/other-attempt-disk"},
+  {"type":"Microsoft.Network/virtualNetworks","name":"vnet-e2e-12345-2","id":"/other-attempt-vnet"},
+  {"type":"Microsoft.Compute/disks","name":"production-disk","id":"/unrelated"}
+]`
+	if err := os.WriteFile(inventoryPath, []byte(inventory), 0o600); err != nil {
+		t.Fatalf("write resource inventory: %v", err)
+	}
+
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+INVENTORY_FILE="$2"
+source "$3"
+_resource_inventory() { cat "${INVENTORY_FILE}"; }
+az() { printf 'AZ=%s\n' "$*"; }
+printf '%s\n' 'IDS-BEGIN'
+_tagged_resource_ids test-rg 12345 test-subscription 12345-1 0
+printf '%s\n' 'IDS-END'
+_delete_tagged_resources test-rg 12345 test-subscription 12345-1 0
+`
+	output, err := runBash(t, script, workDir, inventoryPath, cleanupScript)
+	if err != nil {
+		t.Fatalf("legacy tagged cleanup failed: %v\n%s", err, output)
+	}
+	text := string(output)
+	for _, ownID := range []string{"/own-disk", "/own-nic"} {
+		if !strings.Contains(text, ownID) {
+			t.Errorf("legacy tagged cleanup omitted owned resource %q:\n%s", ownID, text)
+		}
+	}
+	for _, foreignID := range []string{"/other-attempt-disk", "/other-attempt-vnet", "/unrelated"} {
+		if strings.Contains(text, foreignID) {
+			t.Errorf("legacy tagged cleanup selected foreign resource %q:\n%s", foreignID, text)
+		}
+	}
+}
+
+func TestLegacyImplicitOSDiskCleanupIsScopedToValidatedVMNames(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	inventoryPath := filepath.Join(workDir, "inventory.json")
+	inventory := `[
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-1_OsDisk_1_abcd","id":"/own-legacy-disk"},
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-2_OsDisk_1_efgh","id":"/other-attempt-disk"},
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-1-extra_OsDisk_1_ijkl","id":"/prefix-collision-disk"},
+  {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-12345-1-osdisk","id":"/deterministic-disk"},
+  {"type":"Microsoft.Network/networkInterfaces","name":"vm-e2e-token-12345-1_OsDisk_1_abcd","id":"/wrong-resource-type"},
+  {"type":"Microsoft.Compute/disks","name":"production-disk","id":"/unrelated-disk"}
+]`
+	if err := os.WriteFile(inventoryPath, []byte(inventory), 0o600); err != nil {
+		t.Fatalf("write resource inventory: %v", err)
+	}
+
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+INVENTORY_FILE="$2"
+source "$3"
+_resource_inventory() { cat "${INVENTORY_FILE}"; }
+az() { printf 'AZ=%s\n' "$*"; }
+printf '%s\n' 'IDS-BEGIN'
+_legacy_implicit_os_disk_ids test-rg test-subscription 0 \
+  vm-e2e-msi-12345-1 vm-e2e-token-12345-1
+printf '%s\n' 'IDS-END'
+_delete_legacy_implicit_os_disks test-rg test-subscription 0 \
+  vm-e2e-msi-12345-1 vm-e2e-token-12345-1
+`
+	output, err := runBash(t, script, workDir, inventoryPath, cleanupScript)
+	if err != nil {
+		t.Fatalf("legacy implicit OS-disk cleanup failed: %v\n%s", err, output)
+	}
+	text := string(output)
+	if !strings.Contains(text, "/own-legacy-disk") ||
+		!strings.Contains(text, "resource delete --ids /own-legacy-disk") {
+		t.Fatalf("legacy implicit OS disk was not selected and deleted:\n%s", text)
+	}
+	for _, foreignID := range []string{
+		"/other-attempt-disk",
+		"/prefix-collision-disk",
+		"/deterministic-disk",
+		"/wrong-resource-type",
+		"/unrelated-disk",
+	} {
+		if strings.Contains(text, foreignID) {
+			t.Errorf("legacy implicit OS-disk cleanup selected foreign resource %q:\n%s", foreignID, text)
+		}
+	}
+}
+
+func TestCleanupValidatesNamesBeforeAzureMutation(t *testing.T) {
+	t.Parallel()
+
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	contents, err := os.ReadFile(cleanupScript)
+	if err != nil {
+		t.Fatalf("read cleanup script: %v", err)
+	}
+	body := string(contents)
+	cleanupStart := strings.Index(body, "cleanup() {")
+	if cleanupStart < 0 {
+		t.Fatal("cleanup function is absent")
+	}
+	body = body[cleanupStart:]
+	validation := strings.Index(body, "if ! _validate_cleanup_target_names")
+	if validation < 0 {
+		t.Fatal("cleanup does not validate deterministic target names")
+	}
+	for _, mutation := range []string{
+		`_delete_node_resource_group "${node_resource_group}"`,
+		`az rest --method delete`,
+		`az vm delete`,
+		`az aks delete`,
+		`az network vnet delete`,
+		`_delete_tagged_resources`,
+	} {
+		mutationIndex := strings.Index(body, mutation)
+		if mutationIndex < 0 {
+			t.Fatalf("cleanup mutation %q is absent", mutation)
+		}
+		if validation >= mutationIndex {
+			t.Errorf("cleanup validates names after mutation %q", mutation)
+		}
+	}
+}

--- a/hack/e2e/e2e_scripts_test.go
+++ b/hack/e2e/e2e_scripts_test.go
@@ -1,0 +1,1589 @@
+package e2e_test
+
+import (
+	"context"
+	"embed"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Embedding the scripts makes Go's test cache invalidate on shell-only changes.
+//
+//go:embed run.sh lib/common.sh lib/cleanup.sh lib/runner.sh infra/*.bicep infra/modules/*.bicep
+var e2eScripts embed.FS
+
+func TestRunnerCleanupIsScopedToCurrentAttempt(t *testing.T) {
+	t.Parallel()
+
+	script, err := e2eScripts.ReadFile("lib/runner.sh")
+	if err != nil {
+		t.Fatalf("read embedded runner script: %v", err)
+	}
+	text := string(script)
+	for _, required := range []string{
+		`local work_dir="${E2E_WORK_DIR:-}"`,
+		`^/tmp/aks-flex-node-e2e(-[A-Za-z0-9][A-Za-z0-9._-]*)?$`,
+		`rm -rf -- "${work_dir}"`,
+		`Refusing to clean unexpected E2E work directory`,
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("runner cleanup is missing attempt-scoped guard %q", required)
+		}
+	}
+	if strings.Contains(text, `find /tmp`) || strings.Contains(text, `-name 'aks-flex-node-e2e-*'`) {
+		t.Error("runner cleanup still removes work directories owned by other attempts")
+	}
+}
+
+func TestRunnerCleanupRejectsUnsafeWorkDirectories(t *testing.T) {
+	t.Parallel()
+
+	runnerScript := e2eScriptPath(t, "lib", "runner.sh")
+	tests := map[string]func(string) string{
+		"unexpected parent": func(targetDir string) string { return targetDir },
+		"parent traversal":  func(targetDir string) string { return "/tmp/.." + targetDir },
+	}
+	for name, workDirPath := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			targetDir := filepath.Join(t.TempDir(), "aks-flex-node-e2e-test")
+			if err := os.MkdirAll(targetDir, 0o700); err != nil {
+				t.Fatalf("create protected directory: %v", err)
+			}
+			sentinel := filepath.Join(targetDir, "sentinel")
+			if err := os.WriteFile(sentinel, []byte("keep"), 0o600); err != nil {
+				t.Fatalf("write protected sentinel: %v", err)
+			}
+			workDir := workDirPath(targetDir)
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+sudo() { return 1; }
+go() { return 0; }
+if cleanup_runner_workspace; then
+  printf 'RESULT=unexpected-success\n'
+else
+  printf 'RESULT=rejected\n'
+fi
+`
+			output, err := runBash(t, script, workDir, runnerScript)
+			if err != nil {
+				t.Fatalf("runner cleanup safety harness failed: %v\n%s", err, output)
+			}
+			if !strings.Contains(string(output), "RESULT=rejected") {
+				t.Fatalf("runner cleanup accepted unsafe work directory %q:\n%s", workDir, output)
+			}
+			if _, err := os.Stat(sentinel); err != nil {
+				t.Fatalf("runner cleanup removed data outside its allowed path: %v", err)
+			}
+		})
+	}
+}
+
+func TestBicepModuleDeploymentNamesAreUniquePerRun(t *testing.T) {
+	t.Parallel()
+
+	mainBicep, err := e2eScripts.ReadFile("infra/main.bicep")
+	if err != nil {
+		t.Fatalf("read embedded main.bicep: %v", err)
+	}
+	for _, moduleName := range []string{"msi", "token", "offline", "kubeadm", "arc"} {
+		want := "name: 'deploy-vm-" + moduleName + "-${nameSuffix}'"
+		if !strings.Contains(string(mainBicep), want) {
+			t.Errorf("VM module %q does not use a per-run deployment name %q", moduleName, want)
+		}
+	}
+}
+
+func TestLoadConfigTreatsEmptyOptionalValuesAsImplicit(t *testing.T) {
+	t.Parallel()
+
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+E2E_RESOURCE_GROUP=test-rg
+E2E_LOCATION=test-location
+AZURE_SUBSCRIPTION_ID=test-subscription
+AZURE_TENANT_ID=test-tenant
+E2E_NAME_SUFFIX=test
+E2E_KUBERNETES_VERSION=
+E2E_TARGET_AGENT_POOL_NAME=
+E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME=
+load_config >/dev/null
+printf 'RESULT=%s|%s|%s|%s|%s|%s\n' \
+  "${_E2E_KUBERNETES_VERSION_EXPLICIT}" "${E2E_KUBERNETES_VERSION}" \
+  "${_E2E_TARGET_AGENT_POOL_NAME_EXPLICIT}" "${E2E_TARGET_AGENT_POOL_NAME}" \
+  "${_E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME_EXPLICIT}" "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}"
+`
+	output, err := runBash(t, script, t.TempDir(), commonScript)
+	if err != nil {
+		t.Fatalf("load config failed: %v\n%s", err, output)
+	}
+	const want = "RESULT=0|1.35.0|0|aksflexnodes|0|aksflexnodes\n"
+	if !strings.Contains(string(output), want) {
+		t.Fatalf("empty optional values were treated as explicit: got %q, want %q", output, want)
+	}
+}
+
+func TestFullE2ECleanupFailureIsAggregated(t *testing.T) {
+	t.Parallel()
+
+	runScript, err := e2eScripts.ReadFile("run.sh")
+	if err != nil {
+		t.Fatalf("read embedded run.sh: %v", err)
+	}
+	if !strings.Contains(string(runScript), "cleanup || exit_code=1") {
+		t.Fatal("full E2E does not aggregate cleanup failure into its final result")
+	}
+}
+
+func TestRestoreKubernetesVersionFromState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		configuredVersion string
+		explicit          string
+		persistedVersion  string
+		liveVersion       string
+		liveSystemVersion string
+		liveFlexVersion   string
+		lookupFails       string
+		omitSubscription  bool
+		wantVersion       string
+		wantError         string
+	}{
+		{
+			name:              "restores persisted version when unset",
+			configuredVersion: "1.35.0",
+			explicit:          "0",
+			persistedVersion:  "1.34.9",
+			liveVersion:       "1.34.9",
+			wantVersion:       "1.34.9",
+		},
+		{
+			name:              "accepts matching explicit version",
+			configuredVersion: "1.34.9",
+			explicit:          "1",
+			persistedVersion:  "1.34.9",
+			liveVersion:       "1.34.9",
+			wantVersion:       "1.34.9",
+		},
+		{
+			name:              "rejects mismatched explicit version",
+			configuredVersion: "1.35.0",
+			explicit:          "1",
+			persistedVersion:  "1.34.9",
+			liveVersion:       "1.34.9",
+			wantError:         "existing cluster state records 1.34.9",
+		},
+		{
+			name:              "rejects invalid persisted version",
+			configuredVersion: "1.35.0",
+			explicit:          "0",
+			persistedVersion:  "1.34",
+			liveVersion:       "1.34",
+			wantError:         "must be an exact x.y.z patch version",
+		},
+		{
+			name:              "recovers version from legacy state",
+			configuredVersion: "1.35.0",
+			explicit:          "0",
+			liveVersion:       "1.34.9",
+			wantVersion:       "1.34.9",
+		},
+		{
+			name:              "rejects stale persisted version",
+			configuredVersion: "1.34.9",
+			explicit:          "0",
+			persistedVersion:  "1.34.9",
+			liveVersion:       "1.35.0",
+			wantError:         "live cluster is 1.35.0",
+		},
+		{
+			name:              "fails closed when live lookup fails",
+			configuredVersion: "1.35.0",
+			explicit:          "0",
+			persistedVersion:  "1.35.0",
+			lookupFails:       "1",
+			wantError:         "Cannot determine the live Kubernetes version",
+		},
+		{
+			name:              "rejects control plane and pool skew",
+			configuredVersion: "1.34.9",
+			explicit:          "0",
+			persistedVersion:  "1.34.9",
+			liveVersion:       "1.34.9",
+			liveSystemVersion: "1.34.9",
+			liveFlexVersion:   "1.35.0",
+			wantError:         "AKS version skew",
+		},
+		{
+			name:              "requires persisted subscription",
+			configuredVersion: "1.35.0",
+			explicit:          "0",
+			persistedVersion:  "1.35.0",
+			omitSubscription:  true,
+			wantError:         "cluster and subscription",
+		},
+	}
+
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			liveSystemVersion := tt.liveSystemVersion
+			if liveSystemVersion == "" {
+				liveSystemVersion = tt.liveVersion
+			}
+			liveFlexVersion := tt.liveFlexVersion
+			if liveFlexVersion == "" {
+				liveFlexVersion = tt.liveVersion
+			}
+			subscription := "test-subscription"
+			if tt.omitSubscription {
+				subscription = ""
+			}
+
+			script := `
+set -euo pipefail
+unset AZURE_SUBSCRIPTION_ID
+E2E_WORK_DIR="$1"
+source "$2"
+E2E_KUBERNETES_VERSION="$3"
+_E2E_KUBERNETES_VERSION_EXPLICIT="$4"
+LIVE_VERSION="$6"
+LIVE_SYSTEM_VERSION="$7"
+LIVE_FLEX_VERSION="$8"
+LOOKUP_FAILS="$9"
+SUBSCRIPTION="${10}"
+az() {
+  [[ "${LOOKUP_FAILS}" != "1" ]] || return 1
+  if [[ "$1 $2" == "aks show" ]]; then
+    [[ "$*" == *"--subscription test-subscription"* ]] || {
+      echo 'aks lookup omitted persisted subscription' >&2
+      return 1
+    }
+    jq -n --arg version "${LIVE_VERSION}" \
+      '{id: "/subscriptions/test-subscription/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-aks", version: $version}'
+  elif [[ "$1" == "rest" && "$*" == *'/agentPools/system?'* ]]; then
+    printf '%s\n' "${LIVE_SYSTEM_VERSION}"
+  elif [[ "$1" == "rest" ]]; then
+    printf '%s\n' "${LIVE_FLEX_VERSION}"
+  else
+    return 1
+  fi
+}
+state_set resource_group test-rg
+state_set cluster_name test-aks
+if [[ -n "${SUBSCRIPTION}" ]]; then
+  state_set subscription_id "${SUBSCRIPTION}"
+fi
+if [[ -n "$5" ]]; then
+  state_set kubernetes_version "$5"
+fi
+restore_kubernetes_version_from_state
+printf 'RESULT=%s\n' "${E2E_KUBERNETES_VERSION}"
+`
+			output, err := runBash(t, script, t.TempDir(), commonScript,
+				tt.configuredVersion, tt.explicit, tt.persistedVersion, tt.liveVersion,
+				liveSystemVersion, liveFlexVersion, tt.lookupFails, subscription)
+			if tt.wantError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got success:\n%s", tt.wantError, output)
+				}
+				if !strings.Contains(string(output), tt.wantError) {
+					t.Fatalf("error output %q does not contain %q", output, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("restore script failed: %v\n%s", err, output)
+			}
+			if !strings.Contains(string(output), "RESULT="+tt.wantVersion+"\n") {
+				t.Fatalf("output %q does not contain restored version %q", output, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestStateRequiresVerifiedCleanupBeforeReplacement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		stateJSON string
+		wantAllow bool
+	}{
+		{name: "missing state", wantAllow: true},
+		{name: "empty state", stateJSON: `{}`, wantAllow: true},
+		{name: "verified cleanup string", stateJSON: `{"deployment_name":"e2e-old","lifecycle":"cleaned","cleanup_complete":"true"}`, wantAllow: true},
+		{name: "verified cleanup boolean", stateJSON: `{"deployment_name":"e2e-old","lifecycle":"cleaned","cleanup_complete":true}`, wantAllow: true},
+		{name: "same active deployment", stateJSON: `{"deployment_name":"e2e-new","lifecycle":"provisioning"}`},
+		{name: "active prior deployment", stateJSON: `{"deployment_name":"e2e-old","lifecycle":"ready"}`},
+		{name: "unknown legacy deployment", stateJSON: `{"cluster_name":"old-aks"}`},
+		{name: "invalid json", stateJSON: `{not-json`},
+		{name: "non-object json", stateJSON: `[]`},
+	}
+
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workDir := t.TempDir()
+			statePath := filepath.Join(workDir, "state.json")
+			if tt.stateJSON != "" {
+				if err := os.WriteFile(statePath, []byte(tt.stateJSON), 0o600); err != nil {
+					t.Fatalf("write initial state: %v", err)
+				}
+			}
+			before, _ := os.ReadFile(statePath)
+
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+next_state="$(jq -n '{deployment_name: "e2e-new", lifecycle: "provisioning"}')"
+if state_begin_deployment "${next_state}"; then
+  printf 'DECISION=ALLOWED\n'
+else
+  printf 'DECISION=REJECTED\n'
+fi
+`
+			output, err := runBash(t, script, workDir, commonScript)
+			if err != nil {
+				t.Fatalf("state guard script failed: %v\n%s", err, output)
+			}
+			gotAllow := strings.Contains(string(output), "DECISION=ALLOWED\n")
+			if gotAllow != tt.wantAllow {
+				t.Fatalf("allow = %t, want %t; output:\n%s", gotAllow, tt.wantAllow, output)
+			}
+			after, readErr := os.ReadFile(statePath)
+			if readErr != nil {
+				t.Fatalf("read resulting state: %v", readErr)
+			}
+			if !tt.wantAllow && string(after) != string(before) {
+				t.Fatalf("rejected replacement mutated state: before=%q after=%q", before, after)
+			}
+			if tt.wantAllow && !strings.Contains(string(after), `"deployment_name": "e2e-new"`) {
+				t.Fatalf("allowed replacement did not install new state: %s", after)
+			}
+			info, statErr := os.Stat(statePath)
+			if statErr != nil {
+				t.Fatalf("stat state file: %v", statErr)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("state file mode = %o, want 600", got)
+			}
+		})
+	}
+}
+
+func TestConcurrentStateWritesArePrivateAndComplete(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "state.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write initial state: %v", err)
+	}
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+for i in $(seq 1 40); do
+  state_set "key_${i}" "${i}" &
+done
+wait
+jq -e 'length == 40' "${E2E_STATE_FILE}"
+`
+	if output, err := runBash(t, script, workDir, commonScript); err != nil {
+		t.Fatalf("concurrent state script failed: %v\n%s", err, output)
+	}
+
+	info, err := os.Stat(filepath.Join(workDir, "state.json"))
+	if err != nil {
+		t.Fatalf("stat state file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("state file mode = %o, want 600", got)
+	}
+}
+
+func TestStateWriteFailurePreservesExistingState(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	statePath := filepath.Join(workDir, "state.json")
+	const invalidState = `{not-json`
+	if err := os.WriteFile(statePath, []byte(invalidState), 0o600); err != nil {
+		t.Fatalf("write invalid state: %v", err)
+	}
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+if state_set test value; then
+  echo 'unexpected success' >&2
+  exit 1
+fi
+`
+	if output, err := runBash(t, script, workDir, commonScript); err != nil {
+		t.Fatalf("failure-path script failed: %v\n%s", err, output)
+	}
+	after, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if string(after) != invalidState {
+		t.Fatalf("failed state update replaced recoverable state: %q", after)
+	}
+}
+
+func TestStateDumpRedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	commonScript := e2eScriptPath(t, "lib", "common.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+state_set kubeadm_bootstrap_token abcdef.0123456789abcdef
+state_set token_vm_ip 192.0.2.1
+state_dump
+`
+	output, err := runBash(t, script, t.TempDir(), commonScript)
+	if err != nil {
+		t.Fatalf("state dump script failed: %v\n%s", err, output)
+	}
+	if strings.Contains(string(output), "abcdef.0123456789abcdef") {
+		t.Fatalf("state dump exposed bootstrap token: %s", output)
+	}
+	if !strings.Contains(string(output), "192.0.2.1") {
+		t.Fatalf("state dump unexpectedly redacted non-secret metadata: %s", output)
+	}
+}
+
+func TestCancelDeploymentWaitsForTerminalOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		initialState  string
+		terminalState string
+		cancelFails   string
+		listFails     string
+		wantCancel    bool
+		wantError     bool
+	}{
+		{name: "running deployment", initialState: "Running", terminalState: "Canceled", wantCancel: true},
+		{name: "already succeeded", initialState: "Succeeded", terminalState: "Succeeded"},
+		{name: "cancel races natural completion", initialState: "Running", terminalState: "Succeeded", cancelFails: "1", wantCancel: true},
+		{name: "query failure", listFails: "1", wantError: true},
+	}
+
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workDir := t.TempDir()
+			callLog := filepath.Join(workDir, "az-calls.log")
+			marker := filepath.Join(workDir, "deployment-terminal")
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+AZ_MARKER="$4"
+INITIAL_STATE="$5"
+TERMINAL_STATE="$6"
+CANCEL_FAILS="$7"
+LIST_FAILS="$8"
+E2E_CLEANUP_TIMEOUT=2
+E2E_CLEANUP_POLL_INTERVAL=0.01
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  if [[ "$1 $2 $3" == "deployment group list" ]]; then
+    [[ "${LIST_FAILS}" != "1" ]] || return 1
+    state="${INITIAL_STATE}"
+    [[ ! -f "${AZ_MARKER}" ]] || state="${TERMINAL_STATE}"
+    jq -n --arg state "${state}" '[{name:"e2e-test",properties:{provisioningState:$state}}]'
+  elif [[ "$1 $2 $3" == "deployment group cancel" ]]; then
+    : > "${AZ_MARKER}"
+    [[ "${CANCEL_FAILS}" != "1" ]]
+  elif [[ "$1 $2 $3 $4" == "deployment operation group list" ]]; then
+    printf '[{"properties":{"provisioningState":"Succeeded"}}]\n'
+  else
+    return 1
+  fi
+}
+if _cancel_active_deployment test-rg e2e-test test-subscription; then
+  printf 'RESULT=success\n'
+else
+  printf 'RESULT=error\n'
+fi
+`
+			output, err := runBash(t, script, workDir, cleanupScript, callLog, marker,
+				tt.initialState, tt.terminalState, tt.cancelFails, tt.listFails)
+			if err != nil {
+				t.Fatalf("cancellation script failed: %v\n%s", err, output)
+			}
+			gotError := strings.Contains(string(output), "RESULT=error\n")
+			if gotError != tt.wantError {
+				t.Fatalf("error = %t, want %t; output:\n%s", gotError, tt.wantError, output)
+			}
+			calls, readErr := os.ReadFile(callLog)
+			if readErr != nil {
+				t.Fatalf("read az call log: %v", readErr)
+			}
+			gotCancel := strings.Contains(string(calls), "deployment group cancel")
+			if gotCancel != tt.wantCancel {
+				t.Fatalf("cancel call = %t, want %t; calls:\n%s", gotCancel, tt.wantCancel, calls)
+			}
+			if !tt.wantError {
+				operationIndex := strings.Index(string(calls), "deployment operation group list")
+				if operationIndex < 0 {
+					t.Fatalf("deployment operations were not verified:\n%s", calls)
+				}
+				if tt.wantCancel && operationIndex < strings.Index(string(calls), "deployment group cancel") {
+					t.Fatalf("operations were checked before cancellation:\n%s", calls)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupIsIdempotentAndWaitsForDependencies(t *testing.T) {
+	t.Parallel()
+
+	workDir, statePath, callLog, output, err := runCleanup(t, cleanupOptions{runTwice: true})
+	_ = workDir
+	if err != nil {
+		t.Fatalf("cleanup failed: %v\n%s", err, output)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if !strings.Contains(string(state), `"cleanup_complete": "true"`) ||
+		!strings.Contains(string(state), `"lifecycle": "cleaned"`) {
+		t.Fatalf("cleanup did not record verified completion: %s", state)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	operationIndex := strings.Index(string(calls), "deployment operation group list")
+	deleteIndex := strings.Index(string(calls), "vm delete")
+	if operationIndex < 0 || deleteIndex <= operationIndex {
+		t.Fatalf("resource deletion began before deployment operations were terminal:\n%s", calls)
+	}
+	if strings.Count(string(calls), "resource list") < 6 {
+		t.Fatalf("cleanup did not perform repeated tagged and exact inventories across two runs:\n%s", calls)
+	}
+}
+
+func TestCleanupResidualPreventsCleanState(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, _, output, err := runCleanup(t, cleanupOptions{leaveCluster: true})
+	if err != nil {
+		t.Fatalf("cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") {
+		t.Fatalf("cleanup unexpectedly accepted residual resource:\n%s", output)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) ||
+		strings.Contains(string(state), `"lifecycle": "cleaned"`) {
+		t.Fatalf("failed cleanup was marked clean: %s", state)
+	}
+}
+
+func TestCleanupUsesExactNamesWithoutRunTag(t *testing.T) {
+	t.Parallel()
+
+	_, _, callLog, output, err := runCleanup(t, cleanupOptions{noRunTags: true})
+	if err != nil {
+		t.Fatalf("cleanup without tags failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("cleanup without tags did not succeed:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if strings.Contains(string(calls), "--tag github-run=") {
+		t.Fatalf("cleanup unexpectedly used an absent run tag:\n%s", calls)
+	}
+	if !strings.Contains(string(calls), "resource list --resource-group test-rg --subscription test-subscription --output json") {
+		t.Fatalf("cleanup skipped exact-name verification:\n%s", calls)
+	}
+}
+
+func TestCleanupUsesPersistedSubscriptionWithoutEnvironment(t *testing.T) {
+	t.Parallel()
+
+	_, _, callLog, output, err := runCleanup(t, cleanupOptions{unsetSubscriptionEnv: true})
+	if err != nil {
+		t.Fatalf("cleanup without subscription environment failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("cleanup did not use the persisted subscription:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if !strings.Contains(string(calls), "--subscription test-subscription") {
+		t.Fatalf("cleanup did not pass the persisted subscription to Azure CLI:\n%s", calls)
+	}
+}
+
+func TestCleanupHandlesLegacyStateWithoutVMNames(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, _, output, err := runCleanup(t, cleanupOptions{noRunTags: true, blankVMNames: true})
+	if err != nil {
+		t.Fatalf("legacy partial-state cleanup failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("legacy partial-state cleanup did not succeed:\n%s", output)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if !strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("legacy partial-state cleanup was not marked complete: %s", state)
+	}
+}
+
+func TestCleanupDeletesDetachedUntaggedLegacyOSDisk(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		runTwice:           true,
+		noRunTags:          true,
+		legacyDetachedDisk: true,
+	})
+	if err != nil {
+		t.Fatalf("legacy detached OS-disk cleanup failed: %v\n%s", err, output)
+	}
+	if strings.Count(string(output), "RESULT=success") != 2 {
+		t.Fatalf("legacy detached OS-disk cleanup was not idempotent:\n%s", output)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if !strings.Contains(string(state), `"cleanup_complete": "true"`) ||
+		!strings.Contains(string(state), `"lifecycle": "cleaned"`) {
+		t.Fatalf("legacy detached OS-disk cleanup did not record completion: %s", state)
+	}
+
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "resource delete --ids /own-legacy-disk") {
+		t.Fatalf("cleanup did not delete the detached untagged legacy OS disk:\n%s", calls)
+	}
+	for _, foreignID := range []string{"/other-attempt-disk", "/unrelated-disk"} {
+		if strings.Contains(callText, "resource delete --ids "+foreignID) {
+			t.Errorf("cleanup deleted foreign resource %q:\n%s", foreignID, calls)
+		}
+	}
+}
+
+func TestCleanupRetriesAndReportsResidualLegacyOSDisk(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		noRunTags:                true,
+		legacyDetachedDisk:       true,
+		legacyDiskDeletePersists: true,
+	})
+	if err != nil {
+		t.Fatalf("cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") {
+		t.Fatalf("cleanup accepted a residual legacy OS disk:\n%s", output)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) ||
+		strings.Contains(string(state), `"lifecycle": "cleaned"`) {
+		t.Fatalf("residual legacy OS disk was marked clean: %s", state)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if got := strings.Count(string(calls), "resource delete --ids /own-legacy-disk"); got < 4 {
+		t.Fatalf("legacy OS-disk deletion was attempted %d times, want at least 4:\n%s", got, calls)
+	}
+}
+
+func TestCleanupDeletesOrphanNodeResourceGroupWhenParentIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{parentGroupAbsent: true})
+	if err != nil {
+		t.Fatalf("orphan cleanup failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("orphan cleanup did not succeed:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if !strings.Contains(string(calls), "group delete --name MC_aksflex-e2e-test") {
+		t.Fatalf("orphan node resource group was not deleted:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if !strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("orphan cleanup did not record completion: %s", state)
+	}
+}
+
+func TestCleanupReliesOnAKSDeletionForLiveNodeResourceGroup(t *testing.T) {
+	t.Parallel()
+
+	_, _, callLog, output, err := runCleanup(t, cleanupOptions{nodeGroupForbidden: true})
+	if err != nil {
+		t.Fatalf("live-cluster cleanup failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("cleanup did not accept confirmed AKS deletion:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "aks wait --resource-group test-rg --name aks-e2e-test") {
+		t.Fatalf("cleanup did not wait for confirmed AKS deletion:\n%s", calls)
+	}
+	for _, operation := range []string{
+		"group exists --name MC_aksflex-e2e-test",
+		"group delete --name MC_aksflex-e2e-test",
+		"group wait --name MC_aksflex-e2e-test",
+	} {
+		if strings.Contains(callText, operation) {
+			t.Fatalf("cleanup directly managed the live cluster's node resource group with %q:\n%s", operation, calls)
+		}
+	}
+}
+
+func TestCleanupDoesNotTouchNodeResourceGroupWhenAKSRemains(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		aksDeleteRemains:   true,
+		nodeGroupForbidden: true,
+	})
+	if err != nil {
+		t.Fatalf("AKS deletion failure harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "AKS cluster still exists after cleanup timeout") {
+		t.Fatalf("cleanup accepted a cluster that remained after deletion:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "aks show --resource-group test-rg --name aks-e2e-test") {
+		t.Fatalf("cleanup did not verify that the AKS cluster remained:\n%s", calls)
+	}
+	for _, operation := range []string{
+		"group exists --name MC_aksflex-e2e-test",
+		"group delete --name MC_aksflex-e2e-test",
+		"group wait --name MC_aksflex-e2e-test",
+	} {
+		if strings.Contains(callText, operation) {
+			t.Fatalf("cleanup touched a live cluster's node resource group with %q:\n%s", operation, calls)
+		}
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("failed AKS deletion was marked clean: %s", state)
+	}
+}
+
+func TestCleanupDoesNotAssumeAKSDeletionWhenWaitIsUnconfirmed(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		aksWaitUnconfirmed: true,
+		nodeGroupForbidden: true,
+	})
+	if err != nil {
+		t.Fatalf("unconfirmed AKS deletion harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Failed to confirm AKS cluster deletion") {
+		t.Fatalf("cleanup accepted an unconfirmed AKS deletion:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "aks show --resource-group test-rg --name aks-e2e-test") {
+		t.Fatalf("cleanup did not inspect AKS after the wait command failed:\n%s", calls)
+	}
+	for _, operation := range []string{
+		"group exists --name MC_aksflex-e2e-test",
+		"group delete --name MC_aksflex-e2e-test",
+		"group wait --name MC_aksflex-e2e-test",
+	} {
+		if strings.Contains(callText, operation) {
+			t.Fatalf("cleanup touched the node resource group after an unconfirmed AKS deletion with %q:\n%s", operation, calls)
+		}
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("unconfirmed AKS deletion was marked clean: %s", state)
+	}
+}
+
+func TestCleanupPropagatesOrphanNodeResourceGroupDeleteFailure(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		parentGroupAbsent:    true,
+		nodeGroupDeleteFails: true,
+	})
+	if err != nil {
+		t.Fatalf("orphan deletion failure harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Failed to delete orphaned AKS node resource group") ||
+		!strings.Contains(string(output), "AuthorizationFailed") {
+		t.Fatalf("cleanup swallowed the orphan node resource group deletion failure:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "group delete --name MC_aksflex-e2e-test") {
+		t.Fatalf("cleanup did not attempt orphan node resource group deletion:\n%s", calls)
+	}
+	if strings.Contains(callText, "group wait --name MC_aksflex-e2e-test") {
+		t.Fatalf("cleanup waited after orphan node resource group deletion failed:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("failed orphan deletion was marked clean: %s", state)
+	}
+}
+
+func TestCleanupTreatsOrphanDeleteNotFoundAsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		parentGroupAbsent:       true,
+		nodeGroupDeleteNotFound: true,
+	})
+	if err != nil {
+		t.Fatalf("orphan not-found harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("cleanup did not accept explicit orphan absence:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "group delete --name MC_aksflex-e2e-test") {
+		t.Fatalf("cleanup did not encounter the orphan deletion race:\n%s", calls)
+	}
+	if strings.Contains(callText, "group wait --name MC_aksflex-e2e-test") {
+		t.Fatalf("cleanup waited after Azure reported the orphan absent:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if !strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("idempotent orphan cleanup was not marked complete: %s", state)
+	}
+}
+
+func TestCleanupRejectsUnexpectedOrphanNodeResourceGroup(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{
+		parentGroupAbsent:      true,
+		unexpectedNodeResource: true,
+	})
+	if err != nil {
+		t.Fatalf("orphan cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Refusing to delete unexpected AKS node resource group") {
+		t.Fatalf("cleanup did not reject an unexpected orphan node resource group:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if strings.Contains(string(calls), "group delete --name production-node-rg") {
+		t.Fatalf("cleanup attempted to delete an unexpected resource group:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("rejected cleanup was marked complete: %s", state)
+	}
+}
+
+func TestCleanupRejectsUnexpectedLiveNodeResourceGroup(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{unexpectedLiveNodeRG: true})
+	if err != nil {
+		t.Fatalf("live node resource group cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Refusing to delete unexpected AKS node resource group 'production-live-node-rg'") {
+		t.Fatalf("cleanup did not reject an unexpected live node resource group:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	for _, mutation := range []string{"group delete", "vm delete", "aks delete", "rest --method delete"} {
+		if strings.Contains(string(calls), mutation) {
+			t.Fatalf("cleanup attempted mutation %q for an unexpected live node resource group:\n%s", mutation, calls)
+		}
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("rejected cleanup was marked complete: %s", state)
+	}
+}
+
+func TestCleanupRejectsUnexpectedArcMachineID(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{unexpectedArcMachineID: true})
+	if err != nil {
+		t.Fatalf("Arc cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Refusing to delete Arc machine with an unexpected persisted resource ID") {
+		t.Fatalf("cleanup did not reject an unexpected Arc machine ID:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if strings.Contains(string(calls), "rest --method delete") {
+		t.Fatalf("cleanup attempted to delete an unexpected Arc resource:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("rejected cleanup was marked complete: %s", state)
+	}
+}
+
+func TestCleanupRetriesTransientAzureQueries(t *testing.T) {
+	t.Parallel()
+
+	workDir, _, callLog, output, err := runCleanup(t, cleanupOptions{transientQueryFailures: true})
+	if err != nil {
+		t.Fatalf("transient-query cleanup failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=success") {
+		t.Fatalf("cleanup did not recover from transient Azure query failures:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if strings.Count(string(calls), "group exists") < 3 {
+		t.Errorf("cleanup did not retry a failed resource-group query:\n%s", calls)
+	}
+	for _, marker := range []string{"group-query-failed", "resource-query-failed"} {
+		failures, readErr := os.ReadFile(filepath.Join(workDir, marker))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", marker, readErr)
+		}
+		if strings.TrimSpace(string(failures)) != "2" {
+			t.Errorf("%s recorded %q transient failures, want 2", marker, strings.TrimSpace(string(failures)))
+		}
+	}
+}
+
+func TestCleanupFiltersResourceInventoryByTagWithinGroup(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	callLog := filepath.Join(workDir, "az-calls")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  printf '%s\n' '[
+    {"name":"owned","tags":{"github-run":"test-run"}},
+    {"name":"another-run","tags":{"github-run":"other-run"}},
+    {"name":"untagged"}
+  ]'
+}
+inventory="$(_resource_inventory test-rg test-subscription test-run 0)"
+printf 'INVENTORY=%s\n' "${inventory}"
+`
+	output, err := runBash(t, script, workDir, cleanupScript, callLog)
+	if err != nil {
+		t.Fatalf("tagged resource inventory harness failed: %v\n%s", err, output)
+	}
+	text := string(output)
+	if !strings.Contains(text, `"name":"owned"`) ||
+		strings.Contains(text, `"name":"another-run"`) ||
+		strings.Contains(text, `"name":"untagged"`) {
+		t.Fatalf("resource inventory was not filtered to the requested run tag:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	callText := string(calls)
+	if !strings.Contains(callText, "resource list --resource-group test-rg --subscription test-subscription --output json") {
+		t.Fatalf("resource inventory was not scoped to the parent resource group:\n%s", calls)
+	}
+	if strings.Contains(callText, "--tag") {
+		t.Fatalf("resource inventory used Azure CLI's incompatible --resource-group/--tag combination:\n%s", calls)
+	}
+}
+
+func TestCleanupAzureQueryFailureIncludesDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+E2E_CLEANUP_POLL_INTERVAL=0.01
+az() {
+  printf '%s\n' '(TooManyRequests) ARM throttled the cleanup query' >&2
+  return 1
+}
+if _resource_inventory test-rg test-subscription "" 0; then
+  printf 'RESULT=unexpected-success\n'
+else
+  printf 'RESULT=error\n'
+fi
+`
+	output, err := runBash(t, script, workDir, cleanupScript)
+	if err != nil {
+		t.Fatalf("Azure query diagnostic harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") ||
+		!strings.Contains(string(output), "Last Azure CLI error: (TooManyRequests) ARM throttled the cleanup query") {
+		t.Fatalf("cleanup omitted the final Azure CLI diagnostic:\n%s", output)
+	}
+}
+
+func TestCleanupAzureQueriesStopOnAuthorizationFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, query := range []string{"group", "inventory"} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			workDir := t.TempDir()
+			cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+			callLog := filepath.Join(workDir, "az-calls")
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+QUERY="$4"
+E2E_CLEANUP_POLL_INTERVAL=0.01
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  printf '%s\n' "ERROR: Operation returned an invalid status 'Forbidden'" >&2
+  return 1
+}
+deadline=$((SECONDS + 60))
+if [[ "${QUERY}" == "group" ]]; then
+  _group_exists_with_retry test-rg test-subscription "${deadline}" || true
+else
+  _resource_inventory test-rg test-subscription "" "${deadline}" || true
+fi
+printf 'CALLS=%s\n' "$(wc -l < "${AZ_CALL_LOG}")"
+`
+			output, err := runBash(t, script, workDir, cleanupScript, callLog, query)
+			if err != nil {
+				t.Fatalf("authorization failure harness failed: %v\n%s", err, output)
+			}
+			if !strings.Contains(string(output), "after 1 attempts") ||
+				!strings.Contains(string(output), "invalid status 'Forbidden'") ||
+				!strings.Contains(string(output), "CALLS=1") {
+				t.Fatalf("authorization failure was retried or lost its diagnostic:\n%s", output)
+			}
+		})
+	}
+}
+
+func TestCleanupAzureQueriesBoundRetriesByAttemptAndDeadline(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	callLog := filepath.Join(workDir, "az-calls")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+E2E_CLEANUP_POLL_INTERVAL=0.01
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  printf '%s\n' '(TooManyRequests) ARM throttled the cleanup query' >&2
+  return 1
+}
+sleep() { :; }
+deadline=$((SECONDS + 60))
+_group_exists_with_retry test-rg test-subscription "${deadline}" || true
+printf 'GROUP_CALLS=%s\n' "$(wc -l < "${AZ_CALL_LOG}")"
+: > "${AZ_CALL_LOG}"
+_resource_inventory test-rg test-subscription "" "${deadline}" || true
+printf 'INVENTORY_CALLS=%s\n' "$(wc -l < "${AZ_CALL_LOG}")"
+`
+	output, err := runBash(t, script, workDir, cleanupScript, callLog)
+	if err != nil {
+		t.Fatalf("bounded retry harness failed: %v\n%s", err, output)
+	}
+	for _, expected := range []string{"GROUP_CALLS=5", "INVENTORY_CALLS=5"} {
+		if !strings.Contains(string(output), expected) {
+			t.Fatalf("Azure query retries were not bounded by attempt count; missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCleanupTreatsResourceGroupNotFoundAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	callLog := filepath.Join(workDir, "az-calls")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  printf '%s\n' '(ResourceGroupNotFound) Resource group was not found.' >&2
+  return 1
+}
+result="$(_group_exists_with_retry test-rg test-subscription 0)"
+printf 'RESULT=%s\n' "${result}"
+printf 'CALLS=%s\n' "$(wc -l < "${AZ_CALL_LOG}")"
+`
+	output, err := runBash(t, script, workDir, cleanupScript, callLog)
+	if err != nil {
+		t.Fatalf("ResourceGroupNotFound harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=false") ||
+		!strings.Contains(string(output), "CALLS=1") {
+		t.Fatalf("ResourceGroupNotFound was not treated as successful absence:\n%s", output)
+	}
+}
+
+func TestCleanupAzureQueriesHonorExpiredDeadline(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	callLog := filepath.Join(workDir, "az-calls")
+	sleepLog := filepath.Join(workDir, "sleep-delay")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+SLEEP_LOG="$4"
+az() { printf '%s\n' "$*" >> "${AZ_CALL_LOG}"; return 1; }
+sleep() { printf '%s\n' "$1" > "${SLEEP_LOG}"; }
+
+SECONDS=10
+if _group_exists_with_retry test-rg test-subscription 5; then
+  printf 'GROUP=unexpected-success\n'
+else
+  printf 'GROUP=expired\n'
+fi
+if _resource_inventory test-rg test-subscription "" 5; then
+  printf 'INVENTORY=unexpected-success\n'
+else
+  printf 'INVENTORY=expired\n'
+fi
+calls=0
+[[ ! -f "${AZ_CALL_LOG}" ]] || calls="$(wc -l < "${AZ_CALL_LOG}")"
+printf 'CALLS=%s\n' "${calls}"
+
+E2E_CLEANUP_POLL_INTERVAL=30
+SECONDS=10
+_sleep_before_azure_query_retry 11
+printf 'SLEEP=%s\n' "$(<"${SLEEP_LOG}")"
+`
+	output, err := runBash(t, script, workDir, cleanupScript, callLog, sleepLog)
+	if err != nil {
+		t.Fatalf("Azure query deadline harness failed: %v\n%s", err, output)
+	}
+	for _, expected := range []string{"GROUP=expired", "INVENTORY=expired", "CALLS=0", "SLEEP=1"} {
+		if !strings.Contains(string(output), expected) {
+			t.Fatalf("Azure query deadline was not enforced; missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestCleanupQueryFailureDoesNotDeleteResources(t *testing.T) {
+	t.Parallel()
+
+	_, statePath, callLog, output, err := runCleanup(t, cleanupOptions{deploymentQueryFails: true})
+	if err != nil {
+		t.Fatalf("cleanup test harness failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "RESULT=error") {
+		t.Fatalf("cleanup unexpectedly succeeded:\n%s", output)
+	}
+	calls, readErr := os.ReadFile(callLog)
+	if readErr != nil {
+		t.Fatalf("read az calls: %v", readErr)
+	}
+	if strings.Contains(string(calls), "vm delete") || strings.Contains(string(calls), "aks delete") {
+		t.Fatalf("cleanup deleted resources after deployment query failure:\n%s", calls)
+	}
+	state, readErr := os.ReadFile(statePath)
+	if readErr != nil {
+		t.Fatalf("read state: %v", readErr)
+	}
+	if strings.Contains(string(state), `"cleanup_complete": "true"`) {
+		t.Fatalf("query failure was marked clean: %s", state)
+	}
+}
+
+type cleanupOptions struct {
+	runTwice                  bool
+	leaveCluster              bool
+	aksDeleteRemains          bool
+	aksWaitUnconfirmed        bool
+	parentGroupAbsent         bool
+	deploymentQueryFails      bool
+	noRunTags                 bool
+	blankVMNames              bool
+	nodeGroupForbidden        bool
+	nodeGroupDeleteFails      bool
+	nodeGroupDeleteNotFound   bool
+	unexpectedNodeResource    bool
+	unexpectedLiveNodeRG      bool
+	legacyDefaultNodeResource bool
+	legacyDetachedDisk        bool
+	legacyDiskDeletePersists  bool
+	unexpectedArcMachineID    bool
+	transientQueryFailures    bool
+	unsetSubscriptionEnv      bool
+}
+
+func runCleanup(t *testing.T, options cleanupOptions) (string, string, string, []byte, error) {
+	t.Helper()
+	workDir := t.TempDir()
+	statePath := filepath.Join(workDir, "state.json")
+	callLog := filepath.Join(workDir, "az-calls.log")
+	nodeGroupDeleted := filepath.Join(workDir, "node-group-deleted")
+	groupQueryFailed := filepath.Join(workDir, "group-query-failed")
+	resourceQueryFailed := filepath.Join(workDir, "resource-query-failed")
+	clusterDeleted := filepath.Join(workDir, "cluster-deleted")
+	state := `{
+  "resource_group": "test-rg",
+  "location": "test-location",
+  "subscription_id": "test-subscription",
+  "deployment_name": "e2e-test",
+  "run_id": "test-run",
+  "name_suffix": "test",
+  "lifecycle": "ready",
+  "cluster_name": "aks-e2e-test",
+  "node_resource_group": "MC_aksflex-e2e-test",
+  "msi_vm_name": "vm-e2e-msi-test",
+  "token_vm_name": "vm-e2e-token-test",
+  "offline_vm_name": "vm-e2e-offline-test",
+  "kubeadm_vm_name": "vm-e2e-kubeadm-test",
+  "arc_vm_name": "vm-e2e-arc-test",
+  "arc_machine_name": "",
+  "vnet_name": "vnet-e2e-test",
+  "nsg_name": "nsg-e2e-test"
+}`
+	if options.noRunTags {
+		state = strings.Replace(state, `"run_id": "test-run"`, `"run_id": ""`, 1)
+	}
+	if options.blankVMNames {
+		for _, name := range []string{
+			"vm-e2e-msi-test",
+			"vm-e2e-token-test",
+			"vm-e2e-offline-test",
+			"vm-e2e-kubeadm-test",
+			"vm-e2e-arc-test",
+		} {
+			state = strings.ReplaceAll(state, name, "")
+		}
+	}
+	if options.unexpectedNodeResource {
+		state = strings.Replace(state, `"node_resource_group": "MC_aksflex-e2e-test"`, `"node_resource_group": "production-node-rg"`, 1)
+	}
+	if options.legacyDefaultNodeResource {
+		state = strings.Replace(state, "  \"node_resource_group\": \"MC_aksflex-e2e-test\",\n", "", 1)
+	}
+	if options.unexpectedArcMachineID {
+		state = strings.Replace(state, `"arc_machine_name": ""`, `"arc_machine_name": "vm-e2e-arc-test-connected",
+  "arc_machine_id": "/subscriptions/test-subscription/resourceGroups/production-rg/providers/Microsoft.HybridCompute/machines/production-machine"`, 1)
+	}
+	if err := os.WriteFile(statePath, []byte(state), 0o600); err != nil {
+		t.Fatalf("write cleanup state: %v", err)
+	}
+	cleanupScript := e2eScriptPath(t, "lib", "cleanup.sh")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+NODE_GROUP_DELETED="$4"
+GROUP_QUERY_FAILED="$5"
+RESOURCE_QUERY_FAILED="$6"
+LEAVE_CLUSTER="$7"
+PARENT_GROUP_ABSENT="$8"
+DEPLOYMENT_QUERY_FAILS="$9"
+RUN_TWICE="${10}"
+TRANSIENT_QUERY_FAILURES="${11}"
+UNEXPECTED_LIVE_NODE_RG="${12}"
+LEGACY_DEFAULT_NODE_RG="${13}"
+LEGACY_DETACHED_DISK="${14}"
+LEGACY_DISK_DELETE_PERSISTS="${15}"
+UNSET_SUBSCRIPTION_ENV="${16}"
+AKS_DELETE_REMAINS="${17}"
+NODE_GROUP_FORBIDDEN="${18}"
+NODE_GROUP_DELETE_FAILS="${19}"
+CLUSTER_DELETED="${20}"
+AKS_WAIT_UNCONFIRMED="${21}"
+NODE_GROUP_DELETE_NOT_FOUND="${22}"
+LEGACY_DISK_DELETED="${E2E_WORK_DIR}/legacy-disk-deleted"
+# Keep cleanup fixtures independent from the ambient GitHub Actions run. Tests
+# that need tag-based cleanup persist an explicit run_id in their state.
+unset GITHUB_RUN_ID
+if [[ "${UNSET_SUBSCRIPTION_ENV}" == "1" ]]; then
+  unset AZURE_SUBSCRIPTION_ID
+else
+  AZURE_SUBSCRIPTION_ID=test-subscription
+fi
+E2E_SKIP_CLEANUP=0
+E2E_CLEANUP_TIMEOUT=5
+E2E_CLEANUP_POLL_INTERVAL=0.01
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  if [[ "$1 $2 $3" == "deployment group list" ]]; then
+    [[ "${DEPLOYMENT_QUERY_FAILS}" != "1" ]] || return 1
+    printf '[{"name":"e2e-test","properties":{"provisioningState":"Succeeded"}}]\n'
+  elif [[ "$1 $2 $3 $4" == "deployment operation group list" ]]; then
+    printf '[{"properties":{"provisioningState":"Succeeded"}}]\n'
+  elif [[ "$1 $2" == "group exists" ]]; then
+    if [[ "$*" == *"--name MC_aksflex-e2e-test"* || \
+            "$*" == *"--name MC_test-rg_aks-e2e-test_test-location"* ]]; then
+      if [[ "${NODE_GROUP_FORBIDDEN}" == "1" ]]; then
+        printf '%s\n' "ERROR: Operation returned an invalid status 'Forbidden'" >&2
+        return 1
+      fi
+      [[ -f "${NODE_GROUP_DELETED}" ]] && printf 'false\n' || printf 'true\n'
+    elif [[ "$*" == *"--name test-rg"* ]]; then
+      query_failures="$(cat "${GROUP_QUERY_FAILED}" 2>/dev/null || printf '0\n')"
+      if [[ "${TRANSIENT_QUERY_FAILURES}" == "1" && "${query_failures}" -lt 2 ]]; then
+        printf '%s\n' "$((query_failures + 1))" > "${GROUP_QUERY_FAILED}"
+        printf '%s\n' '(TooManyRequests) transient resource-group query failure' >&2
+        return 1
+      fi
+      [[ "${PARENT_GROUP_ABSENT}" == "1" ]] && printf 'false\n' || printf 'true\n'
+    else
+      printf 'false\n'
+    fi
+  elif [[ "$1 $2" == "group delete" ]]; then
+    if [[ "${NODE_GROUP_DELETE_FAILS}" == "1" ]]; then
+      printf '%s\n' '(AuthorizationFailed) The client cannot delete this resource group.' >&2
+      return 1
+    fi
+    if [[ "${NODE_GROUP_DELETE_NOT_FOUND}" == "1" ]]; then
+      printf '%s\n' '(ResourceGroupNotFound) Resource group was not found.' >&2
+      return 1
+    fi
+    : > "${NODE_GROUP_DELETED}"
+  elif [[ "$1 $2" == "group wait" ]]; then
+    return 0
+  elif [[ "$1 $2" == "vm list" ]]; then
+    printf '[]\n'
+  elif [[ "$1 $2" == "aks list" ]]; then
+    if [[ -f "${CLUSTER_DELETED}" ]]; then
+      printf '[]\n'
+    elif [[ "${UNEXPECTED_LIVE_NODE_RG}" == "1" ]]; then
+      printf '[{"name":"aks-e2e-test","nodeResourceGroup":"production-live-node-rg"}]\n'
+    elif [[ "${LEGACY_DEFAULT_NODE_RG}" == "1" ]]; then
+      printf '[{"name":"aks-e2e-test","location":"test-location","nodeResourceGroup":"MC_test-rg_aks-e2e-test_test-location"}]\n'
+    else
+      printf '[{"name":"aks-e2e-test","location":"test-location","nodeResourceGroup":"MC_aksflex-e2e-test"}]\n'
+    fi
+  elif [[ "$1 $2" == "aks delete" ]]; then
+    [[ "${AKS_DELETE_REMAINS}" == "1" ]] || : > "${CLUSTER_DELETED}"
+  elif [[ "$1 $2" == "aks wait" ]]; then
+    [[ "${AKS_DELETE_REMAINS}" != "1" && "${AKS_WAIT_UNCONFIRMED}" != "1" ]]
+  elif [[ "$1 $2" == "aks show" ]]; then
+    if [[ "${AKS_WAIT_UNCONFIRMED}" == "1" ]]; then
+      printf '%s\n' "ERROR: Operation returned an invalid status 'Forbidden'" >&2
+      return 1
+    fi
+    [[ "${AKS_DELETE_REMAINS}" == "1" ]]
+  elif [[ "$1 $2" == "resource delete" ]]; then
+    if [[ "$*" == *"--ids /own-legacy-disk"* && \
+          "${LEGACY_DISK_DELETE_PERSISTS}" != "1" ]]; then
+      : > "${LEGACY_DISK_DELETED}"
+    fi
+    return 0
+  elif [[ "$1 $2" == "resource list" ]]; then
+    query_failures="$(cat "${RESOURCE_QUERY_FAILED}" 2>/dev/null || printf '0\n')"
+    if [[ "${TRANSIENT_QUERY_FAILURES}" == "1" && "${query_failures}" -lt 2 ]]; then
+      printf '%s\n' "$((query_failures + 1))" > "${RESOURCE_QUERY_FAILED}"
+      printf '%s\n' '(TooManyRequests) transient resource inventory failure' >&2
+      return 1
+    fi
+    if [[ "$*" == *"--tag "* ]]; then
+      [[ "$*" == *"--output json"* ]] && printf '[]\n' || true
+    elif [[ "$*" == *"--output json"* ]]; then
+      resource_json='[]'
+      if [[ "${LEAVE_CLUSTER}" == "1" ]]; then
+        resource_json="$(jq -c '. + [{"name":"aks-e2e-test","id":"/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/aks-e2e-test"}]' <<<"${resource_json}")"
+      fi
+      if [[ "${LEGACY_DETACHED_DISK}" == "1" ]]; then
+        resource_json="$(jq -c '. + [
+          {"type":"Microsoft.Compute/disks","name":"vm-e2e-token-other_OsDisk_1_efgh","id":"/other-attempt-disk"},
+          {"type":"Microsoft.Compute/disks","name":"production-disk","id":"/unrelated-disk"}
+        ]' <<<"${resource_json}")"
+        if [[ ! -f "${LEGACY_DISK_DELETED}" ]]; then
+          resource_json="$(jq -c '. + [{"type":"Microsoft.Compute/disks","name":"vm-e2e-token-test_OsDisk_1_abcd","id":"/own-legacy-disk"}]' <<<"${resource_json}")"
+        fi
+      fi
+      printf '%s\n' "${resource_json}"
+    fi
+  else
+    return 0
+  fi
+}
+run_cleanup() {
+  if cleanup; then
+    printf 'RESULT=success\n'
+  else
+    printf 'RESULT=error\n'
+  fi
+}
+run_cleanup
+if [[ "${RUN_TWICE}" == "1" ]]; then
+  run_cleanup
+fi
+`
+	output, err := runBash(t, script, workDir, cleanupScript, callLog, nodeGroupDeleted,
+		groupQueryFailed, resourceQueryFailed,
+		boolString(options.leaveCluster), boolString(options.parentGroupAbsent),
+		boolString(options.deploymentQueryFails), boolString(options.runTwice),
+		boolString(options.transientQueryFailures), boolString(options.unexpectedLiveNodeRG),
+		boolString(options.legacyDefaultNodeResource), boolString(options.legacyDetachedDisk),
+		boolString(options.legacyDiskDeletePersists), boolString(options.unsetSubscriptionEnv),
+		boolString(options.aksDeleteRemains), boolString(options.nodeGroupForbidden),
+		boolString(options.nodeGroupDeleteFails), clusterDeleted,
+		boolString(options.aksWaitUnconfirmed), boolString(options.nodeGroupDeleteNotFound))
+	return workDir, statePath, callLog, output, err
+}
+
+func boolString(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func e2eScriptPath(t *testing.T, elements ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, name := range []string{"common.sh", "cleanup.sh", "runner.sh"} {
+		contents, err := e2eScripts.ReadFile(filepath.ToSlash(filepath.Join("lib", name)))
+		if err != nil {
+			t.Fatalf("read embedded %s: %v", name, err)
+		}
+		path := filepath.Join(root, "lib", name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create embedded script directory: %v", err)
+		}
+		if err := os.WriteFile(path, contents, 0o700); err != nil {
+			t.Fatalf("materialize embedded %s: %v", name, err)
+		}
+	}
+	return filepath.Join(append([]string{root}, elements...)...)
+}
+
+func runBash(t *testing.T, script string, args ...string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	commandArgs := append([]string{"-c", script, "e2e-script-test"}, args...)
+	cmd := exec.CommandContext(ctx, "bash", commandArgs...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("shell test timed out: %v\n%s", ctx.Err(), output)
+	}
+	return output, err
+}

--- a/hack/e2e/e2e_scripts_test.go
+++ b/hack/e2e/e2e_scripts_test.go
@@ -13,7 +13,7 @@ import (
 
 // Embedding the scripts makes Go's test cache invalidate on shell-only changes.
 //
-//go:embed run.sh lib/common.sh lib/cleanup.sh lib/runner.sh infra/*.bicep infra/modules/*.bicep
+//go:embed run.sh lib/common.sh lib/cleanup.sh lib/controller.sh lib/node-join-arc.sh lib/runner.sh infra/*.bicep infra/modules/*.bicep
 var e2eScripts embed.FS
 
 func TestRunnerCleanupIsScopedToCurrentAttempt(t *testing.T) {
@@ -470,6 +470,272 @@ state_dump
 	}
 	if !strings.Contains(string(output), "192.0.2.1") {
 		t.Fatalf("state dump unexpectedly redacted non-secret metadata: %s", output)
+	}
+}
+
+func TestArcRoleAssignmentIsPersistedOnlyAfterVerification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		mode              string
+		initiallyVerified bool
+		wantSuccess       bool
+		wantCreate        bool
+	}{
+		{name: "existing assignment", mode: "visible", wantSuccess: true},
+		{name: "delayed list visibility", mode: "delayed", wantSuccess: true, wantCreate: true},
+		{name: "wrong principal returned by create", mode: "wrong-principal", wantCreate: true},
+		{name: "wrong scope returned by create", mode: "wrong-scope", wantCreate: true},
+		{name: "list visibility timeout clears stale state", mode: "timeout", initiallyVerified: true, wantCreate: true},
+		{name: "query failure clears stale state without creating", mode: "query-error", initiallyVerified: true},
+	}
+
+	arcScript := e2eScriptPath(t, "lib", "node-join-arc.sh")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workDir := t.TempDir()
+			callLog := filepath.Join(workDir, "az-calls")
+			listCount := filepath.Join(workDir, "list-count")
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+AZ_CALL_LOG="$3"
+LIST_COUNT="$4"
+MODE="$5"
+INITIALLY_VERIFIED="$6"
+PRINCIPAL_ID=11111111-1111-1111-1111-111111111111
+ROLE_ID=ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8
+CLUSTER_ID=/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-aks
+SUBSCRIPTION_ID=test-subscription
+role_record() {
+  jq -n --arg principal "$1" --arg scope "$2" --arg role "${ROLE_ID}" '{
+    id: "/subscriptions/test/providers/Microsoft.Authorization/roleAssignments/test-assignment",
+    principalId: $principal,
+    roleDefinitionId: ("/subscriptions/test/providers/Microsoft.Authorization/roleDefinitions/" + $role),
+    scope: $scope
+  }'
+}
+az() {
+  printf '%s\n' "$*" >> "${AZ_CALL_LOG}"
+  if [[ "$1 $2 $3" == "role assignment list" ]]; then
+    if [[ "${MODE}" == "query-error" ]]; then
+      return 1
+    fi
+    count="$(cat "${LIST_COUNT}" 2>/dev/null || printf '0\n')"
+    count=$((count + 1))
+    printf '%s\n' "${count}" > "${LIST_COUNT}"
+    if [[ "${MODE}" == "visible" || ("${MODE}" == "delayed" && "${count}" -ge 3) ]]; then
+      role_record "${PRINCIPAL_ID}" "${CLUSTER_ID}" | jq -s '.'
+    else
+      printf '[]\n'
+    fi
+  elif [[ "$1 $2 $3" == "role assignment create" ]]; then
+    principal="${PRINCIPAL_ID}"
+    scope="${CLUSTER_ID}"
+    [[ "${MODE}" != "wrong-principal" ]] || principal=22222222-2222-2222-2222-222222222222
+    [[ "${MODE}" != "wrong-scope" ]] || scope="${CLUSTER_ID}/agentPools/other"
+    role_record "${principal}" "${scope}"
+  else
+    return 1
+  fi
+}
+sleep() { :; }
+if [[ "${INITIALLY_VERIFIED}" == "1" ]]; then
+  state_set arc_role_assigned true
+fi
+if _ensure_arc_role_assignment "${PRINCIPAL_ID}" "${CLUSTER_ID}" "${SUBSCRIPTION_ID}"; then
+  printf 'RESULT=success\n'
+else
+  printf 'RESULT=failure\n'
+fi
+printf 'STATE=%s\n' "$(state_get arc_role_assigned)"
+`
+			output, err := runBash(t, script, workDir, arcScript, callLog, listCount, tt.mode, boolString(tt.initiallyVerified))
+			if err != nil {
+				t.Fatalf("Arc role-assignment harness failed: %v\n%s", err, output)
+			}
+			wantResult := "RESULT=failure\n"
+			wantState := "STATE=false\n"
+			if tt.wantSuccess {
+				wantResult = "RESULT=success\n"
+				wantState = "STATE=true\n"
+			}
+			if !strings.Contains(string(output), wantResult) || !strings.Contains(string(output), wantState) {
+				t.Fatalf("Arc role-assignment result did not match expectations:\n%s", output)
+			}
+			calls, readErr := os.ReadFile(callLog)
+			if readErr != nil {
+				t.Fatalf("read Azure CLI calls: %v", readErr)
+			}
+			gotCreate := strings.Contains(string(calls), "role assignment create")
+			if gotCreate != tt.wantCreate {
+				t.Fatalf("role assignment create = %t, want %t; calls:\n%s", gotCreate, tt.wantCreate, calls)
+			}
+			for _, required := range []string{
+				"--assignee-object-id 11111111-1111-1111-1111-111111111111",
+				"--role ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+				"--scope /subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-aks",
+				"--subscription test-subscription",
+			} {
+				if !strings.Contains(string(calls), required) {
+					t.Errorf("Azure CLI calls omitted %q:\n%s", required, calls)
+				}
+			}
+		})
+	}
+}
+
+func TestAKSContributorRoleDefinitionAllowsBootstrapDataAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		actions    string
+		notActions string
+		wantAllow  bool
+	}{
+		{name: "exact action", actions: `["Microsoft.ContainerService/managedClusters/agentPools/listBootstrapData/action"]`, notActions: `[]`, wantAllow: true},
+		{name: "managed cluster wildcard", actions: `["Microsoft.ContainerService/managedClusters/*"]`, notActions: `[]`, wantAllow: true},
+		{name: "global wildcard", actions: `["*"]`, notActions: `[]`, wantAllow: true},
+		{name: "explicit exclusion", actions: `["Microsoft.ContainerService/managedClusters/*"]`, notActions: `["Microsoft.ContainerService/managedClusters/agentPools/listBootstrapData/action"]`},
+		{name: "unrelated action", actions: `["Microsoft.Compute/*"]`, notActions: `[]`},
+	}
+
+	arcScript := e2eScriptPath(t, "lib", "node-join-arc.sh")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+ACTIONS="$3"
+NOT_ACTIONS="$4"
+CALL_LOG="$5"
+az() {
+  printf '%s\n' "$*" > "${CALL_LOG}"
+  [[ "$1 $2 $3" == "role definition show" ]] || return 1
+  jq -n --argjson actions "${ACTIONS}" --argjson notActions "${NOT_ACTIONS}" \
+    '{permissions: [{actions: $actions, notActions: $notActions}]}'
+}
+if _aks_contributor_allows_bootstrap_data test-subscription; then
+  printf 'RESULT=allowed\n'
+else
+  printf 'RESULT=denied\n'
+fi
+`
+			workDir := t.TempDir()
+			callLog := filepath.Join(workDir, "az-call")
+			output, err := runBash(t, script, workDir, arcScript, tt.actions, tt.notActions, callLog)
+			if err != nil {
+				t.Fatalf("role-definition harness failed: %v\n%s", err, output)
+			}
+			gotAllow := strings.Contains(string(output), "RESULT=allowed\n")
+			if gotAllow != tt.wantAllow {
+				t.Fatalf("allowed = %t, want %t; output:\n%s", gotAllow, tt.wantAllow, output)
+			}
+			calls, readErr := os.ReadFile(callLog)
+			if readErr != nil {
+				t.Fatalf("read role-definition call: %v", readErr)
+			}
+			for _, required := range []string{
+				"role definition show",
+				"--id /subscriptions/test-subscription/providers/Microsoft.Authorization/roleDefinitions/ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+				"--subscription test-subscription",
+			} {
+				if !strings.Contains(string(calls), required) {
+					t.Errorf("role-definition lookup omitted %q: %s", required, calls)
+				}
+			}
+		})
+	}
+}
+
+func TestArcBootstrapFetchReportsBoundedAuthorizationDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	arcScript := e2eScriptPath(t, "lib", "node-join-arc.sh")
+	fetchCount := filepath.Join(workDir, "fetch-count")
+	script := `
+set -euo pipefail
+E2E_WORK_DIR="$1"
+source "$2"
+FETCH_COUNT="$3"
+E2E_BINARY=/tmp/test-binary
+E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME=flex
+PRINCIPAL_ID=11111111-1111-1111-1111-111111111111
+ROLE_ID=ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8
+CLUSTER_ID=/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-aks
+ARC_ID=/subscriptions/test/resourceGroups/test-rg/providers/Microsoft.HybridCompute/machines/test-arc
+SUBSCRIPTION_ID=test-subscription
+remote_copy() { :; }
+remote_exec() {
+  if [[ "$*" == *"fetch-bootstrap-data"* ]]; then
+    count="$(cat "${FETCH_COUNT}" 2>/dev/null || printf '0\n')"
+    printf '%s\n' "$((count + 1))" > "${FETCH_COUNT}"
+    printf '%s\n' 'Command execution failed: fetch bootstrap data returned HTTP status 403: error.code="AuthorizationFailed", error.message="role assignment has not propagated", x-ms-request-id="request-123", x-ms-correlation-request-id="correlation-456"' >&2
+    printf '%s\n' 'Bearer TOP_SECRET_TOKEN_MUST_NOT_APPEAR' >&2
+    return 1
+  fi
+  if [[ "$*" == *"himdsd_active"* ]]; then
+    printf 'true|true\n'
+  fi
+}
+az() {
+  if [[ "$1 $2 $3" == "role assignment list" ]]; then
+    jq -n --arg principal "${PRINCIPAL_ID}" --arg role "${ROLE_ID}" --arg scope "${CLUSTER_ID}" \
+      '[{principalId: $principal, roleDefinitionId: ("/subscriptions/test/providers/Microsoft.Authorization/roleDefinitions/" + $role), scope: $scope}]'
+  elif [[ "$1 $2 $3" == "role definition show" ]]; then
+    printf '%s\n' '{"permissions":[{"actions":["Microsoft.ContainerService/managedClusters/*"],"notActions":[]}]}'
+  elif [[ "$1 $2" == "resource show" ]]; then
+    printf '%s\n' "${PRINCIPAL_ID}"
+  else
+    return 1
+  fi
+}
+sleep() { :; }
+if _fetch_arc_bootstrap_config 192.0.2.1 10.0.0.4 test-node "${CLUSTER_ID}" "${E2E_WORK_DIR}/config.json" "${ARC_ID}" "${PRINCIPAL_ID}" "${SUBSCRIPTION_ID}"; then
+  printf 'RESULT=unexpected-success\n'
+else
+  printf 'RESULT=expected-failure\n'
+fi
+printf 'FETCHES=%s\n' "$(cat "${FETCH_COUNT}")"
+`
+	output, err := runBash(t, script, workDir, arcScript, fetchCount)
+	if err != nil {
+		t.Fatalf("Arc bootstrap diagnostic harness failed: %v\n%s", err, output)
+	}
+	text := string(output)
+	for _, expected := range []string{
+		"RESULT=expected-failure",
+		"FETCHES=60",
+		`error.code="AuthorizationFailed"`,
+		`x-ms-request-id="request-123"`,
+		`x-ms-correlation-request-id="correlation-456"`,
+		"roleAssignmentVisible=true roleAllowsListBootstrapData=true arcPrincipalMatches=true himdsdActive=true azcmagentConnected=true",
+		"still HTTP 403 despite a verified assignment",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("diagnostic output omitted %q:\n%s", expected, output)
+		}
+	}
+	for _, attempt := range []string{"1", "10", "20", "30", "40", "50", "60"} {
+		marker := "Arc authorization diagnostics (" + attempt + "/60)"
+		if strings.Count(text, marker) != 1 {
+			t.Errorf("diagnostic marker %q count = %d, want 1", marker, strings.Count(text, marker))
+		}
+	}
+	if got := strings.Count(text, "Arc authorization diagnostics ("); got != 7 {
+		t.Errorf("authorization diagnostics emitted %d times, want 7", got)
+	}
+	if strings.Contains(text, "TOP_SECRET_TOKEN_MUST_NOT_APPEAR") {
+		t.Fatalf("diagnostics exposed the discarded token: %s", output)
 	}
 }
 
@@ -1559,7 +1825,7 @@ func boolString(value bool) string {
 func e2eScriptPath(t *testing.T, elements ...string) string {
 	t.Helper()
 	root := t.TempDir()
-	for _, name := range []string{"common.sh", "cleanup.sh", "runner.sh"} {
+	for _, name := range []string{"common.sh", "cleanup.sh", "controller.sh", "node-join-arc.sh", "runner.sh"} {
 		contents, err := e2eScripts.ReadFile(filepath.ToSlash(filepath.Join("lib", name)))
 		if err != nil {
 			t.Fatalf("read embedded %s: %v", name, err)

--- a/hack/e2e/infra/main.bicep
+++ b/hack/e2e/infra/main.bicep
@@ -52,6 +52,7 @@ var kubeadmVmName = 'vm-e2e-kubeadm-${nameSuffix}'
 var arcVmName     = 'vm-e2e-arc-${nameSuffix}'
 var vnetName      = 'vnet-e2e-${nameSuffix}'
 var nsgName       = 'nsg-e2e-${nameSuffix}'
+var nodeResourceGroupName = 'MC_aksflex-e2e-${nameSuffix}'
 
 var subnetAksName = 'snet-aks'
 var subnetVmName  = 'snet-vm'
@@ -125,6 +126,7 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-01-01' = {
   }
   properties: {
     dnsPrefix: clusterName
+    nodeResourceGroup: nodeResourceGroupName
     kubernetesVersion: kubernetesVersion
     enableRBAC: true
     aadProfile: {
@@ -167,7 +169,7 @@ resource flexAgentPool 'Microsoft.ContainerService/managedClusters/agentPools@20
 // Flex-node VMs (via reusable module)
 // ---------------------------------------------------------------------------
 module vmMsi 'modules/vm.bicep' = {
-  name: 'deploy-vm-msi'
+  name: 'deploy-vm-msi-${nameSuffix}'
   params: {
     location: location
     vmName: msiVmName
@@ -181,7 +183,7 @@ module vmMsi 'modules/vm.bicep' = {
 }
 
 module vmToken 'modules/vm.bicep' = {
-  name: 'deploy-vm-token'
+  name: 'deploy-vm-token-${nameSuffix}'
   params: {
     location: location
     vmName: tokenVmName
@@ -197,7 +199,7 @@ module vmToken 'modules/vm.bicep' = {
 }
 
 module vmOffline 'modules/vm.bicep' = {
-  name: 'deploy-vm-offline'
+  name: 'deploy-vm-offline-${nameSuffix}'
   params: {
     location: location
     vmName: offlineVmName
@@ -211,7 +213,7 @@ module vmOffline 'modules/vm.bicep' = {
 }
 
 module vmKubeadm 'modules/vm.bicep' = {
-  name: 'deploy-vm-kubeadm'
+  name: 'deploy-vm-kubeadm-${nameSuffix}'
   params: {
     location: location
     vmName: kubeadmVmName
@@ -228,7 +230,7 @@ module vmKubeadm 'modules/vm.bicep' = {
 // an official Arc evaluation host by disabling walinuxagent, blocking Azure
 // IMDS, and setting MSFT_ARC_TEST before installing the Connected Machine agent.
 module vmArc 'modules/vm.bicep' = {
-  name: 'deploy-vm-arc'
+  name: 'deploy-vm-arc-${nameSuffix}'
   params: {
     location: location
     vmName: arcVmName

--- a/hack/e2e/infra/modules/vm.bicep
+++ b/hack/e2e/infra/modules/vm.bicep
@@ -120,12 +120,19 @@ resource vm 'Microsoft.Compute/virtualMachines@2024-03-01' = {
         version: imageVersion
       }
       osDisk: {
+        name: '${vmName}-osdisk'
         createOption: 'FromImage'
+        deleteOption: 'Delete'
         managedDisk: { storageAccountType: 'StandardSSD_LRS' }
       }
     }
     networkProfile: {
-      networkInterfaces: [ { id: nic.id } ]
+      networkInterfaces: [
+        {
+          id: nic.id
+          properties: { deleteOption: 'Delete' }
+        }
+      ]
     }
   }
 }

--- a/hack/e2e/lib/cleanup.sh
+++ b/hack/e2e/lib/cleanup.sh
@@ -178,6 +178,535 @@ collect_logs() {
 # ---------------------------------------------------------------------------
 # cleanup - Delete Azure resources
 # ---------------------------------------------------------------------------
+_deployment_state() {
+  local resource_group="$1" deployment_name="$2" subscription_id="$3"
+  local deployments
+
+  deployments="$(az deployment group list \
+    --resource-group "${resource_group}" \
+    --subscription "${subscription_id}" \
+    --output json 2>/dev/null)" || return 1
+  jq -er --arg name "${deployment_name}" '
+    if type != "array" then error("deployment list must be an array")
+    else ([.[] | select(.name == $name)][0].properties.provisioningState // "")
+    end
+  ' <<<"${deployments}"
+}
+
+_wait_for_deployment_operations() {
+  local resource_group="$1" deployment_name="$2" subscription_id="$3" deadline="$4"
+  local operations
+
+  while (( SECONDS < deadline )); do
+    if ! operations="$(az deployment operation group list \
+      --resource-group "${resource_group}" \
+      --name "${deployment_name}" \
+      --subscription "${subscription_id}" \
+      --output json 2>/dev/null)"; then
+      log_error "Failed to query operations for ARM deployment '${deployment_name}'"
+      return 1
+    fi
+    if jq -e '
+      type == "array" and all(.[].properties.provisioningState;
+        . == "Succeeded" or . == "Failed" or . == "Canceled" or
+        . == "Cancelled" or . == "Skipped")
+    ' <<<"${operations}" >/dev/null; then
+      return 0
+    fi
+    sleep "${E2E_CLEANUP_POLL_INTERVAL:-5}"
+  done
+
+  log_error "ARM deployment '${deployment_name}' still has active operations after the cleanup timeout"
+  return 1
+}
+
+_cancel_active_deployment() {
+  local resource_group="$1" deployment_name="$2" subscription_id="$3"
+  local deadline="${4:-$((SECONDS + E2E_CLEANUP_TIMEOUT))}"
+  local deployment_state
+
+  [[ -n "${deployment_name}" ]] || return 0
+  if ! deployment_state="$(_deployment_state \
+    "${resource_group}" "${deployment_name}" "${subscription_id}")"; then
+    log_error "Failed to query ARM deployment '${deployment_name}'; refusing to race resource deletion"
+    return 1
+  fi
+
+  case "${deployment_state}" in
+    ""|Succeeded|Failed|Canceled|Cancelled)
+      [[ -z "${deployment_state}" ]] || _wait_for_deployment_operations \
+        "${resource_group}" "${deployment_name}" "${subscription_id}" "${deadline}"
+      return
+      ;;
+  esac
+
+  log_warn "ARM deployment '${deployment_name}' is ${deployment_state}; canceling it before resource deletion"
+  az deployment group cancel \
+    --resource-group "${resource_group}" \
+    --name "${deployment_name}" \
+    --subscription "${subscription_id}" \
+    --output none 2>/dev/null || true
+
+  while (( SECONDS < deadline )); do
+    if ! deployment_state="$(_deployment_state \
+      "${resource_group}" "${deployment_name}" "${subscription_id}")"; then
+      log_error "Failed to query ARM deployment '${deployment_name}' after requesting cancellation"
+      return 1
+    fi
+    case "${deployment_state}" in
+      ""|Succeeded|Failed|Canceled|Cancelled)
+        log_info "ARM deployment is terminal: ${deployment_state:-not found}"
+        [[ -z "${deployment_state}" ]] || _wait_for_deployment_operations \
+          "${resource_group}" "${deployment_name}" "${subscription_id}" "${deadline}"
+        return
+        ;;
+    esac
+    sleep "${E2E_CLEANUP_POLL_INTERVAL:-5}"
+  done
+
+  log_error "ARM deployment '${deployment_name}' remained ${deployment_state} after ${E2E_CLEANUP_TIMEOUT}s"
+  return 1
+}
+
+_remaining_cleanup_timeout() {
+  local deadline="$1"
+  local remaining=$((deadline - SECONDS))
+  (( remaining > 0 )) || return 1
+  printf '%s\n' "${remaining}"
+}
+
+_azure_query_can_attempt() {
+  local attempt="$1" deadline="${2:-0}"
+
+  (( attempt < 5 && (deadline <= 0 || SECONDS < deadline) ))
+}
+
+_sleep_before_azure_query_retry() {
+  local deadline="${1:-0}"
+  local delay="${E2E_CLEANUP_POLL_INTERVAL:-5}" remaining whole_seconds
+
+  if [[ ! "${delay}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    log_error "Invalid E2E_CLEANUP_POLL_INTERVAL '${delay}'"
+    return 1
+  fi
+  if (( deadline > 0 )); then
+    remaining=$((deadline - SECONDS))
+    (( remaining > 0 )) || return 1
+    whole_seconds="${delay%%.*}"
+    if (( whole_seconds >= remaining )); then
+      delay="${remaining}"
+    fi
+  fi
+  sleep "${delay}"
+}
+
+_azure_error_summary() {
+  local message="$1"
+  message="${message//$'\r'/ }"
+  message="${message//$'\n'/ }"
+  printf '%.500s\n' "${message}"
+}
+
+_azure_error_is_authorization_failure() {
+  local message="${1,,}"
+
+  [[ "${message}" == *forbidden* ||
+    "${message}" == *unauthorized* ||
+    "${message}" == *authorizationfailed* ||
+    "${message}" == *authorizationpermissionmismatch* ||
+    "${message}" == *authenticationfailed* ||
+    "${message}" == *invalidauthenticationtoken* ||
+    "${message}" == *expiredauthenticationtoken* ||
+    "${message}" == *"does not have authorization"* ||
+    "${message}" == *"permission denied"* ||
+    "${message}" == *"insufficient privileges"* ]]
+}
+
+_azure_error_is_resource_group_not_found() {
+  [[ "$1" == *ResourceGroupNotFound* ]]
+}
+
+_group_exists_with_retry() {
+  local group_name="$1" subscription_id="$2" deadline="${3:-0}"
+  local exists attempt=0 last_error="" error_file
+
+  if ! error_file="$(mktemp "${E2E_WORK_DIR}/azure-group-query.XXXXXX")"; then
+    log_error "Failed to create temporary Azure query diagnostics"
+    return 1
+  fi
+
+  while _azure_query_can_attempt "${attempt}" "${deadline}"; do
+    attempt=$((attempt + 1))
+    : > "${error_file}"
+    if exists="$(az group exists \
+      --name "${group_name}" \
+      --subscription "${subscription_id}" \
+      --output tsv 2>"${error_file}")"; then
+      case "${exists}" in
+        true|false)
+          rm -f -- "${error_file}"
+          printf '%s\n' "${exists}"
+          return 0
+          ;;
+        *)
+          last_error="Azure CLI returned an unexpected resource-group existence result: ${exists}"
+          ;;
+      esac
+    else
+      last_error="$(<"${error_file}")"
+      # ARM can report the resource as not found while `az group exists` still
+      # exits nonzero during asynchronous AKS-managed resource-group deletion.
+      if _azure_error_is_resource_group_not_found "${last_error}"; then
+        rm -f -- "${error_file}"
+        printf 'false\n'
+        return 0
+      fi
+    fi
+    if _azure_error_is_authorization_failure "${last_error}"; then
+      break
+    fi
+    if ! _azure_query_can_attempt "${attempt}" "${deadline}" || \
+      ! _sleep_before_azure_query_retry "${deadline}"; then
+      break
+    fi
+  done
+
+  rm -f -- "${error_file}"
+  log_error "Failed to determine whether resource group '${group_name}' exists after ${attempt} attempts" >&2
+  if [[ -n "${last_error}" ]]; then
+    log_error "Last Azure CLI error: $(_azure_error_summary "${last_error}")" >&2
+  fi
+  return 1
+}
+
+_resource_inventory() {
+  local resource_group="$1" subscription_id="$2" run_id="${3:-}" deadline="${4:-0}"
+  local resource_json attempt=0 last_error="" error_file
+
+  if ! error_file="$(mktemp "${E2E_WORK_DIR}/azure-resource-query.XXXXXX")"; then
+    log_error "Failed to create temporary Azure query diagnostics"
+    return 1
+  fi
+
+  while _azure_query_can_attempt "${attempt}" "${deadline}"; do
+    attempt=$((attempt + 1))
+    : > "${error_file}"
+    if resource_json="$(az resource list \
+      --resource-group "${resource_group}" \
+      --subscription "${subscription_id}" \
+      --output json 2>"${error_file}")"; then
+      if resource_json="$(jq -ce --arg run_id "${run_id}" '
+        if type != "array" then error("resource list must be an array")
+        elif $run_id == "" then .
+        else [.[] | select((.tags // {})["github-run"] == $run_id)]
+        end
+      ' <<<"${resource_json}")"; then
+        rm -f -- "${error_file}"
+        printf '%s\n' "${resource_json}"
+        return 0
+      fi
+      last_error="Azure CLI returned a malformed resource inventory"
+    else
+      last_error="$(<"${error_file}")"
+    fi
+    if _azure_error_is_authorization_failure "${last_error}"; then
+      break
+    fi
+    if ! _azure_query_can_attempt "${attempt}" "${deadline}" || \
+      ! _sleep_before_azure_query_retry "${deadline}"; then
+      break
+    fi
+  done
+
+  rm -f -- "${error_file}"
+  log_error "Failed to inventory resources in '${resource_group}' after ${attempt} attempts" >&2
+  if [[ -n "${last_error}" ]]; then
+    log_error "Last Azure CLI error: $(_azure_error_summary "${last_error}")" >&2
+  fi
+  return 1
+}
+
+_cleanup_resource_owner() {
+  local name_suffix="${1:-}" owner
+  if [[ -z "${name_suffix}" ]]; then
+    name_suffix="$(state_get name_suffix)"
+  fi
+  owner="$(state_get resource_owner)"
+  if [[ -n "${owner}" ]]; then
+    if [[ -z "${name_suffix}" || "${owner}" != "${name_suffix}" ]]; then
+      log_error "Refusing tagged cleanup with resource owner '${owner}' that does not match E2E name suffix '${name_suffix}'"
+      return 1
+    fi
+    printf '%s\n' "${owner}"
+    return 0
+  fi
+
+  # State written before resource_owner was introduced used run_id as the
+  # github-run tag value. Keep those deployments recoverable.
+  state_get run_id "${GITHUB_RUN_ID:-}"
+}
+
+_is_expected_legacy_tagged_resource() {
+  local resource_type="${1,,}" resource_name="$2" name_suffix="$3"
+  local role vm_prefix
+
+  [[ -n "${resource_name}" && -n "${name_suffix}" ]] || return 1
+  case "${resource_type}" in
+    microsoft.compute/disks)
+      for role in msi token offline kubeadm arc; do
+        vm_prefix="vm-e2e-${role}-${name_suffix}"
+        if [[ "${resource_name}" == "${vm_prefix}-osdisk" || \
+              "${resource_name}" == "${vm_prefix}"_OsDisk_* ]]; then
+          return 0
+        fi
+      done
+      ;;
+    microsoft.network/networkinterfaces)
+      for role in msi token offline kubeadm arc; do
+        [[ "${resource_name}" == "vm-e2e-${role}-${name_suffix}-nic" ]] && return 0
+      done
+      ;;
+    microsoft.network/publicipaddresses)
+      for role in msi token offline kubeadm arc; do
+        [[ "${resource_name}" == "vm-e2e-${role}-${name_suffix}-pip" ]] && return 0
+      done
+      ;;
+    microsoft.network/virtualnetworks)
+      [[ "${resource_name}" == "vnet-e2e-${name_suffix}" ]] && return 0
+      ;;
+    microsoft.network/networksecuritygroups)
+      [[ "${resource_name}" == "nsg-e2e-${name_suffix}" ]] && return 0
+      ;;
+  esac
+  return 1
+}
+
+_legacy_implicit_os_disk_ids_from_inventory() {
+  local resource_json="$1"
+  shift
+  local resource_rows resource_type resource_name id vm_name
+
+  if ! resource_rows="$(jq -r '
+    if type != "array" then error("resource list must be an array")
+    else .[] | [(.type // ""), (.name // ""), (.id // "")] |
+      if all(.[]; type == "string") then @tsv
+      else error("resource type, name, and ID must be strings")
+      end
+    end
+  ' <<<"${resource_json}")"; then
+    log_error "Azure returned an invalid resource inventory while locating legacy OS disks"
+    return 1
+  fi
+
+  while IFS=$'\t' read -r resource_type resource_name id; do
+    [[ "${resource_type,,}" == "microsoft.compute/disks" && -n "${id}" ]] || continue
+    for vm_name in "$@"; do
+      [[ -n "${vm_name}" ]] || continue
+      if [[ "${resource_name}" == "${vm_name}"_OsDisk_* ]]; then
+        printf '%s\n' "${id}"
+        break
+      fi
+    done
+  done <<<"${resource_rows}"
+}
+
+_legacy_implicit_os_disk_ids() {
+  local resource_group="$1" subscription_id="$2" deadline="$3" resource_json
+  shift 3
+
+  (( $# > 0 )) || return 0
+  if ! resource_json="$(_resource_inventory "${resource_group}" "${subscription_id}" "" "${deadline}")"; then
+    return 1
+  fi
+  _legacy_implicit_os_disk_ids_from_inventory "${resource_json}" "$@"
+}
+
+_delete_legacy_implicit_os_disks() {
+  local resource_group="$1" subscription_id="$2" deadline="$3" disk_ids disk_id
+  shift 3
+
+  if ! disk_ids="$(_legacy_implicit_os_disk_ids "${resource_group}" "${subscription_id}" "${deadline}" "$@")"; then
+    return 1
+  fi
+  while IFS= read -r disk_id; do
+    [[ -n "${disk_id}" ]] || continue
+    log_info "Deleting residual legacy OS disk: ${disk_id##*/}"
+    az resource delete --ids "${disk_id}" --subscription "${subscription_id}" --output none 2>/dev/null || true
+  done <<<"${disk_ids}"
+}
+
+_validate_expected_cleanup_name() {
+  local description="$1" actual="$2" expected="$3"
+
+  [[ -n "${actual}" ]] || return 0
+  if [[ "${actual}" != "${expected}" ]]; then
+    log_error "Refusing to delete unexpected ${description} '${actual}'"
+    log_error "Expected '${expected}' for this E2E deployment"
+    return 1
+  fi
+}
+
+_validate_cleanup_target_names() {
+  local name_suffix="$1" deployment_name="$2" cluster_name="$3" node_resource_group="$4"
+  local msi_vm_name="$5" token_vm_name="$6" offline_vm_name="$7" kubeadm_vm_name="$8"
+  local arc_vm_name="$9" arc_machine_name="${10}" vnet_name="${11}" nsg_name="${12}"
+  local resource_group="${13}" location="${14}"
+
+  if [[ -z "${name_suffix}" ]]; then
+    if [[ -n "${deployment_name}${cluster_name}${node_resource_group}${msi_vm_name}${token_vm_name}${offline_vm_name}${kubeadm_vm_name}${arc_vm_name}${arc_machine_name}${vnet_name}${nsg_name}" ]]; then
+      log_error "Cannot validate persisted cleanup targets without an E2E name suffix"
+      return 1
+    fi
+    return 0
+  fi
+
+  _validate_expected_cleanup_name "ARM deployment" "${deployment_name}" "e2e-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "AKS cluster" "${cluster_name}" "aks-e2e-${name_suffix}" || return 1
+  _validate_expected_node_resource_group \
+    "${node_resource_group}" "${name_suffix}" "${resource_group}" "${cluster_name}" "${location}" || return 1
+  _validate_expected_cleanup_name "MSI VM" "${msi_vm_name}" "vm-e2e-msi-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "token VM" "${token_vm_name}" "vm-e2e-token-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "offline VM" "${offline_vm_name}" "vm-e2e-offline-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "kubeadm VM" "${kubeadm_vm_name}" "vm-e2e-kubeadm-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "Arc VM" "${arc_vm_name}" "vm-e2e-arc-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "Arc machine" "${arc_machine_name}" "vm-e2e-arc-${name_suffix}-connected" || return 1
+  _validate_expected_cleanup_name "virtual network" "${vnet_name}" "vnet-e2e-${name_suffix}" || return 1
+  _validate_expected_cleanup_name "network security group" "${nsg_name}" "nsg-e2e-${name_suffix}" || return 1
+}
+
+_validate_expected_node_resource_group() {
+  local node_resource_group="$1" name_suffix="$2"
+  local resource_group="${3:-}" cluster_name="${4:-}" location="${5:-}"
+
+  [[ -n "${node_resource_group}" ]] || return 0
+  if [[ -z "${name_suffix}" ]]; then
+    log_error "Cannot validate AKS node resource group '${node_resource_group}' without an E2E name suffix"
+    return 1
+  fi
+
+  local expected_node_resource_group="MC_aksflex-e2e-${name_suffix}"
+  if [[ "${node_resource_group}" == "${expected_node_resource_group}" ]]; then
+    return 0
+  fi
+
+  # E2E state written before the template assigned a deterministic node
+  # resource group uses AKS's documented default naming convention.
+  local legacy_node_resource_group=""
+  if [[ -n "${resource_group}" && -n "${cluster_name}" && -n "${location}" ]]; then
+    legacy_node_resource_group="MC_${resource_group}_${cluster_name}_${location}"
+    if [[ "${node_resource_group}" == "${legacy_node_resource_group}" ]]; then
+      return 0
+    fi
+  fi
+
+  log_error "Refusing to delete unexpected AKS node resource group '${node_resource_group}'"
+  if [[ -n "${legacy_node_resource_group}" ]]; then
+    log_error "Expected '${expected_node_resource_group}' or legacy '${legacy_node_resource_group}' for this E2E deployment"
+  else
+    log_error "Expected '${expected_node_resource_group}' for this E2E deployment"
+  fi
+  return 1
+}
+
+_delete_node_resource_group() {
+  local node_resource_group="$1" subscription_id="$2" deadline="$3"
+  local delete_error error_file exists wait_timeout
+
+  [[ -n "${node_resource_group}" ]] || return 0
+  if ! exists="$(_group_exists_with_retry "${node_resource_group}" "${subscription_id}" "${deadline}")"; then
+    log_error "Failed to determine whether AKS node resource group '${node_resource_group}' exists"
+    return 1
+  fi
+  case "${exists}" in
+    false)
+      return 0
+      ;;
+    true)
+      ;;
+    *)
+      log_error "Unexpected existence result for AKS node resource group '${node_resource_group}': ${exists}"
+      return 1
+      ;;
+  esac
+
+  if ! error_file="$(mktemp "${E2E_WORK_DIR}/azure-group-delete.XXXXXX")"; then
+    log_error "Failed to create temporary Azure deletion diagnostics"
+    return 1
+  fi
+  if ! az group delete --name "${node_resource_group}" --subscription "${subscription_id}" \
+    --yes --no-wait --output none 2>"${error_file}"; then
+    delete_error="$(<"${error_file}")"
+    rm -f -- "${error_file}"
+    if _azure_error_is_resource_group_not_found "${delete_error}"; then
+      return 0
+    fi
+    log_error "Failed to delete orphaned AKS node resource group '${node_resource_group}'"
+    if [[ -n "${delete_error}" ]]; then
+      log_error "Azure CLI error: $(_azure_error_summary "${delete_error}")"
+    fi
+    return 1
+  fi
+  rm -f -- "${error_file}"
+  if ! wait_timeout="$(_remaining_cleanup_timeout "${deadline}")"; then
+    log_error "Cleanup deadline reached before deleting AKS node resource group '${node_resource_group}'"
+    return 1
+  fi
+  if ! az group wait --name "${node_resource_group}" --subscription "${subscription_id}" \
+    --deleted --interval 10 --timeout "${wait_timeout}" 2>/dev/null; then
+    log_error "AKS node resource group still exists after cleanup timeout: ${node_resource_group}"
+    return 1
+  fi
+}
+
+_delete_tagged_resources() {
+  local resource_group="$1" run_id="$2" subscription_id="$3" legacy_name_suffix="${4:-}" deadline="${5:-0}"
+  local resource_json resource_type resource_name id
+  local -a resource_types=(
+    "Microsoft.Compute/disks"
+    "Microsoft.Network/networkInterfaces"
+    "Microsoft.Network/publicIPAddresses"
+    "Microsoft.Network/virtualNetworks"
+    "Microsoft.Network/networkSecurityGroups"
+  )
+
+  [[ -n "${run_id}" ]] || return 0
+  if ! resource_json="$(_resource_inventory "${resource_group}" "${subscription_id}" "${run_id}" "${deadline}")"; then
+    log_error "Failed to list E2E resources tagged github-run=${run_id}"
+    return 1
+  fi
+
+  for resource_type in "${resource_types[@]}"; do
+    while IFS=$'\t' read -r resource_name id; do
+      [[ -n "${id}" ]] || continue
+      if [[ -n "${legacy_name_suffix}" ]] && \
+        ! _is_expected_legacy_tagged_resource "${resource_type}" "${resource_name}" "${legacy_name_suffix}"; then
+        log_warn "Ignoring legacy-tagged ${resource_type} outside this E2E attempt: ${resource_name}"
+        continue
+      fi
+      log_info "Deleting residual ${resource_type}: ${id##*/}"
+      az resource delete --ids "${id}" --subscription "${subscription_id}" --output none 2>/dev/null || true
+    done < <(jq -r --arg resource_type "${resource_type}" \
+      '.[] | select((.type | ascii_downcase) == ($resource_type | ascii_downcase)) | [.name, .id] | @tsv' \
+      <<<"${resource_json}")
+  done
+}
+
+_tagged_resource_ids() {
+  local resource_group="$1" run_id="$2" subscription_id="$3" legacy_name_suffix="${4:-}" deadline="${5:-0}"
+  local resource_json resource_type resource_name id
+
+  [[ -n "${run_id}" ]] || return 0
+  resource_json="$(_resource_inventory "${resource_group}" "${subscription_id}" "${run_id}" "${deadline}")" || return 1
+  while IFS=$'\t' read -r resource_type resource_name id; do
+    [[ -n "${id}" ]] || continue
+    if [[ -n "${legacy_name_suffix}" ]] && \
+      ! _is_expected_legacy_tagged_resource "${resource_type}" "${resource_name}" "${legacy_name_suffix}"; then
+      continue
+    fi
+    printf '%s\n' "${id}"
+  done < <(jq -r '.[] | [.type, .name, .id] | @tsv' <<<"${resource_json}")
+}
+
 cleanup() {
   log_section "Cleaning Up Resources"
 
@@ -189,6 +718,8 @@ cleanup() {
   fi
 
   local resource_group cluster_name msi_vm_name token_vm_name offline_vm_name kubeadm_vm_name arc_vm_name arc_machine_name arc_machine_id
+  local subscription_id deployment_name resource_owner persisted_resource_owner legacy_tag_name_suffix
+  local cleanup_failed vnet_name nsg_name name_suffix node_resource_group location cleanup_deadline
   resource_group="$(state_get resource_group)"
   cluster_name="$(state_get cluster_name)"
   msi_vm_name="$(state_get msi_vm_name)"
@@ -197,16 +728,213 @@ cleanup() {
   kubeadm_vm_name="$(state_get kubeadm_vm_name)"
   arc_vm_name="$(state_get arc_vm_name)"
   arc_machine_name="$(state_get arc_machine_name)"
+  subscription_id="$(state_get subscription_id "${AZURE_SUBSCRIPTION_ID:-}")"
   arc_machine_id="$(state_get arc_machine_id)"
-  if [[ -z "${arc_machine_id}" && -n "${arc_machine_name}" ]]; then
-    arc_machine_id="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${resource_group}/providers/Microsoft.HybridCompute/machines/${arc_machine_name}"
-  fi
-  local deployment_name
   deployment_name="$(state_get deployment_name)"
+  persisted_resource_owner="$(state_get resource_owner)"
+  name_suffix="$(state_get name_suffix)"
+  vnet_name="$(state_get vnet_name)"
+  nsg_name="$(state_get nsg_name)"
+  node_resource_group="$(state_get node_resource_group)"
+  location="$(state_get location)"
+  if [[ -z "${name_suffix}" && "${cluster_name}" == aks-e2e-* ]]; then
+    name_suffix="${cluster_name#aks-e2e-}"
+  fi
+  if [[ -z "${deployment_name}" && -n "${name_suffix}" ]]; then
+    deployment_name="e2e-${name_suffix}"
+  fi
+  if [[ -z "${vnet_name}" && -n "${name_suffix}" ]]; then
+    vnet_name="vnet-e2e-${name_suffix}"
+  fi
+  if [[ -z "${nsg_name}" && -n "${name_suffix}" ]]; then
+    nsg_name="nsg-e2e-${name_suffix}"
+  fi
+  if [[ -z "${node_resource_group}" && -z "${persisted_resource_owner}" && \
+        -n "${resource_group}" && -n "${cluster_name}" && -n "${location}" ]]; then
+    node_resource_group="MC_${resource_group}_${cluster_name}_${location}"
+  fi
+  if ! resource_owner="$(_cleanup_resource_owner "${name_suffix}")"; then
+    return 1
+  fi
+  legacy_tag_name_suffix=""
+  if [[ -z "${persisted_resource_owner}" && -n "${resource_owner}" ]]; then
+    if [[ -z "${name_suffix}" ]]; then
+      log_error "Cannot safely clean resources with a legacy run tag without an E2E name suffix"
+      return 1
+    fi
+    legacy_tag_name_suffix="${name_suffix}"
+  fi
+  cleanup_failed=0
+  cleanup_deadline=$((SECONDS + E2E_CLEANUP_TIMEOUT))
 
   if [[ -z "${resource_group}" ]]; then
-    log_warn "No resource group in state; nothing to clean up"
-    return 0
+    if [[ ! -f "${E2E_STATE_FILE}" ]] || jq -e 'length == 0' "${E2E_STATE_FILE}" >/dev/null 2>&1; then
+      log_warn "No resource group in state; nothing to clean up"
+      return 0
+    fi
+    log_error "State is nonempty but has no resource_group; refusing to declare cleanup complete"
+    return 1
+  fi
+
+  local resource_group_exists
+  if ! resource_group_exists="$(_group_exists_with_retry \
+    "${resource_group}" "${subscription_id}" "${cleanup_deadline}")"; then
+    log_error "Failed to determine whether resource group '${resource_group}' exists"
+    return 1
+  fi
+
+  if ! _validate_cleanup_target_names \
+    "${name_suffix}" "${deployment_name}" "${cluster_name}" "${node_resource_group}" \
+    "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" "${kubeadm_vm_name}" \
+    "${arc_vm_name}" "${arc_machine_name}" "${vnet_name}" "${nsg_name}" \
+    "${resource_group}" "${location}"; then
+    return 1
+  fi
+
+  if [[ -n "${arc_machine_name}" ]]; then
+    local expected_arc_machine_id="/subscriptions/${subscription_id}/resourceGroups/${resource_group}/providers/Microsoft.HybridCompute/machines/${arc_machine_name}"
+    if [[ -n "${arc_machine_id}" && "${arc_machine_id,,}" != "${expected_arc_machine_id,,}" ]]; then
+      log_error "Refusing to delete Arc machine with an unexpected persisted resource ID: ${arc_machine_id}"
+      return 1
+    fi
+    # The ID is completely determined by other state fields. Reconstructing it
+    # avoids trusting a redundant deletion target from stale or damaged state.
+    arc_machine_id="${expected_arc_machine_id}"
+  elif [[ -n "${arc_machine_id}" ]]; then
+    log_error "Cannot validate persisted Arc machine resource ID without arc_machine_name"
+    return 1
+  fi
+
+  case "${resource_group_exists}" in
+    false)
+      # The parent group's absence proves the cluster is gone, so this is a
+      # safe recovery path for an exact-name-validated orphan node group.
+      if ! _validate_expected_node_resource_group \
+        "${node_resource_group}" "${name_suffix}" "${resource_group}" "${cluster_name}" "${location}"; then
+        return 1
+      fi
+      if ! _delete_node_resource_group "${node_resource_group}" "${subscription_id}" "${cleanup_deadline}"; then
+        return 1
+      fi
+      state_set "lifecycle" "cleaned" || return 1
+      state_set "cleanup_complete" "true" || return 1
+      log_success "Resource group is absent; cleanup is complete"
+      return 0
+      ;;
+    true)
+      ;;
+    *)
+      log_error "Unexpected existence result for resource group '${resource_group}': ${resource_group_exists}"
+      return 1
+      ;;
+  esac
+
+  state_set "cleanup_complete" "false" || return 1
+  state_set "lifecycle" "cleaning" || return 1
+
+  if ! _cancel_active_deployment \
+    "${resource_group}" "${deployment_name}" "${subscription_id}" "${cleanup_deadline}"; then
+    # Deleting while ARM is still provisioning races new resource creation and
+    # can report false success, so preserve state for a later cleanup attempt.
+    state_set "cleanup_complete" "false" || true
+    return 1
+  fi
+
+  # Snapshot IDs that are difficult to recover after deleting their parents.
+  # This supports cleanup of deployments created before deterministic OS-disk
+  # names and delete options were added to the Bicep module.
+  local vm_inventory aks_inventory resource_inventory live_node_resource_group live_cluster_location
+  local vm_name disk_id nic_id nic_output legacy_disk_output
+  local -a managed_disk_ids=() legacy_implicit_os_disk_ids=() nic_ids=()
+  if ! vm_inventory="$(az vm list \
+    --resource-group "${resource_group}" \
+    --subscription "${subscription_id}" \
+    --output json 2>/dev/null)"; then
+    log_error "Failed to inventory E2E VMs before cleanup"
+    return 1
+  fi
+  if ! aks_inventory="$(az aks list \
+    --resource-group "${resource_group}" \
+    --subscription "${subscription_id}" \
+    --output json 2>/dev/null)"; then
+    log_error "Failed to inventory E2E AKS clusters before cleanup"
+    return 1
+  fi
+  if ! jq -e 'type == "array"' <<<"${vm_inventory}" >/dev/null || \
+    ! jq -e 'type == "array"' <<<"${aks_inventory}" >/dev/null; then
+    log_error "Azure returned an invalid VM or AKS cleanup inventory"
+    return 1
+  fi
+  if ! resource_inventory="$(_resource_inventory \
+    "${resource_group}" "${subscription_id}" "" "${cleanup_deadline}")"; then
+    log_error "Failed to inventory E2E resources before cleanup"
+    return 1
+  fi
+  if ! legacy_disk_output="$(_legacy_implicit_os_disk_ids_from_inventory \
+    "${resource_inventory}" \
+    "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" \
+    "${kubeadm_vm_name}" "${arc_vm_name}")"; then
+    return 1
+  fi
+  while IFS= read -r disk_id; do
+    [[ -z "${disk_id}" ]] || legacy_implicit_os_disk_ids+=("${disk_id}")
+  done <<<"${legacy_disk_output}"
+  for vm_name in "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" "${kubeadm_vm_name}" "${arc_vm_name}"; do
+    [[ -n "${vm_name}" ]] || continue
+    if ! disk_id="$(jq -r --arg name "${vm_name}" \
+      '.[] | select(.name == $name) | .storageProfile.osDisk.managedDisk.id // empty' \
+      <<<"${vm_inventory}")"; then
+      log_error "Failed to inspect OS disk for VM '${vm_name}'"
+      return 1
+    fi
+    [[ -z "${disk_id}" ]] || managed_disk_ids+=("${disk_id}")
+    if ! nic_output="$(jq -r --arg name "${vm_name}" \
+      '.[] | select(.name == $name) | .networkProfile.networkInterfaces[]?.id // empty' \
+      <<<"${vm_inventory}")"; then
+      log_error "Failed to inspect network interfaces for VM '${vm_name}'"
+      return 1
+    fi
+    while read -r nic_id; do
+      [[ -z "${nic_id}" ]] || nic_ids+=("${nic_id}")
+    done <<<"${nic_output}"
+  done
+  if ! live_node_resource_group="$(jq -r --arg name "${cluster_name}" \
+    '.[] | select(.name == $name) | .nodeResourceGroup // empty' \
+    <<<"${aks_inventory}")"; then
+    log_error "Failed to inspect the AKS node resource group"
+    return 1
+  fi
+  if ! live_cluster_location="$(jq -r --arg name "${cluster_name}" \
+    '.[] | select(.name == $name) | .location // empty' \
+    <<<"${aks_inventory}")"; then
+    log_error "Failed to inspect the AKS cluster location"
+    return 1
+  fi
+  if [[ -n "${live_cluster_location}" ]]; then
+    if [[ -n "${location}" && "${location,,}" != "${live_cluster_location,,}" ]]; then
+      log_error "Refusing cleanup because live AKS location '${live_cluster_location}' differs from state '${location}'"
+      return 1
+    fi
+    location="${live_cluster_location}"
+    state_set "location" "${location}" || return 1
+  fi
+  if [[ -n "${live_node_resource_group}" ]]; then
+    if ! _validate_expected_node_resource_group \
+      "${live_node_resource_group}" "${name_suffix}" "${resource_group}" "${cluster_name}" "${location}"; then
+      return 1
+    fi
+    if [[ -n "${node_resource_group}" && "${node_resource_group}" != "${live_node_resource_group}" ]]; then
+      log_warn "Live AKS node resource group differs from state; using the live cluster value '${live_node_resource_group}'"
+    fi
+    node_resource_group="${live_node_resource_group}"
+    state_set "node_resource_group" "${node_resource_group}" || return 1
+  elif ! _validate_expected_node_resource_group \
+    "${node_resource_group}" "${name_suffix}" "${resource_group}" "${cluster_name}" "${location}"; then
+    return 1
+  fi
+  if [[ -n "${node_resource_group}" && "${node_resource_group}" == "${resource_group}" ]]; then
+    log_error "Refusing to delete parent resource group as an AKS node resource group"
+    return 1
   fi
 
   # Arc lifecycle is external to Flex Node. Remove the E2E-owned Arc resource
@@ -216,50 +944,209 @@ cleanup() {
     az rest --method delete --url "https://management.azure.com${arc_machine_id}?api-version=2024-07-10" --output none 2>/dev/null || true
   fi
 
-  # Delete VMs first (faster than waiting for full RG delete)
-  log_info "[2/8] Deleting MSI VM: ${msi_vm_name}..."
-  az vm delete --resource-group "${resource_group}" --name "${msi_vm_name}" \
-    --force-deletion yes --yes --no-wait 2>/dev/null || true
+  # Start independent VM and AKS deletes together, then wait for all of them
+  # before removing their network dependencies.
+  for vm_name in "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" "${kubeadm_vm_name}" "${arc_vm_name}"; do
+    [[ -n "${vm_name}" ]] || continue
+    log_info "Deleting VM: ${vm_name}..."
+    az vm delete --resource-group "${resource_group}" --name "${vm_name}" \
+      --subscription "${subscription_id}" --force-deletion yes --yes --no-wait 2>/dev/null || true
+  done
 
-  log_info "[3/8] Deleting Token VM: ${token_vm_name}..."
-  az vm delete --resource-group "${resource_group}" --name "${token_vm_name}" \
-    --force-deletion yes --yes --no-wait 2>/dev/null || true
-
-  log_info "[4/8] Deleting Offline VM: ${offline_vm_name}..."
-  az vm delete --resource-group "${resource_group}" --name "${offline_vm_name}" \
-    --force-deletion yes --yes --no-wait 2>/dev/null || true
-
-  log_info "[5/8] Deleting Kubeadm VM: ${kubeadm_vm_name}..."
-  az vm delete --resource-group "${resource_group}" --name "${kubeadm_vm_name}" \
-    --force-deletion yes --yes --no-wait 2>/dev/null || true
-
-  log_info "[6/8] Deleting Arc VM: ${arc_vm_name}..."
-  az vm delete --resource-group "${resource_group}" --name "${arc_vm_name}" \
-    --force-deletion yes --yes --no-wait 2>/dev/null || true
-
-  # Clean up leftover networking resources tied to our deployment
-  log_info "[7/8] Cleaning up networking resources..."
-  local run_id="${GITHUB_RUN_ID:-}"
-  if [[ -n "${run_id}" ]]; then
-    local resource_ids
-    for res_type in networkInterfaces publicIPAddresses networkSecurityGroups disks; do
-      resource_ids="$(az resource list --resource-group "${resource_group}" \
-        --query "[?tags.\"github-run\"=='${run_id}' && contains(type, '${res_type}')].id" \
-        -o tsv 2>/dev/null || true)"
-      while read -r id; do
-        [[ -n "${id}" ]] || continue
-        az resource delete --ids "${id}" --no-wait 2>/dev/null || true
-      done <<<"${resource_ids}"
-    done
+  if [[ -n "${cluster_name}" ]]; then
+    log_info "Deleting AKS cluster: ${cluster_name}..."
+    az aks delete --resource-group "${resource_group}" --name "${cluster_name}" \
+      --subscription "${subscription_id}" --yes --no-wait 2>/dev/null || true
   fi
 
-  log_info "[8/8] Deleting AKS cluster: ${cluster_name}..."
-  az aks delete --resource-group "${resource_group}" --name "${cluster_name}" \
-    --yes --no-wait 2>/dev/null || true
+  for vm_name in "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" "${kubeadm_vm_name}" "${arc_vm_name}"; do
+    [[ -n "${vm_name}" ]] || continue
+    local wait_timeout
+    if ! wait_timeout="$(_remaining_cleanup_timeout "${cleanup_deadline}")"; then
+      log_error "Cleanup deadline reached while waiting for VMs"
+      cleanup_failed=1
+      break
+    fi
+    if ! az vm wait --resource-group "${resource_group}" --name "${vm_name}" \
+      --subscription "${subscription_id}" --deleted --interval 10 --timeout "${wait_timeout}" 2>/dev/null; then
+      if az vm show --resource-group "${resource_group}" --name "${vm_name}" \
+        --subscription "${subscription_id}" --output none 2>/dev/null; then
+        log_error "VM still exists after cleanup timeout: ${vm_name}"
+        cleanup_failed=1
+      fi
+    fi
+    az disk delete --resource-group "${resource_group}" --name "${vm_name}-osdisk" \
+      --subscription "${subscription_id}" --yes --output none 2>/dev/null || true
+    az network nic delete --resource-group "${resource_group}" --name "${vm_name}-nic" \
+      --subscription "${subscription_id}" --output none 2>/dev/null || true
+    az network public-ip delete --resource-group "${resource_group}" --name "${vm_name}-pip" \
+      --subscription "${subscription_id}" --output none 2>/dev/null || true
+  done
 
-  # If we created the VNet/NSG via Bicep, they'll be cleaned up when no
-  # resources reference them, or on next deployment.  We don't delete the
-  # resource group itself since it may be shared.
+  for disk_id in "${managed_disk_ids[@]}" "${legacy_implicit_os_disk_ids[@]}"; do
+    az resource delete --ids "${disk_id}" --subscription "${subscription_id}" --output none 2>/dev/null || true
+  done
+  for nic_id in "${nic_ids[@]}"; do
+    az resource delete --ids "${nic_id}" --subscription "${subscription_id}" --output none 2>/dev/null || true
+  done
 
-  log_success "Cleanup initiated (async deletes in progress)"
+  if [[ -n "${cluster_name}" ]]; then
+    local aks_wait_timeout
+    if ! aks_wait_timeout="$(_remaining_cleanup_timeout "${cleanup_deadline}")"; then
+      log_error "Cleanup deadline reached before AKS deletion completed"
+      cleanup_failed=1
+    elif ! az aks wait \
+      --resource-group "${resource_group}" --name "${cluster_name}" \
+      --subscription "${subscription_id}" --deleted --interval 10 \
+      --timeout "${aks_wait_timeout}" 2>/dev/null; then
+      cleanup_failed=1
+      if az aks show --resource-group "${resource_group}" --name "${cluster_name}" \
+        --subscription "${subscription_id}" --output none 2>/dev/null; then
+        log_error "AKS cluster still exists after cleanup timeout: ${cluster_name}"
+      else
+        log_error "Failed to confirm AKS cluster deletion after the wait command failed: ${cluster_name}"
+      fi
+    fi
+  fi
+
+  # AKS owns the managed node resource group's lifecycle and deletes it with
+  # the cluster. Avoid querying or deleting that sibling group directly: the
+  # least-privilege cleanup identity may only have access to the parent group.
+  # https://learn.microsoft.com/azure/aks/faq#can-i-restore-my-cluster-after-i-delete-it-
+
+  if [[ -n "${arc_machine_id}" ]]; then
+    local arc_wait_timeout
+    if ! arc_wait_timeout="$(_remaining_cleanup_timeout "${cleanup_deadline}")"; then
+      log_error "Cleanup deadline reached before Arc machine deletion completed"
+      cleanup_failed=1
+    elif ! az resource wait --ids "${arc_machine_id}" --subscription "${subscription_id}" \
+      --api-version 2024-07-10 --deleted --interval 10 --timeout "${arc_wait_timeout}" \
+      --output none 2>/dev/null; then
+      log_error "Arc machine still exists after cleanup timeout: ${arc_machine_id}"
+      cleanup_failed=1
+    fi
+  fi
+
+  [[ -z "${vnet_name}" ]] || az network vnet delete \
+    --resource-group "${resource_group}" --name "${vnet_name}" \
+    --subscription "${subscription_id}" --output none 2>/dev/null || true
+  [[ -z "${nsg_name}" ]] || az network nsg delete \
+    --resource-group "${resource_group}" --name "${nsg_name}" \
+    --subscription "${subscription_id}" --output none 2>/dev/null || true
+
+  log_info "[8/8] Cleaning up tagged network and disk resources..."
+  local remaining_ids legacy_remaining_ids empty_inventories=0
+  for _ in 1 2 3 4; do
+    if ! _delete_tagged_resources "${resource_group}" "${resource_owner}" "${subscription_id}" "${legacy_tag_name_suffix}" "${cleanup_deadline}"; then
+      cleanup_failed=1
+      break
+    fi
+    # Old VM deployments let Azure choose names such as
+    # <vm>_OsDisk_1_<hash>. Those disks can be detached, untagged, and absent
+    # from `az vm list`, so rediscover and retry them from the full RG inventory.
+    for disk_id in "${legacy_implicit_os_disk_ids[@]}"; do
+      az resource delete --ids "${disk_id}" --subscription "${subscription_id}" --output none 2>/dev/null || true
+    done
+    if ! _delete_legacy_implicit_os_disks \
+      "${resource_group}" "${subscription_id}" "${cleanup_deadline}" \
+      "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" \
+      "${kubeadm_vm_name}" "${arc_vm_name}"; then
+      log_error "Failed to delete legacy implicit OS disks"
+      cleanup_failed=1
+      break
+    fi
+    if ! remaining_ids="$(_tagged_resource_ids "${resource_group}" "${resource_owner}" "${subscription_id}" "${legacy_tag_name_suffix}" "${cleanup_deadline}")"; then
+      log_error "Failed to verify tagged-resource deletion"
+      cleanup_failed=1
+      break
+    fi
+    if ! legacy_remaining_ids="$(_legacy_implicit_os_disk_ids \
+      "${resource_group}" "${subscription_id}" "${cleanup_deadline}" \
+      "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" \
+      "${kubeadm_vm_name}" "${arc_vm_name}")"; then
+      log_error "Failed to verify legacy implicit OS-disk deletion"
+      cleanup_failed=1
+      break
+    fi
+    if [[ -z "${remaining_ids}" && -z "${legacy_remaining_ids}" ]]; then
+      empty_inventories=$((empty_inventories + 1))
+      if (( empty_inventories >= 2 )); then
+        break
+      fi
+    else
+      empty_inventories=0
+    fi
+    sleep "${E2E_CLEANUP_POLL_INTERVAL:-5}"
+  done
+
+  if (( empty_inventories < 2 )); then
+    log_error "Residual-resource inventory did not remain empty for two consecutive checks"
+    cleanup_failed=1
+  fi
+
+  if ! remaining_ids="$(_tagged_resource_ids "${resource_group}" "${resource_owner}" "${subscription_id}" "${legacy_tag_name_suffix}" "${cleanup_deadline}")"; then
+    log_error "Failed final tagged-resource verification"
+    cleanup_failed=1
+  elif [[ -n "${remaining_ids}" ]]; then
+    log_error "Tagged E2E resources remain after cleanup:"
+    printf '%s\n' "${remaining_ids}" >&2
+    cleanup_failed=1
+  fi
+
+  local final_inventory expected_names known_remaining captured_id resource_name
+  local -a expected_name_args=()
+  if ! final_inventory="$(_resource_inventory "${resource_group}" "${subscription_id}" "" "${cleanup_deadline}")"; then
+    log_error "Failed final exact-name resource verification"
+    cleanup_failed=1
+    final_inventory='[]'
+  fi
+  for resource_name in "${cluster_name}" "${arc_machine_name}" "${vnet_name}" "${nsg_name}"; do
+    [[ -z "${resource_name}" ]] || expected_name_args+=("${resource_name}")
+  done
+  for vm_name in "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" "${kubeadm_vm_name}" "${arc_vm_name}"; do
+    [[ -n "${vm_name}" ]] || continue
+    expected_name_args+=("${vm_name}" "${vm_name}-nic" "${vm_name}-pip" "${vm_name}-osdisk")
+  done
+  if ! expected_names="$(jq -cn --args '$ARGS.positional' -- "${expected_name_args[@]}")"; then
+    log_error "Failed to build exact-name cleanup inventory"
+    cleanup_failed=1
+    expected_names='[]'
+  fi
+  if ! known_remaining="$(jq -er --argjson names "${expected_names}" '
+    if type != "array" then error("resource list must be an array")
+    else [.[] | select(.name as $name | $names | index($name)) | .id] | join("\n")
+    end
+  ' <<<"${final_inventory}")"; then
+    log_error "Azure returned invalid final resource inventory"
+    cleanup_failed=1
+    known_remaining=""
+  fi
+  if ! legacy_remaining_ids="$(_legacy_implicit_os_disk_ids_from_inventory \
+    "${final_inventory}" \
+    "${msi_vm_name}" "${token_vm_name}" "${offline_vm_name}" \
+    "${kubeadm_vm_name}" "${arc_vm_name}")"; then
+    cleanup_failed=1
+    legacy_remaining_ids=""
+  elif [[ -n "${legacy_remaining_ids}" ]]; then
+    known_remaining+=$'\n'"${legacy_remaining_ids}"
+  fi
+  for captured_id in "${managed_disk_ids[@]}" "${legacy_implicit_os_disk_ids[@]}" "${nic_ids[@]}" "${arc_machine_id}"; do
+    [[ -n "${captured_id}" ]] || continue
+    if jq -e --arg id "${captured_id}" '.[] | select(.id == $id)' <<<"${final_inventory}" >/dev/null; then
+      known_remaining+=$'\n'"${captured_id}"
+    fi
+  done
+  if [[ -n "${known_remaining}" ]]; then
+    log_error "Known E2E resources remain after cleanup:"
+    printf '%s\n' "${known_remaining}" >&2
+    cleanup_failed=1
+  fi
+
+  if [[ "${cleanup_failed}" != "0" ]]; then
+    return 1
+  fi
+
+  state_set "lifecycle" "cleaned" || return 1
+  state_set "cleanup_complete" "true" || return 1
+  log_success "Cleanup completed and no known E2E resources remain"
 }

--- a/hack/e2e/lib/common.sh
+++ b/hack/e2e/lib/common.sh
@@ -120,7 +120,7 @@ check_prerequisites() {
   log_info "Checking prerequisites..."
   local missing=0
 
-  for cmd in az docker git go jq kubectl make python3 ssh scp openssl; do
+  for cmd in az docker flock git go jq kubectl make python3 ssh scp openssl; do
     if ! command -v "${cmd}" &>/dev/null; then
       log_error "Missing required tool: ${cmd}"
       missing=1
@@ -193,13 +193,28 @@ load_config() {
   E2E_SSH_OPTS="${E2E_SSH_OPTS:--o StrictHostKeyChecking=no -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR}"
 
   # Component versions (match the workflow defaults)
+  if [[ -n "${E2E_KUBERNETES_VERSION:-}" ]]; then
+    _E2E_KUBERNETES_VERSION_EXPLICIT=1
+  else
+    _E2E_KUBERNETES_VERSION_EXPLICIT=0
+  fi
   E2E_KUBERNETES_VERSION="${E2E_KUBERNETES_VERSION:-1.35.0}"
   E2E_CONTAINERD_VERSION="${E2E_CONTAINERD_VERSION:-2.0.4}"
   E2E_RUNC_VERSION="${E2E_RUNC_VERSION:-1.1.12}"
+  if [[ -n "${E2E_TARGET_AGENT_POOL_NAME:-}" ]]; then
+    _E2E_TARGET_AGENT_POOL_NAME_EXPLICIT=1
+  else
+    _E2E_TARGET_AGENT_POOL_NAME_EXPLICIT=0
+  fi
   E2E_TARGET_AGENT_POOL_NAME="${E2E_TARGET_AGENT_POOL_NAME:-aksflexnodes}"
   # listBootstrapData requires an existing ARM agent pool. The in-cluster
   # controller still uses E2E_TARGET_AGENT_POOL_NAME for its synthetic machine
   # contract, while the MSI repave scenario uses this real pool for join data.
+  if [[ -n "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-}" ]]; then
+    _E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME_EXPLICIT=1
+  else
+    _E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME_EXPLICIT=0
+  fi
   E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-${E2E_TARGET_AGENT_POOL_NAME}}"
 
   # Kubelet resource reservation overrides applied to the token node config.
@@ -219,6 +234,8 @@ load_config() {
   E2E_NODE_JOIN_TIMEOUT="${E2E_NODE_JOIN_TIMEOUT:-300}"
   E2E_POD_READY_TIMEOUT="${E2E_POD_READY_TIMEOUT:-120}"
   E2E_BOOTSTRAP_SETTLE_TIME="${E2E_BOOTSTRAP_SETTLE_TIME:-60}"
+  E2E_CLEANUP_TIMEOUT="${E2E_CLEANUP_TIMEOUT:-900}"
+  E2E_CLEANUP_POLL_INTERVAL="${E2E_CLEANUP_POLL_INTERVAL:-5}"
 
   log_info "Configuration loaded:"
   log_info "  Resource Group:   ${E2E_RESOURCE_GROUP}"
@@ -279,17 +296,98 @@ init_work_dir() {
   log_debug "Work directory: ${E2E_WORK_DIR}"
 }
 
+# Atomically reserve a work directory and write its complete deployment
+# manifest. Any nonempty state must first reach verified cleanup; otherwise a
+# new run could erase the only record capable of removing the old resources.
+state_begin_deployment() {
+  local state_json="$1"
+
+  (
+    if ! flock -x 9; then
+      log_error "Failed to lock E2E deployment state"
+      return 1
+    fi
+    local tmp existing_state requested_deployment existing_deployment
+    if ! requested_deployment="$(jq -er '
+      if type != "object" then error("state must be an object")
+      else .deployment_name | select(type == "string" and length > 0)
+      end
+    ' <<<"${state_json}")"; then
+      log_error "New E2E deployment state is invalid or has no deployment_name"
+      return 1
+    fi
+
+    if [[ -f "${E2E_STATE_FILE}" ]]; then
+      if ! existing_state="$(jq -ec '
+        if type == "object" then . else error("state must be an object") end
+      ' "${E2E_STATE_FILE}")"; then
+        log_error "Existing E2E state is invalid; refusing to overwrite cleanup metadata"
+        return 1
+      fi
+      if ! jq -e '
+        length == 0 or
+        (.lifecycle == "cleaned" and
+          (.cleanup_complete == "true" or .cleanup_complete == true))
+      ' <<<"${existing_state}" >/dev/null; then
+        existing_deployment="$(jq -r '.deployment_name // empty' <<<"${existing_state}")"
+        log_error "E2E state already tracks deployment '${existing_deployment:-unknown legacy deployment}'"
+        log_error "Run cleanup with this work directory before deploying '${requested_deployment}', or choose a new E2E_WORK_DIR"
+        return 1
+      fi
+    fi
+
+    if ! tmp="$(mktemp "${E2E_STATE_FILE}.tmp.XXXXXX")"; then
+      log_error "Failed to create temporary E2E state file"
+      return 1
+    fi
+    trap 'rm -f "${tmp}"' EXIT
+    if ! jq -e 'if type == "object" then . else error("state must be an object") end' \
+      <<<"${state_json}" > "${tmp}"; then
+      log_error "Failed to render initial E2E deployment state"
+      return 1
+    fi
+    if ! chmod 0600 "${tmp}" || ! mv "${tmp}" "${E2E_STATE_FILE}"; then
+      log_error "Failed to install initial E2E deployment state"
+      return 1
+    fi
+    trap - EXIT
+  ) 9> "${E2E_STATE_FILE}.lock"
+}
+
 # Write a key=value into the state file (JSON)
 state_set() {
   local key="$1" value="$2"
-  local tmp="${E2E_STATE_FILE}.tmp"
 
-  if [[ -f "${E2E_STATE_FILE}" ]]; then
-    jq --arg k "${key}" --arg v "${value}" '. + {($k): $v}' "${E2E_STATE_FILE}" > "${tmp}"
-  else
-    jq -n --arg k "${key}" --arg v "${value}" '{($k): $v}' > "${tmp}"
-  fi
-  mv "${tmp}" "${E2E_STATE_FILE}"
+  (
+    if ! flock -x 9; then
+      log_error "Failed to lock E2E deployment state"
+      return 1
+    fi
+    local tmp
+    if ! tmp="$(mktemp "${E2E_STATE_FILE}.tmp.XXXXXX")"; then
+      log_error "Failed to create temporary E2E state file"
+      return 1
+    fi
+    trap 'rm -f "${tmp}"' EXIT
+
+    if [[ -f "${E2E_STATE_FILE}" ]]; then
+      if ! jq --arg k "${key}" --arg v "${value}" '. + {($k): $v}' \
+        "${E2E_STATE_FILE}" > "${tmp}"; then
+        log_error "Failed to update E2E state key '${key}'"
+        return 1
+      fi
+    else
+      if ! jq -n --arg k "${key}" --arg v "${value}" '{($k): $v}' > "${tmp}"; then
+        log_error "Failed to initialize E2E state key '${key}'"
+        return 1
+      fi
+    fi
+    if ! chmod 0600 "${tmp}" || ! mv "${tmp}" "${E2E_STATE_FILE}"; then
+      log_error "Failed to install updated E2E state"
+      return 1
+    fi
+    trap - EXIT
+  ) 9> "${E2E_STATE_FILE}.lock"
 }
 
 # Read a value from the state file
@@ -305,11 +403,114 @@ state_get() {
   fi
 }
 
+require_exact_kubernetes_version() {
+  if [[ ! "${E2E_KUBERNETES_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "E2E_KUBERNETES_VERSION must be an exact x.y.z patch version, got '${E2E_KUBERNETES_VERSION}'"
+    return 1
+  fi
+}
+
+restore_kubernetes_version_from_state() {
+  local persisted_version resource_group cluster_name subscription_id live_version live_cluster cluster_id
+  local persisted_target_pool persisted_bootstrap_pool system_pool live_system_version live_flex_version
+  persisted_version="$(state_get kubernetes_version)"
+  resource_group="$(state_get resource_group)"
+  cluster_name="$(state_get cluster_name)"
+  subscription_id="$(state_get subscription_id "${AZURE_SUBSCRIPTION_ID:-}")"
+  persisted_target_pool="$(state_get target_agent_pool_name "${E2E_TARGET_AGENT_POOL_NAME:-aksflexnodes}")"
+  persisted_bootstrap_pool="$(state_get bootstrap_data_agent_pool_name "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-${persisted_target_pool}}")"
+  system_pool="$(state_get system_pool_name system)"
+
+  if [[ -z "${resource_group}" || -z "${cluster_name}" || -z "${subscription_id}" ]]; then
+    log_error "Deployment state does not identify an AKS cluster and subscription; run the infra command first"
+    return 1
+  fi
+
+  if [[ "${_E2E_TARGET_AGENT_POOL_NAME_EXPLICIT:-0}" == "1" && \
+        "${E2E_TARGET_AGENT_POOL_NAME:-}" != "${persisted_target_pool}" ]]; then
+    log_error "E2E_TARGET_AGENT_POOL_NAME is ${E2E_TARGET_AGENT_POOL_NAME:-}, but deployment state records ${persisted_target_pool}"
+    return 1
+  fi
+  if [[ "${_E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME_EXPLICIT:-0}" == "1" && \
+        "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-}" != "${persisted_bootstrap_pool}" ]]; then
+    log_error "E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME is ${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME:-}, but deployment state records ${persisted_bootstrap_pool}"
+    return 1
+  fi
+  E2E_TARGET_AGENT_POOL_NAME="${persisted_target_pool}"
+  E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME="${persisted_bootstrap_pool}"
+
+  if ! live_cluster="$(az aks show \
+    --subscription "${subscription_id}" \
+    --resource-group "${resource_group}" \
+    --name "${cluster_name}" \
+    --query '{id:id, version:currentKubernetesVersion || kubernetesVersion}' \
+    --output json 2>/dev/null)" || \
+    ! live_version="$(jq -er '.version | select(type == "string" and length > 0)' <<<"${live_cluster}")" || \
+    ! cluster_id="$(jq -er '.id | select(type == "string" and length > 0)' <<<"${live_cluster}")"; then
+    log_error "Cannot determine the live Kubernetes version for ${resource_group}/${cluster_name}"
+    return 1
+  fi
+  if ! live_system_version="$(az rest \
+    --method get \
+    --url "https://management.azure.com${cluster_id}/agentPools/${system_pool}?api-version=2026-05-02-preview" \
+    --query 'properties.currentOrchestratorVersion || properties.orchestratorVersion' \
+    --output tsv 2>/dev/null)" || [[ -z "${live_system_version}" ]]; then
+    log_error "Cannot determine the live Kubernetes version for system pool ${system_pool}"
+    return 1
+  fi
+  if ! live_flex_version="$(az rest \
+    --method get \
+    --url "https://management.azure.com${cluster_id}/agentPools/${persisted_bootstrap_pool}?api-version=2026-05-02-preview" \
+    --query 'properties.currentOrchestratorVersion || properties.orchestratorVersion' \
+    --output tsv 2>/dev/null)" || [[ -z "${live_flex_version}" ]]; then
+    log_error "Cannot determine the live Kubernetes version for FlexNodes pool ${persisted_bootstrap_pool}"
+    return 1
+  fi
+  if [[ "${live_system_version}" != "${live_version}" || "${live_flex_version}" != "${live_version}" ]]; then
+    log_error "AKS version skew: control plane=${live_version}, system pool=${live_system_version}, FlexNodes pool=${live_flex_version}"
+    return 1
+  fi
+  if [[ -n "${persisted_version}" && "${persisted_version}" != "${live_version}" ]]; then
+    log_error "Deployment state records Kubernetes ${persisted_version}, but the live cluster is ${live_version}"
+    return 1
+  fi
+  if [[ -z "${persisted_version}" ]]; then
+    persisted_version="${live_version}"
+    state_set kubernetes_version "${persisted_version}"
+    log_info "Recovered Kubernetes version from the live cluster: ${persisted_version}"
+  fi
+  if [[ "${_E2E_KUBERNETES_VERSION_EXPLICIT}" == "1" && \
+        "${E2E_KUBERNETES_VERSION}" != "${persisted_version}" ]]; then
+    log_error "E2E_KUBERNETES_VERSION is ${E2E_KUBERNETES_VERSION}, but the existing cluster state records ${persisted_version}"
+    return 1
+  fi
+
+  E2E_KUBERNETES_VERSION="${persisted_version}"
+  state_set system_pool_kubernetes_version "${live_system_version}"
+  state_set flex_pool_kubernetes_version "${live_flex_version}"
+  require_exact_kubernetes_version
+  log_info "Restored Kubernetes version from deployment state: ${E2E_KUBERNETES_VERSION}"
+}
+
 # Dump the state file for debugging
 state_dump() {
   if [[ -f "${E2E_STATE_FILE}" ]]; then
     log_info "Current state:"
-    jq '.' "${E2E_STATE_FILE}"
+    jq '
+      def redact:
+        if type == "object" then
+          with_entries(
+            if (.key | test("(^|_)(bootstrap_)?token$|secret|password|credential"; "i")) then
+              .value = "<redacted>"
+            else
+              .value |= redact
+            end
+          )
+        elif type == "array" then map(redact)
+        else .
+        end;
+      redact
+    ' "${E2E_STATE_FILE}"
   else
     log_info "No state file found"
   fi

--- a/hack/e2e/lib/infra.sh
+++ b/hack/e2e/lib/infra.sh
@@ -51,11 +51,61 @@ infra_deploy() {
   local start
   start=$(timer_start)
 
+  require_exact_kubernetes_version
+
   local bicep_file="${E2E_INFRA_DIR}/main.bicep"
   if [[ ! -f "${bicep_file}" ]]; then
     log_error "Bicep template not found: ${bicep_file}"
     return 1
   fi
+
+  # Persist deterministic identities before Azure starts provisioning so the
+  # always-run cleanup stage can remove resources after a partial deployment.
+  local deployment_name="e2e-${E2E_NAME_SUFFIX}"
+  local run_id="${GITHUB_RUN_ID:-local-${E2E_NAME_SUFFIX}}"
+  # A workflow rerun keeps github.run_id but increments github.run_attempt.
+  # E2E_NAME_SUFFIX includes both, so use it as the ownership tag to keep
+  # cleanup for one attempt from deleting another attempt's resources.
+  local resource_owner="${E2E_NAME_SUFFIX}"
+  local initial_state
+  initial_state="$(jq -n \
+    --arg lifecycle "provisioning" \
+    --arg resource_group "${E2E_RESOURCE_GROUP}" \
+    --arg location "${E2E_LOCATION}" \
+    --arg subscription_id "${AZURE_SUBSCRIPTION_ID}" \
+    --arg tenant_id "${AZURE_TENANT_ID}" \
+    --arg run_id "${run_id}" \
+    --arg resource_owner "${resource_owner}" \
+    --arg name_suffix "${E2E_NAME_SUFFIX}" \
+    --arg kubernetes_version "${E2E_KUBERNETES_VERSION}" \
+    --arg target_agent_pool_name "${E2E_TARGET_AGENT_POOL_NAME}" \
+    --arg bootstrap_data_agent_pool_name "${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}" \
+    --arg system_pool_name "system" \
+    --arg deployment_name "${deployment_name}" \
+    --arg cluster_name "aks-e2e-${E2E_NAME_SUFFIX}" \
+    --arg node_resource_group "MC_aksflex-e2e-${E2E_NAME_SUFFIX}" \
+    --arg vnet_name "vnet-e2e-${E2E_NAME_SUFFIX}" \
+    --arg nsg_name "nsg-e2e-${E2E_NAME_SUFFIX}" \
+    --arg msi_vm_name "vm-e2e-msi-${E2E_NAME_SUFFIX}" \
+    --arg token_vm_name "vm-e2e-token-${E2E_NAME_SUFFIX}" \
+    --arg offline_vm_name "vm-e2e-offline-${E2E_NAME_SUFFIX}" \
+    --arg kubeadm_vm_name "vm-e2e-kubeadm-${E2E_NAME_SUFFIX}" \
+    --arg arc_vm_name "vm-e2e-arc-${E2E_NAME_SUFFIX}" \
+    --arg arc_machine_name "vm-e2e-arc-${E2E_NAME_SUFFIX}-connected" \
+    '{schema_version: 1, lifecycle: $lifecycle, resource_group: $resource_group,
+      location: $location, subscription_id: $subscription_id, tenant_id: $tenant_id,
+      run_id: $run_id, resource_owner: $resource_owner,
+      name_suffix: $name_suffix, kubernetes_version: $kubernetes_version,
+      target_agent_pool_name: $target_agent_pool_name,
+      bootstrap_data_agent_pool_name: $bootstrap_data_agent_pool_name,
+      system_pool_name: $system_pool_name,
+      deployment_name: $deployment_name, cluster_name: $cluster_name,
+      node_resource_group: $node_resource_group,
+      vnet_name: $vnet_name, nsg_name: $nsg_name, msi_vm_name: $msi_vm_name,
+      token_vm_name: $token_vm_name, offline_vm_name: $offline_vm_name,
+      kubeadm_vm_name: $kubeadm_vm_name, arc_vm_name: $arc_vm_name,
+      arc_machine_name: $arc_machine_name}')"
+  state_begin_deployment "${initial_state}"
 
   # Ensure resource group exists
   if ! az group show --name "${E2E_RESOURCE_GROUP}" --output none 2>/dev/null; then
@@ -75,16 +125,14 @@ infra_deploy() {
   configure_ssh_identity
 
   # Build tags
-  local run_id="${GITHUB_RUN_ID:-local-$(date +%s)}"
   local tags_json
   tags_json=$(jq -n \
-    --arg run "${run_id}" \
+    --arg run "${resource_owner}" \
     --arg purpose "e2e-test" \
     '{"github-run": $run, "purpose": $purpose}')
 
   # Deploy
   log_info "Deploying Bicep template (this may take 5-10 minutes)..."
-  local deployment_name="e2e-${E2E_NAME_SUFFIX}"
   az deployment group create \
     --resource-group "${E2E_RESOURCE_GROUP}" \
     --name "${deployment_name}" \
@@ -210,6 +258,7 @@ infra_deploy() {
     return 1
   fi
 
+  state_set "lifecycle" "ready"
   log_success "Infrastructure deployed in $(timer_elapsed "${start}")s"
 }
 
@@ -219,8 +268,47 @@ infra_deploy() {
 infra_get_kubeconfig() {
   local cluster_name
   cluster_name="$(state_get cluster_name)"
+  local cluster_id
+  cluster_id="$(state_get cluster_id)"
   local resource_group
   resource_group="$(state_get resource_group)"
+
+  local actual_kubernetes_version system_pool_version flex_pool_version
+  actual_kubernetes_version="$(az aks show \
+    --resource-group "${resource_group}" \
+    --name "${cluster_name}" \
+    --query 'currentKubernetesVersion || kubernetesVersion' \
+    --output tsv)"
+  if [[ "${actual_kubernetes_version}" != "${E2E_KUBERNETES_VERSION}" ]]; then
+    log_error "AKS control-plane version is ${actual_kubernetes_version}, expected ${E2E_KUBERNETES_VERSION}"
+    return 1
+  fi
+  state_set "kubernetes_version" "${actual_kubernetes_version}"
+  log_info "Verified AKS control-plane version: ${actual_kubernetes_version}"
+
+  system_pool_version="$(az rest \
+    --method get \
+    --url "https://management.azure.com${cluster_id}/agentPools/system?api-version=2026-05-02-preview" \
+    --query 'properties.currentOrchestratorVersion || properties.orchestratorVersion' \
+    --output tsv)"
+  if [[ "${system_pool_version}" != "${E2E_KUBERNETES_VERSION}" ]]; then
+    log_error "AKS system pool version is ${system_pool_version}, expected ${E2E_KUBERNETES_VERSION}"
+    return 1
+  fi
+  state_set "system_pool_kubernetes_version" "${system_pool_version}"
+  log_info "Verified AKS system pool version: ${system_pool_version}"
+
+  flex_pool_version="$(az rest \
+    --method get \
+    --url "https://management.azure.com${cluster_id}/agentPools/${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}?api-version=2026-05-02-preview" \
+    --query 'properties.currentOrchestratorVersion || properties.orchestratorVersion' \
+    --output tsv)"
+  if [[ "${flex_pool_version}" != "${E2E_KUBERNETES_VERSION}" ]]; then
+    log_error "AKS FlexNodes pool version is ${flex_pool_version}, expected ${E2E_KUBERNETES_VERSION}"
+    return 1
+  fi
+  state_set "flex_pool_kubernetes_version" "${flex_pool_version}"
+  log_info "Verified AKS FlexNodes pool version: ${flex_pool_version}"
 
   log_info "Fetching kubeconfig for ${cluster_name}..."
   az aks get-credentials \

--- a/hack/e2e/lib/node-join-arc.sh
+++ b/hack/e2e/lib/node-join-arc.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 readonly _E2E_NODE_JOIN_ARC_LOADED=1
 readonly arcHybridComputeAPIVersion="2024-07-10"
 readonly aksContributorRoleDefinitionID="ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8"
+readonly arcBootstrapDataAction="Microsoft.ContainerService/managedClusters/agentPools/listBootstrapData/action"
+readonly arcRoleAssignmentWaitAttempts=12
+readonly arcRoleAssignmentPollInterval=5
+readonly arcBootstrapFetchAttempts=60
+readonly arcBootstrapFetchPollInterval=15
 
 # shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -124,27 +129,233 @@ _wait_for_arc_identity() {
   return 1
 }
 
+_arc_role_records_match() {
+  local records="$1" principal_id="$2" cluster_id="$3"
+
+  jq -e \
+    --arg principalID "${principal_id}" \
+    --arg roleDefinitionID "${aksContributorRoleDefinitionID}" \
+    --arg scope "${cluster_id}" '
+      def records: if type == "array" then . else [.] end;
+      [
+        records[]
+        | select(
+            ((.principalId // "") | ascii_downcase) == ($principalID | ascii_downcase)
+            and (((.roleDefinitionId // "") | split("/") | last | ascii_downcase) == ($roleDefinitionID | ascii_downcase))
+            and (((.scope // "") | ascii_downcase) == ($scope | ascii_downcase))
+          )
+      ]
+      | length == 1
+    ' <<<"${records}" >/dev/null
+}
+
+_arc_role_assignment_visible() {
+  local principal_id="$1" cluster_id="$2" subscription_id="$3"
+  local assignments
+
+  # Keep lookup failure distinct from a valid empty result so callers never
+  # create a duplicate assignment when Azure CLI or ARM is transiently down.
+  if ! assignments="$(az role assignment list \
+    --assignee-object-id "${principal_id}" \
+    --role "${aksContributorRoleDefinitionID}" \
+    --scope "${cluster_id}" \
+    --fill-principal-name false \
+    --fill-role-definition-name false \
+    --subscription "${subscription_id}" \
+    --output json)"; then
+    return 2
+  fi
+  _arc_role_records_match "${assignments}" "${principal_id}" "${cluster_id}"
+}
+
+_aks_contributor_allows_bootstrap_data() {
+  local subscription_id="$1" definition
+
+  if ! definition="$(az role definition show \
+    --id "/subscriptions/${subscription_id}/providers/Microsoft.Authorization/roleDefinitions/${aksContributorRoleDefinitionID}" \
+    --subscription "${subscription_id}" \
+    --output json)"; then
+    return 1
+  fi
+  jq -e --arg action "${arcBootstrapDataAction}" '
+    def covers($grant; $requested):
+      ($grant | ascii_downcase) as $normalizedGrant
+      | ($requested | ascii_downcase) as $normalizedRequested
+      | $normalizedGrant == "*"
+        or $normalizedGrant == $normalizedRequested
+        or (($normalizedGrant | endswith("/*")) and ($normalizedRequested | startswith($normalizedGrant[0:-1])));
+    [
+      .permissions[]?
+      | select(
+          any(.actions[]?; covers(.; $action))
+          and all(.notActions[]?; covers(.; $action) | not)
+        )
+    ]
+    | length > 0
+  ' <<<"${definition}" >/dev/null
+}
+
+_ensure_arc_role_assignment() {
+  local principal_id="$1" cluster_id="$2" subscription_id="$3"
+  local created_assignment assignment_status=0
+
+  if ! state_set "arc_role_assigned" "false"; then
+    return 1
+  fi
+  _arc_role_assignment_visible "${principal_id}" "${cluster_id}" "${subscription_id}" || assignment_status=$?
+  case "${assignment_status}" in
+    0)
+      if ! state_set "arc_role_assigned" "true"; then
+        return 1
+      fi
+      log_info "Verified the Arc AKS Contributor role assignment"
+      return 0
+      ;;
+    1) ;;
+    *)
+      log_error "Failed to query the Arc AKS Contributor role assignment; refusing to create a possibly duplicate assignment"
+      return 1
+      ;;
+  esac
+
+  if ! created_assignment="$(az role assignment create \
+    --assignee-object-id "${principal_id}" \
+    --assignee-principal-type ServicePrincipal \
+    --role "${aksContributorRoleDefinitionID}" \
+    --scope "${cluster_id}" \
+    --subscription "${subscription_id}" \
+    --output json)"; then
+    log_error "Failed to create the Arc AKS Contributor role assignment"
+    return 1
+  fi
+  if ! _arc_role_records_match "${created_assignment}" "${principal_id}" "${cluster_id}"; then
+    log_error "Azure returned an Arc role assignment that did not match the requested principal, role, and cluster scope"
+    return 1
+  fi
+
+  for attempt in $(seq 1 "${arcRoleAssignmentWaitAttempts}"); do
+    assignment_status=0
+    _arc_role_assignment_visible "${principal_id}" "${cluster_id}" "${subscription_id}" || assignment_status=$?
+    case "${assignment_status}" in
+      0)
+        if ! state_set "arc_role_assigned" "true"; then
+          return 1
+        fi
+        log_info "Verified the Arc AKS Contributor role assignment"
+        return 0
+        ;;
+      1) ;;
+      *)
+        log_warn "Failed to query the newly created Arc role assignment; retrying verification (${attempt}/${arcRoleAssignmentWaitAttempts})"
+        ;;
+    esac
+    if [[ "${attempt}" -lt "${arcRoleAssignmentWaitAttempts}" ]]; then
+      sleep "${arcRoleAssignmentPollInterval}"
+    fi
+  done
+
+  if [[ "${assignment_status}" -eq 1 ]]; then
+    log_error "Arc AKS Contributor role assignment was not visible at the expected principal, role, and cluster scope"
+  else
+    log_error "Arc AKS Contributor role assignment could not be verified because Azure CLI queries kept failing"
+  fi
+  return 1
+}
+
+_arc_authorization_diagnostic_values() {
+  local vm_ip="$1" arc_resource_id="$2" principal_id="$3" cluster_id="$4" subscription_id="$5"
+  local assignment_visible=false role_allows_action=false principal_matches=false
+  local himdsd_active=false azcmagent_connected=false current_principal remote_status
+
+  if _arc_role_assignment_visible "${principal_id}" "${cluster_id}" "${subscription_id}" 2>/dev/null; then
+    assignment_visible=true
+  fi
+  if _aks_contributor_allows_bootstrap_data "${subscription_id}" 2>/dev/null; then
+    role_allows_action=true
+  fi
+  current_principal="$(az resource show \
+    --ids "${arc_resource_id}" \
+    --api-version "${arcHybridComputeAPIVersion}" \
+    --query identity.principalId \
+    --subscription "${subscription_id}" \
+    --output tsv 2>/dev/null || true)"
+  if [[ -n "${current_principal}" && "${current_principal,,}" == "${principal_id,,}" ]]; then
+    principal_matches=true
+  fi
+  if remote_status="$(remote_exec "${vm_ip}" \
+    "himdsd_active=false; azcmagent_connected=false; systemctl is-active --quiet himdsd.service && himdsd_active=true; sudo azcmagent show 2>/dev/null | grep -Eq 'Agent Status[[:space:]]*:[[:space:]]*Connected' && azcmagent_connected=true; printf '%s|%s\\n' \"\${himdsd_active}\" \"\${azcmagent_connected}\"")"; then
+    IFS='|' read -r himdsd_active azcmagent_connected <<<"${remote_status}"
+  fi
+
+  printf '%s|%s|%s|%s|%s\n' \
+    "${assignment_visible}" "${role_allows_action}" "${principal_matches}" \
+    "${himdsd_active}" "${azcmagent_connected}"
+}
+
+_log_arc_authorization_diagnostics() {
+  local attempt="$1" values="$2"
+  local assignment_visible role_allows_action principal_matches himdsd_active azcmagent_connected
+  IFS='|' read -r assignment_visible role_allows_action principal_matches himdsd_active azcmagent_connected <<<"${values}"
+
+  log_info "Arc authorization diagnostics (${attempt}/${arcBootstrapFetchAttempts}): roleAssignmentVisible=${assignment_visible} roleAllowsListBootstrapData=${role_allows_action} arcPrincipalMatches=${principal_matches} himdsdActive=${himdsd_active} azcmagentConnected=${azcmagent_connected}"
+}
+
+_arc_fetch_error_summary() {
+  local output="$1"
+  local summary
+
+  summary="$(grep -m1 -F 'fetch bootstrap data returned HTTP status' <<<"${output}" || true)"
+  if [[ -n "${summary}" ]]; then
+    printf '%s\n' "${summary}"
+  else
+    printf '%s\n' "remote fetch failed without a structured ARM response"
+  fi
+}
+
 _fetch_arc_bootstrap_config() {
   local vm_ip="$1" vm_private_ip="$2" vm_name="$3" cluster_id="$4" output="$5"
+  local arc_resource_id="$6" principal_id="$7" subscription_id="$8"
   local remote_binary="/tmp/aks-flex-node-arc-fetch"
   local remote_output="/tmp/aks-flex-node-arc-bootstrap.json"
 
   remote_copy "${E2E_BINARY}" "${vm_ip}" "${remote_binary}"
   remote_exec "${vm_ip}" "sudo chmod 0755 '${remote_binary}'"
 
-  local fetched=0
+  local fetched=0 last_fetch_error="" final_diagnostics=""
   # A newly created Arc principal and role assignment can take several minutes
   # to become effective across ARM frontends.
-  for attempt in $(seq 1 60); do
-    if remote_exec "${vm_ip}" "sudo '${remote_binary}' fetch-bootstrap-data --auth arc --cluster-resource-id '${cluster_id}' --agent-pool-name '${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}' --output '${remote_output}'"; then
+  for attempt in $(seq 1 "${arcBootstrapFetchAttempts}"); do
+    if last_fetch_error="$(remote_exec "${vm_ip}" "sudo '${remote_binary}' fetch-bootstrap-data --auth arc --cluster-resource-id '${cluster_id}' --agent-pool-name '${E2E_BOOTSTRAP_DATA_AGENT_POOL_NAME}' --output '${remote_output}'" 2>&1)"; then
       fetched=1
       break
     fi
-    log_info "Arc bootstrap-data fetch not ready; retrying (${attempt}/60)"
-    sleep 15
+    if [[ "${attempt}" -eq 1 || $((attempt % 10)) -eq 0 || "${attempt}" -eq "${arcBootstrapFetchAttempts}" ]]; then
+      log_warn "Arc bootstrap-data fetch failed: $(_arc_fetch_error_summary "${last_fetch_error}")"
+      final_diagnostics="$(_arc_authorization_diagnostic_values \
+        "${vm_ip}" "${arc_resource_id}" "${principal_id}" "${cluster_id}" "${subscription_id}")"
+      _log_arc_authorization_diagnostics "${attempt}" "${final_diagnostics}"
+    fi
+    if [[ "${attempt}" -lt "${arcBootstrapFetchAttempts}" ]]; then
+      log_info "Arc bootstrap-data fetch not ready; retrying (${attempt}/${arcBootstrapFetchAttempts})"
+      sleep "${arcBootstrapFetchPollInterval}"
+    fi
   done
   if [[ "${fetched}" -ne 1 ]]; then
-    log_error "Arc identity could not fetch AKS bootstrap data"
+    local assignment_visible role_allows_action principal_matches himdsd_active azcmagent_connected
+    IFS='|' read -r assignment_visible role_allows_action principal_matches himdsd_active azcmagent_connected <<<"${final_diagnostics}"
+    if [[ "${last_fetch_error}" != *"HTTP status 403"* ]]; then
+      log_error "Arc identity could not fetch AKS bootstrap data; ARM did not return HTTP 403"
+    elif [[ "${assignment_visible}" != "true" ]]; then
+      log_error "Arc identity could not fetch AKS bootstrap data because the expected role assignment is not visible"
+    elif [[ "${principal_matches}" != "true" ]]; then
+      log_error "Arc identity could not fetch AKS bootstrap data because the Arc principal no longer matches or could not be verified"
+    elif [[ "${role_allows_action}" != "true" ]]; then
+      log_error "Arc identity could not fetch AKS bootstrap data because AKS Contributor does not allow listBootstrapData or the role definition could not be verified"
+    elif [[ "${himdsd_active}" != "true" || "${azcmagent_connected}" != "true" ]]; then
+      log_error "Arc identity could not fetch AKS bootstrap data because the Arc identity service is not healthy"
+    else
+      log_error "Arc authorization is still HTTP 403 despite a verified assignment, matching principal, effective role action, and healthy Arc agent"
+    fi
     return 1
   fi
 
@@ -219,18 +430,16 @@ node_join_arc() {
   state_set "arc_machine_id" "${arc_resource_id}"
   state_set "arc_principal_id" "${principal_id}"
 
-  if [[ "$(state_get arc_role_assigned)" != "true" ]]; then
-    az role assignment create \
-      --assignee-object-id "${principal_id}" \
-      --assignee-principal-type ServicePrincipal \
-      --role "${aksContributorRoleDefinitionID}" \
-      --scope "${cluster_id}" \
-      --output none
-    state_set "arc_role_assigned" "true"
+  if ! _aks_contributor_allows_bootstrap_data "${subscription_id}"; then
+    log_error "AKS Contributor does not allow ${arcBootstrapDataAction}"
+    return 1
   fi
+  _ensure_arc_role_assignment "${principal_id}" "${cluster_id}" "${subscription_id}"
 
   local config_file="${E2E_WORK_DIR}/config-arc.json"
-  _fetch_arc_bootstrap_config "${vm_ip}" "${vm_private_ip}" "${vm_name}" "${cluster_id}" "${config_file}"
+  _fetch_arc_bootstrap_config \
+    "${vm_ip}" "${vm_private_ip}" "${vm_name}" "${cluster_id}" "${config_file}" \
+    "${arc_resource_id}" "${principal_id}" "${subscription_id}"
 
   # The E2E CSR approver uses this source as a fallback when the managed AKS
   # approver isn't available. Runtime Machine reconciliation still uses ARM.

--- a/hack/e2e/lib/node-join-arc.sh
+++ b/hack/e2e/lib/node-join-arc.sh
@@ -148,8 +148,9 @@ _fetch_arc_bootstrap_config() {
     return 1
   fi
 
+  install -m 0600 /dev/null "${output}"
   remote_exec "${vm_ip}" "sudo cat '${remote_output}'" > "${output}"
-  chmod 0600 "${output}"
+  install -m 0600 /dev/null "${output}.tmp"
   jq \
     --arg nodeIP "${vm_private_ip}" \
     --arg nodeName "${vm_name}" \
@@ -165,7 +166,6 @@ _fetch_arc_bootstrap_config() {
       | .node.kubelet.nodeIP = $nodeIP' \
     "${output}" > "${output}.tmp"
   mv "${output}.tmp" "${output}"
-  chmod 0600 "${output}"
 
   remote_exec "${vm_ip}" "sudo rm -f '${remote_output}' '${remote_binary}'"
 }

--- a/hack/e2e/lib/node-join-offline.sh
+++ b/hack/e2e/lib/node-join-offline.sh
@@ -198,6 +198,7 @@ node_join_offline() {
   with_cluster_lock mark_e2e_bootstrap_token_aks_managed \
     "$(jq -er '.azure.bootstrapToken.token' "${config_file}")"
 
+  install -m 0600 /dev/null "${config_file}.tmp"
   jq \
     --arg nodeIP "${vm_private_ip}" \
     --arg machineEndpointURL "${E2E_CONTROLLER_SERVICE_PROXY_PATH}" \

--- a/hack/e2e/lib/node-join-token.sh
+++ b/hack/e2e/lib/node-join-token.sh
@@ -67,6 +67,7 @@ node_join_token() {
   with_cluster_lock mark_e2e_bootstrap_token_aks_managed \
     "$(jq -er '.azure.bootstrapToken.token' "${config_file}")"
 
+  install -m 0600 /dev/null "${config_file}.tmp"
   jq \
     --arg nodeIP "${vm_private_ip}" \
     --arg machineEndpointURL "${E2E_CONTROLLER_SERVICE_PROXY_PATH}" \

--- a/hack/e2e/lib/runner.sh
+++ b/hack/e2e/lib/runner.sh
@@ -32,22 +32,22 @@ cleanup_runner_workspace() {
   df -h / 2>/dev/null || true
 
   local removed=0
-  local dir
-  while IFS= read -r dir; do
-    [[ -n "${dir}" && -d "${dir}" ]] || continue
-    log_info "Removing ${dir}"
+  local work_dir="${E2E_WORK_DIR:-}"
+  if [[ ! "${work_dir}" =~ ^/tmp/aks-flex-node-e2e(-[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]]; then
+    log_error "Refusing to clean unexpected E2E work directory '${work_dir}'"
+    return 1
+  fi
+  if [[ -d "${work_dir}" ]]; then
+    log_info "Removing ${work_dir}"
     if [[ "${can_sudo}" == "1" ]]; then
-      sudo rm -rf -- "${dir}" || { log_warn "Failed to remove ${dir}"; continue; }
+      sudo rm -rf -- "${work_dir}" || { log_warn "Failed to remove ${work_dir}"; return 1; }
     else
-      rm -rf -- "${dir}" || { log_warn "Failed to remove ${dir}"; continue; }
+      rm -rf -- "${work_dir}" || { log_warn "Failed to remove ${work_dir}"; return 1; }
     fi
-    removed=$((removed + 1))
-  done < <(find /tmp -maxdepth 1 -type d \( \
-    -name 'aks-flex-node-e2e' -o \
-    -name 'aks-flex-node-e2e-*' \
-  \) 2>/dev/null || true)
+    removed=1
+  fi
 
-  log_info "Removed ${removed} temporary directories"
+  log_info "Removed ${removed} temporary directory"
 
   if command -v go >/dev/null 2>&1; then
     log_info "Cleaning Go build cache"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -218,7 +218,7 @@ cmd_all() {
   collect_logs || true
 
   # Cleanup
-  cleanup || true
+  cleanup || exit_code=1
 
   echo ""
   log_section "E2E Test Complete"
@@ -259,6 +259,20 @@ main() {
   check_prerequisites
   load_config
   init_work_dir
+
+  case "${COMMAND}" in
+    all|infra)
+      require_exact_kubernetes_version
+      ;;
+    join|join-msi|join-token|join-offline|join-kubeadm|join-arc|upgrade-drift)
+      restore_kubernetes_version_from_state
+      ;;
+    cleanup|runner-cleanup|logs|status|unjoin|unjoin-msi|unjoin-token|unjoin-offline|unjoin-kubeadm|unjoin-arc|validate|validate-absent|smoke|nspawn-lifecycle|agent-upgrade)
+      # Recovery and inspection commands must remain usable even when a caller
+      # supplied a bad or stale version value.
+      ;;
+  esac
+
   configure_ssh_identity
 
   trap 'gha_end_group' EXIT

--- a/pkg/bootstrapdata/bootstrap_data.go
+++ b/pkg/bootstrapdata/bootstrap_data.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -31,6 +32,10 @@ const (
 	DefaultResourceManagerEndpoint = "https://management.azure.com"
 	DefaultAuthorityHost           = "https://login.microsoftonline.com"
 	maxResponseBytes               = int64(16 << 20)
+	maxErrorResponseBytes          = int64(64 << 10)
+	maxARMErrorCodeBytes           = 256
+	maxARMErrorMessageBytes        = 2048
+	maxARMRequestIDBytes           = 256
 )
 
 var (
@@ -190,8 +195,7 @@ func fetch(ctx context.Context, options Options, deps dependencies) (*Data, erro
 		return nil, fmt.Errorf("fetch bootstrap data: %w", err)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		_ = response.Body.Close()
-		return nil, fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
+		return nil, bootstrapDataHTTPError(response, token.Token)
 	}
 	data, readErr := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
 	closeErr := response.Body.Close()
@@ -236,6 +240,63 @@ func fetch(ctx context.Context, options Options, deps dependencies) (*Data, erro
 		CACertData:     responseData.Node.Kubelet.CACertData,
 		raw:            raw,
 	}, nil
+}
+
+func bootstrapDataHTTPError(response *http.Response, bearerToken string) error {
+	statusError := fmt.Errorf("fetch bootstrap data returned HTTP status %d", response.StatusCode)
+	details := make([]string, 0, 4)
+	if response.Body != nil {
+		body, readErr := io.ReadAll(io.LimitReader(response.Body, maxErrorResponseBytes+1))
+		closeErr := response.Body.Close()
+		if readErr == nil && closeErr == nil && int64(len(body)) <= maxErrorResponseBytes && utf8.Valid(body) {
+			var armResponse struct {
+				Error *struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if json.Unmarshal(body, &armResponse) == nil && armResponse.Error != nil {
+				code := boundedDiagnosticValue(armResponse.Error.Code, bearerToken, maxARMErrorCodeBytes)
+				message := boundedDiagnosticValue(armResponse.Error.Message, bearerToken, maxARMErrorMessageBytes)
+				if code != "" {
+					details = append(details, fmt.Sprintf("error.code=%q", code))
+				}
+				if message != "" {
+					details = append(details, fmt.Sprintf("error.message=%q", message))
+				}
+			}
+		}
+	}
+	for _, header := range []string{"x-ms-request-id", "x-ms-correlation-request-id"} {
+		value := boundedDiagnosticValue(response.Header.Get(header), bearerToken, maxARMRequestIDBytes)
+		if value != "" {
+			details = append(details, fmt.Sprintf("%s=%q", header, value))
+		}
+	}
+	if len(details) == 0 {
+		return statusError
+	}
+	return fmt.Errorf("%w: %s", statusError, strings.Join(details, ", "))
+}
+
+func boundedDiagnosticValue(value, bearerToken string, maxBytes int) string {
+	if bearerToken != "" {
+		value = strings.ReplaceAll(value, bearerToken, "[REDACTED]")
+	}
+	value = strings.TrimSpace(value)
+	var result strings.Builder
+	result.Grow(min(len(value), maxBytes))
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			character = ' '
+		}
+		characterBytes := utf8.RuneLen(character)
+		if characterBytes < 0 || result.Len()+characterBytes > maxBytes {
+			break
+		}
+		result.WriteRune(character)
+	}
+	return strings.TrimSpace(result.String())
 }
 
 func validateOptions(options Options) error {

--- a/pkg/bootstrapdata/bootstrap_data_test.go
+++ b/pkg/bootstrapdata/bootstrap_data_test.go
@@ -20,6 +20,15 @@ type staticCredential struct {
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+type errorReadCloser struct {
+	closed bool
+}
+
 func (c staticCredential) GetToken(_ context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	if c.scope != nil && len(options.Scopes) == 1 {
 		*c.scope = options.Scopes[0]
@@ -28,6 +37,18 @@ func (c staticCredential) GetToken(_ context.Context, options policy.TokenReques
 }
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (r *errorReadCloser) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+func (r *errorReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
 
 func TestFetchAndWrite(t *testing.T) {
 	t.Parallel()
@@ -113,6 +134,172 @@ func TestFetchInMemory(t *testing.T) {
 	}
 	if scope != "https://management.core.usgovcloudapi.net/.default" {
 		t.Fatalf("ARM token scope = %q", scope)
+	}
+}
+
+func TestFetchHTTPErrorDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	const statusOnly = "fetch bootstrap data returned HTTP status 403"
+	boundedCode := strings.Repeat("C", maxARMErrorCodeBytes)
+	boundedMessage := strings.Repeat("M", maxARMErrorMessageBytes)
+	boundedRequestID := strings.Repeat("R", maxARMRequestIDBytes)
+	tests := []struct {
+		name        string
+		body        string
+		headers     http.Header
+		want        string
+		notContains []string
+	}{
+		{
+			name: "structured ARM error",
+			body: `{"error":{"code":"AuthorizationFailed","message":"The caller is not authorized."}}`,
+			headers: http.Header{
+				"X-Ms-Request-Id":             []string{"request-123"},
+				"X-Ms-Correlation-Request-Id": []string{"correlation-456"},
+			},
+			want: statusOnly + `: error.code="AuthorizationFailed", error.message="The caller is not authorized.", x-ms-request-id="request-123", x-ms-correlation-request-id="correlation-456"`,
+		},
+		{
+			name: "missing message and request IDs",
+			body: `{"error":{"code":"Forbidden"}}`,
+			want: statusOnly + `: error.code="Forbidden"`,
+		},
+		{
+			name: "missing code",
+			body: `{"error":{"message":"Access denied"}}`,
+			want: statusOnly + `: error.message="Access denied"`,
+		},
+		{
+			name:        "malformed JSON",
+			body:        `{"error":{"message":"arm-token and body-secret"}`,
+			headers:     http.Header{"X-Ms-Request-Id": []string{"malformed-request"}},
+			want:        statusOnly + `: x-ms-request-id="malformed-request"`,
+			notContains: []string{"arm-token", "body-secret"},
+		},
+		{
+			name:        "unrelated JSON",
+			body:        `{"message":"body-secret","bootstrapToken":"bootstrap-secret"}`,
+			headers:     http.Header{"X-Ms-Correlation-Request-Id": []string{"unrelated-correlation"}},
+			want:        statusOnly + `: x-ms-correlation-request-id="unrelated-correlation"`,
+			notContains: []string{"body-secret", "bootstrap-secret"},
+		},
+		{
+			name:        "invalid UTF-8",
+			body:        string([]byte{0xff, 0xfe}),
+			headers:     http.Header{"X-Ms-Request-Id": []string{"invalid-utf8-request"}},
+			want:        statusOnly + `: x-ms-request-id="invalid-utf8-request"`,
+			notContains: []string{string([]byte{0xff, 0xfe})},
+		},
+		{
+			name: "unrelated secrets omitted and bearer token redacted",
+			body: `{"error":{"code":"AuthorizationFailed","message":"token arm-token was rejected"},` +
+				`"bootstrapToken":"bootstrap-secret","secret":"body-secret"}`,
+			want: statusOnly + `: error.code="AuthorizationFailed", error.message="token [REDACTED] was rejected"`,
+			notContains: []string{
+				"arm-token",
+				"bootstrap-secret",
+				"body-secret",
+			},
+		},
+		{
+			name: "oversized fields are bounded",
+			body: `{"error":{"code":"` + boundedCode + `code-secret","message":"` +
+				boundedMessage + `message-secret"}}`,
+			want: statusOnly + `: error.code="` + boundedCode + `", error.message="` + boundedMessage + `"`,
+			notContains: []string{
+				"code-secret",
+				"message-secret",
+			},
+		},
+		{
+			name: "oversized body uses request ID only",
+			body: `{"error":{"code":"Forbidden","message":"` +
+				strings.Repeat("M", int(maxErrorResponseBytes)) + `body-secret"}}`,
+			headers:     http.Header{"X-Ms-Request-Id": []string{"oversized-request"}},
+			want:        statusOnly + `: x-ms-request-id="oversized-request"`,
+			notContains: []string{"Forbidden", "body-secret"},
+		},
+		{
+			name: "request IDs are bounded sanitized and redacted",
+			body: `{"error":{"code":"Forbidden"}}`,
+			headers: http.Header{
+				"X-Ms-Request-Id":             []string{boundedRequestID + "request-secret"},
+				"X-Ms-Correlation-Request-Id": []string{"correlation\r\narm-token\tvalue"},
+			},
+			want: statusOnly + `: error.code="Forbidden", x-ms-request-id="` + boundedRequestID +
+				`", x-ms-correlation-request-id="correlation  [REDACTED] value"`,
+			notContains: []string{
+				"arm-token",
+				"request-secret",
+				"\r",
+				"\n",
+				"\t",
+			},
+		},
+	}
+
+	options := Options{
+		ClusterResourceID:       "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/cluster",
+		AgentPoolName:           "aksflexnodes",
+		AuthMode:                "msi",
+		ResourceManagerEndpoint: DefaultResourceManagerEndpoint,
+		AuthorityHost:           DefaultAuthorityHost,
+		APIVersion:              DefaultAPIVersion,
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := &trackingReadCloser{Reader: strings.NewReader(test.body)}
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       body,
+					Header:     test.headers.Clone(),
+				}, nil
+			})}
+			_, err := fetch(t.Context(), options, dependencies{
+				credential: func(Options, azcore.ClientOptions) (azcore.TokenCredential, error) {
+					return staticCredential{}, nil
+				},
+				httpClient: client,
+			})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("fetch() error = %v, want %q", err, test.want)
+			}
+			for _, value := range test.notContains {
+				if strings.Contains(err.Error(), value) {
+					t.Errorf("fetch() error exposed %q", value)
+				}
+			}
+			if !body.closed {
+				t.Error("fetch() did not close the error response body")
+			}
+		})
+	}
+
+	err := bootstrapDataHTTPError(&http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Header:     http.Header{"X-Ms-Request-Id": []string{"bodyless-request"}},
+	}, "arm-token")
+	const wantBodyless = `fetch bootstrap data returned HTTP status 503: x-ms-request-id="bodyless-request"`
+	if err.Error() != wantBodyless {
+		t.Fatalf("bodyless HTTP error = %q, want %q", err, wantBodyless)
+	}
+
+	readFailureBody := &errorReadCloser{}
+	err = bootstrapDataHTTPError(&http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       readFailureBody,
+		Header:     http.Header{"X-Ms-Correlation-Request-Id": []string{"read-error-correlation"}},
+	}, "arm-token")
+	const wantReadFailure = `fetch bootstrap data returned HTTP status 502: x-ms-correlation-request-id="read-error-correlation"`
+	if err.Error() != wantReadFailure {
+		t.Fatalf("read-failure HTTP error = %q, want %q", err, wantReadFailure)
+	}
+	if !readFailureBody.closed {
+		t.Error("read-failure HTTP error did not close its response body")
 	}
 }
 


### PR DESCRIPTION
## Summary

- isolate every E2E attempt with deterministic names and ownership metadata
- persist deployment state atomically and preserve it until cleanup is verified
- make Azure cleanup fail closed, bounded, idempotent, and safe under partial deployment
- handle AKS-managed node resource groups and legacy untagged OS disks
- upload sanitized cleanup diagnostics and retain failed-attempt state
- pin and recover the exact Kubernetes patch version across commands
- verify the Arc principal, role, cluster scope, and role action before persisting assignment state
- report bounded, redacted ARM error details and periodic Arc authorization health while bootstrap data is retried

## Stack

- Depends on #287.
- This is part 2 of the replacement for #286.
- Followed by #289, which contains the historical v0.1.0 migration scenario.

This branch targets `wenhug/bootstrap-rbac-core` so the review shows only E2E hardening and Arc bootstrap diagnostics. After #287 merges, it will be rebased and retargeted to `main`.

## Scope

Successful shipped Flex Node behavior is unchanged. The bootstrap-data client now exposes only allowlisted, size-bounded, control-character-sanitized ARM error fields and request IDs on failed HTTP responses. The remaining changes are E2E state, infrastructure, cleanup, verification, and test code.

The extensive tests use fake Azure commands to exercise ownership validation, retries, concurrency, partial provisioning, residual detection, deletion ordering, role-assignment verification, and secret-safe failure reporting.

## Validation

- `make check`
- `go test -race ./hack/e2e`
- `go test -race ./pkg/bootstrapdata`
- Bicep compilation
- workflow YAML parsing
- ShellCheck and `bash -n`
- independent pre-push scope, correctness, and security audit
