### PR TITLE
Restart HIMDS after Arc RBAC assignment

### DIFF
--- a/hack/e2e/lib/node-join-arc.sh
+++ b/hack/e2e/lib/node-join-arc.sh
@@ -250,6 +250,12 @@ node_join_arc() {
     state_set "arc_role_assigned" "true"
   fi
 
+  # HIMDS starts during Arc onboarding, before this principal's AKS roles exist.
+  # Restart it after assignment so the bootstrap request cannot reuse in-memory
+  # identity state from before RBAC was granted.
+  log_info "Restarting Arc identity service after AKS role assignment..."
+  remote_exec "${vm_ip}" "sudo systemctl restart himdsd.service && sudo systemctl is-active --quiet himdsd.service"
+
   local config_file="${E2E_WORK_DIR}/config-arc.json"
   _fetch_arc_bootstrap_config "${vm_ip}" "${vm_private_ip}" "${vm_name}" "${cluster_id}" "${config_file}"
 


### PR DESCRIPTION
## Summary
- restart `himdsd.service` after assigning AKS roles to the newly created Arc machine identity
- verify HIMDS is active before fetching AKS bootstrap data
- avoid reusing in-memory identity state established before RBAC was granted

## Context
E2E run 33900499225 connected the Arc machine successfully, but every `listBootstrapData` request returned HTTP 403 until the retry window expired. The Arc identity cannot receive RBAC until after onboarding creates its principal, while HIMDS starts during onboarding.

## Validation
- `bash -n hack/e2e/lib/node-join-arc.sh`
- `git diff --check`
- E2E passed: https://github.com/Azure/AKSFlexNode/actions/runs/33914439987
  - initial Arc join passed without a `listBootstrapData` 403
  - Arc repave/rejoin also passed

- Repeat E2E passed: https://github.com/Azure/AKSFlexNode/actions/runs/33918044584
  - no `listBootstrapData` 403 responses
  - initial Arc join and Arc repave/rejoin both passed
